### PR TITLE
docs: SMART on FHIR planning (research + IP analysis)

### DIFF
--- a/docs/planning/personal-health/fastenhealth-ecosystem.md
+++ b/docs/planning/personal-health/fastenhealth-ecosystem.md
@@ -1,0 +1,62 @@
+# Fastenhealth ecosystem — research notes
+
+Findings from reviewing the [fastenhealth org repositories](https://github.com/orgs/fastenhealth/repositories) and the [fasten-onprem issues](https://github.com/fastenhealth/fasten-onprem/issues) as of 2026-06-03. Organized by relevance to the `jwilleke/yourphr` fork goal: a complete self-hosted PHR with working display for non-US-Core FHIR data (Veradigm/FollowMyHealth).
+
+## Repos worth using in the fork
+
+| Repo | License | Why it matters |
+|---|---|---|
+| [ngx-fhir](https://github.com/fastenhealth/ngx-fhir) | — | Angular FHIR display component library — Angular-native fix for Encounter/Condition rendering gaps |
+| [FHIR-Converter](https://github.com/fastenhealth/FHIR-Converter) | — | Converts legacy/non-standard formats into FHIR — directly relevant to normalizing Veradigm's non-US-Core output before import |
+| [fasten-toolbox](https://github.com/fastenhealth/fasten-toolbox) | — | Standalone FHIR tools based on fasten-onprem — useful for data inspection and manipulation outside the main app |
+| [fasten-answers-ai](https://github.com/fastenhealth/fasten-answers-ai) | — | POC for AI querying of your health record (offline LLM) — the #337/#623 issues ask for exactly this; POC already exists |
+| [fasten-sources-etl](https://github.com/fastenhealth/fasten-sources-etl) | — | Data processing pipeline for sources — could power a normalization step for non-US-Core imports |
+| [gofhir-models](https://github.com/fastenhealth/gofhir-models) | — | Go FHIR R4 models — already used by fasten-onprem backend; understanding it is needed to fix backend extraction bugs |
+
+## Repos to ignore
+
+Everything with `connect` in the name (`fasten-connect-stitch-*`, `fasten-connect-vault-*`, `fasten-connect-quickstart`) is the commercial Fasten Connect product (paid SDK for embedding provider sync into third-party apps). Not open-source, not relevant.
+
+`folio`, `wails`, `gon`, `terraform-aws-github-runner`, `ec2-github-runner`, `pouchdb-authentication` — upstream infrastructure forks, not applicable.
+
+## Issues that directly match our current bugs
+
+These are already filed upstream; our fixes should reference them.
+
+| Issue | What it is |
+|---|---|
+| [#428](https://github.com/fastenhealth/fasten-onprem/issues/428) | Extracted `code` field may be missing content — exactly our Condition display failure (Veradigm uses proprietary coding system URI) |
+| [#430](https://github.com/fastenhealth/fasten-onprem/issues/430) | Date/Periods not correctly extracted into search parameters — affects encounter timeline sorting |
+| [#431](https://github.com/fastenhealth/fasten-onprem/issues/431) | Internal references not translated before stored in columns — breaks resource graph linking (Conditions → Encounters) |
+| [#347](https://github.com/fastenhealth/fasten-onprem/issues/347) | Encounters created manually have empty fhir-datagrid rows — same symptom as our Encounter ID-only display |
+| [#592](https://github.com/fastenhealth/fasten-onprem/issues/592) | `unknown AdministrativeGender code 'm'` on bulk import — Veradigm sends lowercase gender codes; Fasten rejects them |
+
+## Feature issues worth implementing in the fork
+
+Prioritized for a personal PHR use case.
+
+| Issue | Feature | Priority |
+|---|---|---|
+| [#631](https://github.com/fastenhealth/fasten-onprem/issues/631) | Edit and delete individual records | High — basic data management |
+| [#623](https://github.com/fastenhealth/fasten-onprem/issues/623) | Ollama/LLM integration (MedGemma and others) — offline AI query of your records | High — `fasten-answers-ai` POC exists |
+| [#373](https://github.com/fastenhealth/fasten-onprem/issues/373) | Personal journal — private notes attached to health timeline | Medium |
+| [#399](https://github.com/fastenhealth/fasten-onprem/issues/399) | Configurable units on dashboard (mmHg, kg vs lbs, etc.) | Medium |
+| [#535](https://github.com/fastenhealth/fasten-onprem/issues/535) | Prebuilt dashboards (help wanted upstream) | Medium |
+| [#361](https://github.com/fastenhealth/fasten-onprem/issues/361) | PostgreSQL support — SQLite won't scale for a full lifetime PHR | Low (future) |
+| [#337](https://github.com/fastenhealth/fasten-onprem/issues/337) | ChatGPT-style offline interface for querying health record | Low (future, see #623) |
+
+## Data source import guides (upstream issues, useful as docs)
+
+| Issue | Guide topic |
+|---|---|
+| [#479](https://github.com/fastenhealth/fasten-onprem/issues/479) | Apple Health iPhone export → Fasten import |
+| [#480](https://github.com/fastenhealth/fasten-onprem/issues/480) | LibreFreeStyle CGM (continuous glucose monitor) |
+| [#481](https://github.com/fastenhealth/fasten-onprem/issues/481) | Dexcom G7 CGM |
+
+## Recommended order of attack for the fork
+
+1. **Fix display bugs** — Encounter/Condition rendering with non-US-Core data (#428, #431, #347). Code context already gathered; this is the immediate blocker.
+2. **FHIR-Converter normalization** — use as a pre-import step to clean Veradigm's non-standard codings before they hit the DB (#428, #592).
+3. **Edit/delete records** (#631) — basic PHR hygiene before adding more data.
+4. **LLM integration** (#623) — wire `fasten-answers-ai` POC to Ollama with MedGemma; Ollama is already on the infra roadmap.
+5. **PostgreSQL** (#361) — long-term; swap SQLite once record volume or multi-user needs grow.

--- a/docs/planning/personal-health/health-record-aggregation.md
+++ b/docs/planning/personal-health/health-record-aggregation.md
@@ -1,0 +1,93 @@
+# Personal health record aggregation — options
+
+Planning doc for getting health records from patient portals (primarily FollowMyHealth / Veradigm) into a self-hosted store in JSON or XML format.
+
+## Background
+
+- **Current store:** [Fasten onprem](https://fasten.nerdsbythehour.com) — deployed, healthy, Authentik-gated, hourly SQLite backup to NAS. See [`docs/apps/fasten.md`](../../apps/fasten.md).
+- **Key limitation:** fasten-onprem [dropped all provider integrations](https://github.com/fastenhealth/fasten-onprem/issues/629). The live SMART on FHIR sync is a commercial Fasten Connect feature only. The self-hosted version is a manual-import-only FHIR viewer.
+- **Primary source:** [FollowMyHealth](https://www.followmyhealth.com/patientaccess) — Veradigm patient portal. Supports FHIR R4 via SMART on FHIR. Does **not** use US Core profiles (native FHIR R4 with custom extensions).
+- **Format requirement:** JSON or XML.
+
+---
+
+## Option A — Manual portal export → Fasten import (works today)
+
+**How:** FollowMyHealth portal → Health Record → Download → C-CDA XML or FHIR Bundle JSON → Fasten Sources → Manual / File Upload.
+
+**Pros:** no developer registration, no code, works immediately.
+**Cons:** manual process, no automation, must repeat when records update.
+**Format:** C-CDA XML (HL7 CDA R2) or FHIR R4 JSON depending on portal export option.
+**Status:** viable now.
+
+---
+
+## Option B — Custom SMART on FHIR sync script (Veradigm API)
+
+**How:** register a patient-facing SMART app at [developer.veradigm.com](https://developer.veradigm.com), implement the SMART on FHIR OAuth2 launch flow (browser redirect for initial auth, persist refresh token), then run a cronjob that calls `GET /Patient/$everything` and saves the FHIR Bundle JSON for import into Fasten.
+
+**Pros:** automated sync after one-time OAuth setup; FHIR R4 JSON output; reuses the `setup-fasten.mjs` pattern already in the repo.
+**Cons:** requires Veradigm developer app registration (approval process); OAuth redirect needs a reachable localhost or LAN endpoint for the initial flow; refresh token management; Veradigm FHIR R4 deviates from US Core so some resources will have custom extensions.
+**Format:** FHIR R4 Bundle JSON.
+**Effort:** medium — OAuth flow is the hard part; bundle fetch and file save is simple.
+**Status:** not started. Would live at `apps/production/jimsmcp/sync-health-records.mjs` or similar.
+
+### Rough implementation sketch
+
+```text
+1. Register app at developer.veradigm.com → get client_id
+2. One-time: launch SMART auth flow (redirect to FollowMyHealth login)
+   → user authorizes → receive auth_code → exchange for access + refresh tokens
+   → persist refresh token securely (SOPS-encrypted secret)
+3. Cronjob (daily):
+   → use refresh token to get new access token
+   → GET /Patient/$everything → FHIR Bundle JSON
+   → save to /mnt/tank/jims/data/health-records/YYYYMMDD.json
+   → optional: POST bundle to Fasten API if it exposes an import endpoint
+```
+
+---
+
+## Option C — Apple Health as intermediary (iPhone only)
+
+**How:** connect FollowMyHealth to Apple Health (Health app → Health Records → Add Account → FollowMyHealth). Apple Health syncs FHIR records automatically. Export from iPhone: Health app → profile → Export All Health Data → `.zip` containing `export.xml` (Apple CDA variant) and FHIR JSON files.
+
+**Pros:** no developer account, no code, Apple handles the SMART on FHIR auth.
+**Cons:** requires iPhone; export is manual (no server-side automation); Apple's CDA export format is non-standard in places; sync depends on Apple Health's polling interval.
+**Format:** Apple-flavored CDA XML + FHIR JSON bundle files inside the export zip.
+**Status:** viable now if on iPhone. Least technical path.
+
+---
+
+## Option D — Medplum as FHIR server (replace or augment Fasten)
+
+**What:** [Medplum](https://github.com/medplum/medplum) is a FHIR R4 server + developer toolkit. Self-hostable on Kubernetes via Helm.
+
+**Does it solve provider sync?** No — Medplum is a FHIR *server*, not a SMART client. It has no built-in connectors to patient portals. Custom integration code would still be required (same as Option B), but targeting Medplum's storage API instead of Fasten.
+
+**Pros:** modern FHIR R4 native, strong API, active development, proper multi-resource FHIR store.
+**Cons:** significantly more complex to deploy and operate than Fasten (needs PostgreSQL, Redis, background workers); designed for healthcare app developers, not personal PHR; does not eliminate the sync problem.
+**Status:** not recommended unless Fasten's viewer limitations become blocking. Overkill for current use case.
+
+---
+
+## Option E — OpenEMR
+
+**What:** [OpenEMR](https://github.com/openemr/openemr) is a full open-source clinical EMR designed for medical practices.
+
+**Does it solve provider sync?** No — OpenEMR exposes a SMART on FHIR *server* for third-party apps; it has no client for pulling from patient portals.
+
+**Status:** not recommended. Designed for clinics, not personal PHR. High operational complexity for a single user.
+
+---
+
+## Recommendation
+
+| Priority | Option | Why |
+|---|---|---|
+| Now | A (manual export) | Zero effort, works immediately |
+| Next | B (SMART sync script) | Automates the only hard part; reuses existing tooling patterns |
+| Fallback | C (Apple Health export) | No-code path if on iPhone |
+| Defer | D / E | No provider sync benefit; significant added complexity |
+
+Start with **A** to validate that FollowMyHealth's export is clean and Fasten can import it correctly. Build **B** once the format is confirmed.

--- a/docs/planning/smart-on-fhir/oauth-gateway.md
+++ b/docs/planning/smart-on-fhir/oauth-gateway.md
@@ -1,0 +1,104 @@
+# OAuth callback gateway — plan
+
+Plan for adding live provider sync to the self-hosted Fasten instance without relying on the commercial Fasten Lighthouse service.
+
+## Background
+
+The upstream `fasten-sources` library used Fasten Lighthouse — a hosted cloud OAuth relay — as the callback endpoint for SMART on FHIR provider authentication. Lighthouse was moved to the commercial Fasten Connect product (issue #629). Without it, provider sync is broken in the open-source build.
+
+The underlying problem: `fasten.nerdsbythehour.com` is LAN-only and unreachable from the internet. Hospital portals need a publicly accessible `redirect_uri` to complete OAuth. Lighthouse was that public endpoint. We need our own equivalent.
+
+## Chosen approach: Cloudflare Worker relay
+
+A minimal stateless Cloudflare Worker sits at a public URL (e.g. `https://auth.nerdsbythehour.com/callback`) and acts as the OAuth relay. It stores the short-lived authorization code in Cloudflare KV, where the local Fasten instance polls for it and completes the token exchange directly with the provider.
+
+### Why this approach
+
+- **No server to maintain** — Cloudflare Workers free tier is sufficient
+- **Codes never leave the relay** — the Worker stores the code for ≤60 seconds then deletes it; it never sees tokens
+- **Token exchange is local** — Fasten exchanges the code with the provider directly from the LAN; the Worker never touches access/refresh tokens
+- **LAN-only Fasten stays LAN-only** — only the `/callback` Worker endpoint is public
+
+### Flow
+
+```
+1. User clicks "Connect provider" in Fasten UI
+2. Fasten generates a state token + PKCE challenge; stores locally
+3. Fasten redirects browser to provider's SMART authorization endpoint
+   (e.g. https://fhir.veradigm.com/authorize?...&redirect_uri=https://auth.nerdsbythehour.com/callback&state=<token>)
+4. User logs into provider portal and authorizes
+5. Provider redirects to: https://auth.nerdsbythehour.com/callback?code=<code>&state=<token>
+6. Worker stores {state → code} in KV with 60-second TTL
+7. Fasten polls its own /api/oauth/poll?state=<token> endpoint
+8. Fasten's backend polls Worker's GET /pending?state=<token>; Worker returns code
+9. Fasten exchanges code for access + refresh tokens directly with the provider's token endpoint
+10. Fasten stores tokens in SQLite; background worker uses refresh token for ongoing sync
+```
+
+### Worker API (two endpoints)
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/callback?code=X&state=Y` | GET | Receives redirect from provider; stores `{state: code}` in KV (60s TTL); returns 200 HTML "you may close this window" |
+| `/pending?state=Y` | GET | Called by local Fasten; returns `{code}` and deletes KV entry, or 404 if not yet arrived |
+
+The `/pending` endpoint should require a shared secret header (`X-Fasten-Token`) to prevent anyone from polling for codes by guessing state values.
+
+## Work required
+
+### Phase 1 — Cloudflare Worker (standalone, ~1 day)
+
+1. Create `workers/oauth-relay/` in the fork (or a separate repo)
+2. Implement the two-endpoint Worker in TypeScript
+3. Configure KV namespace `OAUTH_CODES`
+4. Deploy to `auth.nerdsbythehour.com` via Cloudflare Pages/Workers
+5. Add `FASTEN_RELAY_SECRET` as a Worker secret
+
+### Phase 2 — SMART on FHIR client in Fasten (~1–2 weeks)
+
+Replace the stubbed `fasten-sources` functionality with a real implementation:
+
+1. **Provider registration:** store per-provider SMART app credentials (client_id, client_secret or PKCE-only) in a config file or encrypted in the DB
+2. **Authorization flow:** generate PKCE challenge, build authorize URL, open browser
+3. **Token exchange:** poll the Worker for the code, exchange with provider's token endpoint, store access + refresh tokens in `SourceCredential`
+4. **Background refresh:** scheduled worker that checks token expiry, refreshes via provider's token endpoint
+5. **Resource sync:** `GET /Patient/$everything` → parse Bundle → call `UpsertRawResource` for each entry
+
+### Phase 3 — Per-provider registrations (~ongoing)
+
+Each provider requires a separate SMART app registration:
+
+| Provider | Developer portal | Notes |
+|---|---|---|
+| Veradigm / FollowMyHealth | developer.veradigm.com | FHIR R4, non-US-Core; `$everything` supported |
+| Epic MyChart | fhir.epic.com | US Core R4; needs Epic app registration |
+| CommonWell / Carequality | varies | Network-level, more complex |
+
+### Phase 4 — Wire into Fasten UI (~1 week)
+
+- Re-enable the "Add Source" → provider search flow in the frontend
+- Connect to the new backend OAuth endpoints instead of the old `fasten-sources` factory
+- Handle the "connect provider" success/error states
+
+## Security considerations
+
+- The Worker never sees access or refresh tokens — only the short-lived authorization code (60s TTL)
+- PKCE is required for all flows (prevents code interception)
+- The `/pending` endpoint is gated by `X-Fasten-Token` (shared secret, set in Worker env)
+- State parameter ties the code to the originating session (prevents CSRF)
+- Cloudflare KV entries auto-expire; no manual cleanup needed
+
+## Relationship to current state
+
+The `fasten-sources` stub in the fork (`./fasten-sources-stub`) satisfies all compile-time imports with stub implementations that return clear errors. The stub is the bridge until Phase 2 is complete. Phases can be implemented incrementally — Phase 1 (the Worker) can be deployed and tested with a standalone script before any Fasten backend work begins.
+
+## Files that will change (in jwilleke/yourphr)
+
+| File | Change |
+|---|---|
+| `fasten-sources-stub/clients/factory/factory.go` | Replace stub `GetSourceClient` with real implementation |
+| `fasten-sources-stub/clients/models/models.go` | Implement `SourceClient` interface methods |
+| `backend/pkg/web/handler/source.go` | OAuth initiation + code polling endpoints |
+| `backend/pkg/web/server.go` | Register new OAuth routes |
+| `workers/oauth-relay/` | New: Cloudflare Worker source |
+| `frontend/src/app/components/...` | Re-enable provider connect UI |

--- a/docs/planning/smart-on-fhir/smart-on-fhir.md
+++ b/docs/planning/smart-on-fhir/smart-on-fhir.md
@@ -1,0 +1,263 @@
+# SMART on FHIR — master plan
+
+Living research-and-decision doc for [issue #20](https://github.com/jwilleke/yourphr/issues/20)
+(support SMART on FHIR live provider sync). Directly serves the mission in
+[issue #15](https://github.com/jwilleke/yourphr/issues/15) — immediate, complete patient
+access to records.
+
+This is the **master** doc; it will be upgraded as decisions are made. The relay-specific
+deep dive lives in [`oauth-gateway.md`](./oauth-gateway.md). Related ingestion options and
+ecosystem notes are in
+[`../personal-health/health-record-aggregation.md`](../personal-health/health-record-aggregation.md)
+and [`../personal-health/fastenhealth-ecosystem.md`](../personal-health/fastenhealth-ecosystem.md).
+
+## Status
+
+- **Phase:** research / design. No implementation started.
+- **Last updated:** 2026-06-04.
+- **Decisions made:** none yet (see [Open decisions](#open-decisions) and [Decision log](#decision-log)).
+
+## TL;DR
+
+- "SMART on FHIR" is OAuth2 authorization-code + PKCE layered on a FHIR API. The protocol is
+  standard; the hard parts are (1) a **public `redirect_uri`** for an instance that may not be
+  internet-reachable, and (2) **per-provider app registration/approval**, which is external and
+  is the real calendar risk.
+- The frontend **already implements** the relay protocol and a desktop poll flow, and the repo
+  already depends on a top-tier OAuth library. We should **reuse**, not rebuild.
+- `yourphr.nerdsbythehour.com` is a **dev/demo platform**, so the first target should be a
+  **SMART sandbox** (test patients, no PHI, flexible registration), not a real provider.
+
+## What SMART on FHIR requires
+
+The OAuth callback gateway is only **one** required piece (the public redirect target), not the
+whole flow. For a patient standalone launch there are three categories.
+
+### Prerequisites (per provider, one-time, external — the long pole)
+
+- A registered SMART app at the provider developer portal yields a `client_id`
+  (and sometimes a `client_secret`).
+- Pre-registered `redirect_uri` values that exactly match the public callback URL. This is *why*
+  a gateway/relay must exist.
+- Declared scopes, e.g. `launch/patient`, `patient/*.read`, `openid fhirUser`, `offline_access`.
+- The provider FHIR base URL and SMART endpoints, discoverable at
+  `GET {fhirBase}/.well-known/smart-configuration`.
+
+### Runtime flow (every connection)
+
+| Step | What happens | Who needs it |
+|---|---|---|
+| 1. Discover | `GET .well-known/smart-configuration` returns auth/token endpoints | our backend |
+| 2. Build authorize URL | `response_type=code`, `client_id`, `redirect_uri`, `scope`, `state`, `aud`, `code_challenge` (PKCE S256) | our backend |
+| 3. Redirect browser | user logs into the portal and consents | provider |
+| 4. Provider redirects back | callback URL receives `code` and `state` | **the gateway** |
+| 5. Token exchange | `POST token_endpoint` with `code` + `code_verifier`, returns `access_token`, `refresh_token`, `patient`, `expires_in` | our backend |
+| 6. Fetch data | `GET {fhirBase}/Patient/{id}/$everything` with a bearer token | our backend |
+| 7. Refresh | on expiry, `POST token_endpoint` with `grant_type=refresh_token` (needs `offline_access`) | our backend (scheduled) |
+
+### Components we must build
+
+| ID | Component | Is it "the gateway"? |
+|---|---|---|
+| A | Per-provider config/credential store (`client_id`, scopes, FHIR base) | no |
+| B | Public, stable HTTPS `redirect_uri` reachable by the provider | **yes** |
+| C | PKCE + `state` generation, stored locally to tie callback to session | no |
+| D | Token-exchange logic (code to tokens) + encrypted token storage | no |
+| E | Refresh-token lifecycle (scheduled refresh) | no |
+| F | FHIR fetch + ingest (Bundle to `UpsertRawResource`) | no |
+| G | UI to initiate connect and handle success/error | no |
+
+**Gateway** answers "where does the provider redirect to?" (component B only). **SMART on FHIR**
+answers "how do we get authorized and pull the records?" — the gateway is just step 4.
+
+## The core problem
+
+SMART requires a publicly reachable `redirect_uri`, but a self-hosted instance often is not
+publicly reachable. Upstream solved this with Fasten Lighthouse — a hosted relay moved into the
+commercial Fasten Connect product (upstream issue #629) — which is why the fork's `fasten-sources`
+is a stub today and live sync is non-functional.
+
+Two framings matter:
+
+- **The demo platform.** `yourphr.nerdsbythehour.com` is a development/demo, not a locked-down LAN
+  production box, so the "maximal LAN isolation" rationale is weak for it. For the demo we can make
+  a callback public (or just use a sandbox) with little concern.
+- **The distributed product.** End users each run their own instance at different, often
+  non-public, URLs. "One app needs thousands of redirect URIs" is the classic self-hosted-OAuth
+  problem. A **shared relay** (one registration per provider, fan-out by `state`) is the
+  low-friction answer and is exactly what Lighthouse was.
+
+## What the repo already implements (reuse, do not rebuild)
+
+- `frontend/src/app/services/lighthouse.service.ts` implements the **Lighthouse relay protocol**:
+  `generateSourceAuthorizeUrl()`, then `redirectWithOriginAndDestination()` which registers an
+  `origin_url` + `dest_url` with a relay and forwards through a `redirect/{state}` URL.
+- **Desktop poll mode** is already coded: it routes to a `desktop/callback/{state}` path and
+  **polls** with `waitForDesktopCodeOrTimeout(state)` then `redirectWithDesktopCode()`. This is the
+  same "store the code, client polls for it" design as the gateway plan — already implemented on
+  the client.
+- Build configs exist for `desktop_sandbox`, `desktop_prod`, `offline_sandbox`, plus a
+  `desktop-callback` page wired into routing.
+- `@panva/oauth4webapi` is already a dependency (`frontend/package.json`).
+- Backend scaffolding exists: `SourceCredential` carries OAuth token fields and a
+  `RefreshDynamicClientAccessToken()` method (called in
+  `backend/pkg/web/handler/source.go`), and the Bundle-to-ingest path (component F) already exists
+  via `CreateManualSource`.
+
+**Implication:** the relay/poll design is largely existing frontend work. The main new task is a
+relay backend that speaks the protocol the frontend already expects, plus backend components
+C, D, E.
+
+## Method options (be open)
+
+| Method | Public endpoint needed | Notes | Status in repo |
+|---|---|---|---|
+| Desktop / poll (loopback-style: client polls relay for code) | relay only; nothing inbound to the instance | strongest isolation | frontend already implemented |
+| Shared relay (Lighthouse model: one registration per provider, fan-out by `state`) | the relay | lowest user friction; reuses most code | frontend protocol already implemented; needs a relay backend |
+| Per-user public deploy (Cloudflare Tunnel / own domain, register own URL) | the instance itself | trivial for the demo | not built |
+| BYO-registration (each user registers their own SMART app) | their instance URL | most decentralized; high user friction | not built |
+| Non-OAuth ingestion (manual export, Apple Health intermediary) | none | works today; sidesteps SMART | manual import works |
+
+For the distributed product, the central fork is **shared community relay** vs
+**per-user public-deploy / BYO**.
+
+## Relay architecture options (for component B)
+
+Detailed in [`oauth-gateway.md`](./oauth-gateway.md). Summary:
+
+| Option | LAN isolation | Moving parts | Token exposure |
+|---|---|---|---|
+| Cloudflare Worker + KV + poll | total (outbound only) | Worker + KV + poll + shared secret | never leaves the instance |
+| Cloudflare Tunnel (scoped `/callback`) | one callback path is internet-reachable | tunnel config only | never leaves the instance |
+
+Both keep tokens on the instance; the only real difference is whether one narrow,
+state-validated callback endpoint is reachable from the internet.
+
+## Well-tested implementations to use
+
+Do not hand-roll OAuth.
+
+| Layer | Use | Why |
+|---|---|---|
+| Backend token machinery (code exchange, PKCE, refresh) | `golang.org/x/oauth2` | canonical, battle-tested Go OAuth2 client; native PKCE and refresh. Covers components D and E |
+| Frontend / spike OAuth + OIDC | `@panva/oauth4webapi` + `jose` (already deps) | spec-compliant gold standard for JS |
+| Reference SMART client (spike / desktop) | `fhirclient` (SMART Health IT "client-js") | reference SMART-on-FHIR JS lib maintained by the SMART team |
+| FHIR parsing | existing `fastenhealth/gofhir-models` | already used; ingest path exists |
+| Dev/demo target | SMART sandboxes: SMART Health IT (`launch.smarthealthit.org`), Epic (`fhir.epic.com`), Cerner/Oracle, Logica | test patients, flexible registration, zero PHI |
+
+SMART on FHIR is roughly `.well-known` discovery (a plain GET) + OAuth2 auth-code-with-PKCE
+(`x/oauth2`) + FHIR fetch (existing models). No bespoke backend SMART library is needed; the only
+genuinely custom piece is the relay (about 50 lines).
+
+## Recommended sequencing (de-risk first)
+
+1. **Spike against a SMART sandbox** (throwaway): prove the full PKCE flow end-to-end
+   (authorize, callback, token exchange, `GET /Patient/$everything`, save bundle) with test
+   patients and no PHI. Validates the protocol and the existing frontend relay/desktop code.
+2. **Spike against real Veradigm**: register the app, repeat the flow. De-risks the external
+   registration/approval long pole and surfaces real non-US-Core data.
+3. **Relay** (Worker or Tunnel) implementing the protocol the frontend already expects.
+4. **Backend SMART client**: generic SMART-R4 client in the `fasten-sources` stub + authorize /
+   callback / scheduled-refresh wiring (components C, D, E).
+5. **Re-enable the "Add Source" UI** against the new endpoints (component G).
+6. **Add providers** (Epic, etc.) as separate registrations.
+
+## Intellectual property and licensing
+
+Short version: **no copyright/IP-infringement risk** in building our own SMART client and relay on
+open standards and permissive libraries. The real obligations are contractual (per-provider terms)
+and license hygiene (GPLv3 + no reuse of Fasten's private/commercial code or marks).
+
+### Veradigm (and other providers)
+
+- Access is via SMART on FHIR under **patient-access rights** (21st Century Cures Act / ONC
+  info-blocking rules). The data is the patient's own; FHIR R4 is an open HL7 standard, free to
+  implement.
+- The obligation is **contractual, not copyright**: each provider runs a developer program with
+  Terms of Use / an API agreement (app registration, allowed use, rate limits, sometimes production
+  approval). We must read and comply with the `developer.veradigm.com` terms (and `fhir.epic.com`
+  for Epic).
+- We copy nothing from Veradigm — we are a standards client to their public patient API. No IP
+  concern there.
+- Watch for terms that restrict commercial use or redistribution, or require attribution; these
+  matter if YourPHR is distributed. Confirm per provider before production.
+
+### Fasten Lighthouse
+
+- Lighthouse is Fasten Health's **proprietary** hosted relay, now part of the commercial Fasten
+  Connect product. Its server source was never open-sourced.
+- We do **not** have, use, or copy Fasten's Lighthouse server code, and we will **not** free-ride on
+  their hosted service. We build our **own** relay.
+- The relay **protocol** (`origin_url` / `dest_url` / `redirect/{state}`) is an interface.
+  Independently reimplementing an API/protocol is well-established as non-infringing
+  (cf. *Google v. Oracle*). We write our own server against the protocol the GPL client already
+  speaks.
+- The **client** that speaks it (`lighthouse.service.ts`) is part of `fasten-onprem`, GPLv3 — we
+  inherited it legally under GPL.
+- **Trademark:** "Fasten" and "Lighthouse" are Fasten's marks. Per `CLAUDE.md` we keep internal
+  identifiers (e.g. `FastenLighthouseEnvSandbox`) but user-facing product strings are YourPHR. Do
+  not brand the relay as "Lighthouse" or imply Fasten endorsement.
+
+### fasten-sources and the provider catalog
+
+- Upstream `fasten-sources` was made private; our `fasten-sources-stub` is our own clean-room
+  reimplementation of the interface. Do **not** reintroduce upstream's private code or its
+  proprietary brand/endpoint catalog.
+- If we need a provider catalog, build it from **open** sources: each provider's
+  `.well-known/smart-configuration`, and public endpoint directories (ONC/CMS, Epic's open endpoint
+  list, CARIN / National Directory) — not a copied private catalog.
+
+### Our code and dependency licenses
+
+- The fork is **GPLv3**; new code (backend client, relay integration) inherits GPLv3 obligations
+  (publish source). Keep our relay GPL-compatible and, ideally, open-source it for community trust.
+- GPLv3 is not AGPLv3: running a network relay does not by itself force source disclosure, but we
+  intend to open it anyway.
+- Planned dependencies are permissive and GPLv3-compatible (verify exact license at adoption):
+  `golang.org/x/oauth2` (BSD-3-Clause), `@panva/oauth4webapi` and `jose` (MIT), SMART `fhirclient` /
+  client-js (permissive), `fastenhealth/gofhir-models` (verify). Apache-2.0 is GPLv3-compatible.
+
+### Action items
+
+- Read and record the Veradigm developer Terms of Use before registering the app.
+- Confirm `gofhir-models` and `fhirclient` exact licenses at adoption.
+- Decide whether our relay is open-sourced (recommended) and under which license (GPLv3 to match).
+
+## Open decisions
+
+1. **Relay architecture** — Cloudflare Worker + KV + poll vs Cloudflare Tunnel (scoped callback).
+2. **Generic vs per-vendor client** — recommend one generic SMART-R4 client driven by `.well-known`
+   discovery + per-provider config; vendor quirks (Veradigm non-US-Core) belong in the
+   display/normalization layer (upstream #428 / #431 / #347), not the auth client.
+3. **Distribution model** — shared community relay vs per-user public-deploy / BYO-registration.
+4. **First provider target** — Veradigm/FollowMyHealth vs Epic vs catalog-driven. (Sandbox first
+   regardless.)
+5. **Sequencing vs display bugs** — the ecosystem doc prioritizes non-US-Core display fixes before
+   sync; confirm SMART is the near-term priority.
+
+## Files likely to change (in `jwilleke/yourphr`)
+
+| File / area | Change |
+|---|---|
+| `fasten-sources-stub/clients/factory/factory.go` | replace stub `GetSourceClient` with a real generic SMART client |
+| `fasten-sources-stub/clients/models/models.go` | implement `SourceClient` interface methods |
+| `backend/pkg/web/handler/source.go` | OAuth initiation + token-exchange (and/or code-poll) endpoints |
+| `backend/pkg/web/server.go` | register new OAuth routes |
+| relay (new) | Cloudflare Worker source, or Cloudflare Tunnel config in `mj-infra-flux` |
+| `frontend/src/app/services/lighthouse.service.ts` + medical-sources components | point at the new relay; re-enable provider connect UI |
+
+## References
+
+- Issues: [#20](https://github.com/jwilleke/yourphr/issues/20) (this feature),
+  [#15](https://github.com/jwilleke/yourphr/issues/15) (mission).
+- Upstream: `fastenhealth/fasten-onprem` #629 (Lighthouse moved to commercial Fasten Connect).
+- Specs: HL7 SMART App Launch; OAuth 2.0 for Native Apps (RFC 8252); PKCE (RFC 7636).
+- Sibling docs: [`oauth-gateway.md`](./oauth-gateway.md),
+  [`../personal-health/health-record-aggregation.md`](../personal-health/health-record-aggregation.md),
+  [`../personal-health/fastenhealth-ecosystem.md`](../personal-health/fastenhealth-ecosystem.md).
+
+## Decision log
+
+Append dated entries as decisions are made.
+
+- *(none yet)*


### PR DESCRIPTION
Brings the SMART on FHIR planning research under version control (`docs/planning/` was untracked) and adds an IP/licensing analysis.

## Adds
- **`docs/planning/smart-on-fhir/smart-on-fhir.md`** — master living plan for #20:
  - what SMART on FHIR requires (the OAuth callback gateway is **component B only**, not the whole flow)
  - what the repo **already implements** (Lighthouse relay protocol + desktop poll mode in `lighthouse.service.ts`, `@panva/oauth4webapi`, `SourceCredential` + ingest scaffolding) → reuse, don't rebuild
  - method options (desktop/poll, shared relay, per-user deploy, BYO-registration, non-OAuth)
  - **well-tested libraries to use** (`golang.org/x/oauth2`, panva, SMART `fhirclient`, gofhir-models) + SMART sandboxes
  - **intellectual property & licensing** analysis (see below)
  - sandbox-first sequencing, open decisions, decision log
- `docs/planning/smart-on-fhir/oauth-gateway.md` — relay deep dive
- `docs/planning/personal-health/{health-record-aggregation,fastenhealth-ecosystem}.md` — ingestion options + upstream ecosystem notes

## IP / licensing summary
- **Veradigm** — contractual (developer ToS), not copyright; we're a standards client to a patient-access FHIR API (Cures Act right). FHIR R4 is an open HL7 standard.
- **Fasten Lighthouse** — their *server* is proprietary/commercial; we build our **own** relay against the protocol the GPLv3 client already speaks (API reimplementation is non-infringing). No reuse of Fasten code; keep "Fasten/Lighthouse" as internal identifiers only.
- **Libraries** — permissive, GPLv3-compatible.
- **Net:** no copyright-infringement risk; obligations are per-provider ToS, GPLv3, and trademark hygiene.

## Notes
- All docs pass `markdownlint` (`.markdownlint.json`); fixed two pre-existing bare-URL lint errors in `fastenhealth-ecosystem.md`.
- No secrets/PHI. Contains some deployment references (`yourphr.nerdsbythehour.com`, `mj-infra-flux`) already present in committed `CLAUDE.md`.

Refs #20, #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)