### PR TITLE
SMART on FHIR planning decisions + neutralize test-token fixture

### DIFF
--- a/docs/planning/smart-on-fhir/smart-on-fhir.md
+++ b/docs/planning/smart-on-fhir/smart-on-fhir.md
@@ -1,47 +1,31 @@
 # SMART on FHIR — master plan
 
-Living research-and-decision doc for [issue #20](https://github.com/jwilleke/yourphr/issues/20)
-(support SMART on FHIR live provider sync). Directly serves the mission in
-[issue #15](https://github.com/jwilleke/yourphr/issues/15) — immediate, complete patient
-access to records.
+Living research-and-decision doc for [issue #20](https://github.com/jwilleke/yourphr/issues/20) (support SMART on FHIR live provider sync). Directly serves the mission in [issue #15](https://github.com/jwilleke/yourphr/issues/15) — immediate, complete patient access to records.
 
-This is the **master** doc; it will be upgraded as decisions are made. The relay-specific
-deep dive lives in [`oauth-gateway.md`](./oauth-gateway.md). Related ingestion options and
-ecosystem notes are in
-[`../personal-health/health-record-aggregation.md`](../personal-health/health-record-aggregation.md)
-and [`../personal-health/fastenhealth-ecosystem.md`](../personal-health/fastenhealth-ecosystem.md).
+This is the **master** doc; it will be upgraded as decisions are made. The relay-specific deep dive lives in [`oauth-gateway.md`](./oauth-gateway.md). Related ingestion options and ecosystem notes are in [`../personal-health/health-record-aggregation.md`](../personal-health/health-record-aggregation.md) and [`../personal-health/fastenhealth-ecosystem.md`](../personal-health/fastenhealth-ecosystem.md).
 
 ## Status
 
 - **Phase:** research / design. No implementation started.
 - **Last updated:** 2026-06-04.
-- **Decisions made:** none yet (see [Open decisions](#open-decisions) and [Decision log](#decision-log)).
+- **Decisions made:** **all Go** (client *and* relay); store-and-poll relay, self-hosted; no Fasten Lighthouse server; rename "Lighthouse" identifiers (see [Decision log](#decision-log)). Others still open (see [Open decisions](#open-decisions)).
 
 ## TL;DR
 
-- "SMART on FHIR" is OAuth2 authorization-code + PKCE layered on a FHIR API. The protocol is
-  standard; the hard parts are (1) a **public `redirect_uri`** for an instance that may not be
-  internet-reachable, and (2) **per-provider app registration/approval**, which is external and
-  is the real calendar risk.
-- The frontend **already implements** the relay protocol and a desktop poll flow, and the repo
-  already depends on a top-tier OAuth library. We should **reuse**, not rebuild.
-- `yourphr.nerdsbythehour.com` is a **dev/demo platform**, so the first target should be a
-  **SMART sandbox** (test patients, no PHI, flexible registration), not a real provider.
+- "SMART on FHIR" is OAuth2 authorization-code + PKCE layered on a FHIR API. The protocol is standard; the hard parts are (1) a **public `redirect_uri`** for an instance that may not be internet-reachable, and (2) **per-provider app registration/approval**, which is external and is the real calendar risk.
+- The frontend **already implements** the relay protocol and a desktop poll flow, and the repo already depends on a top-tier OAuth library. We should **reuse**, not rebuild.
+- `yourphr.nerdsbythehour.com` is a **dev/demo platform**, so the first target should be a **SMART sandbox** (test patients, no PHI, flexible registration), not a real provider.
 
 ## What SMART on FHIR requires
 
-The OAuth callback gateway is only **one** required piece (the public redirect target), not the
-whole flow. For a patient standalone launch there are three categories.
+The OAuth callback gateway is only **one** required piece (the public redirect target), not the whole flow. For a patient standalone launch there are three categories.
 
 ### Prerequisites (per provider, one-time, external — the long pole)
 
-- A registered SMART app at the provider developer portal yields a `client_id`
-  (and sometimes a `client_secret`).
-- Pre-registered `redirect_uri` values that exactly match the public callback URL. This is *why*
-  a gateway/relay must exist.
+- A registered SMART app at the provider developer portal yields a `client_id` (and sometimes a `client_secret`).
+- Pre-registered `redirect_uri` values that exactly match the public callback URL. This is *why* a gateway/relay must exist.
 - Declared scopes, e.g. `launch/patient`, `patient/*.read`, `openid fhirUser`, `offline_access`.
-- The provider FHIR base URL and SMART endpoints, discoverable at
-  `GET {fhirBase}/.well-known/smart-configuration`.
+- The provider FHIR base URL and SMART endpoints, discoverable at `GET {fhirBase}/.well-known/smart-configuration`.
 
 ### Runtime flow (every connection)
 
@@ -67,46 +51,26 @@ whole flow. For a patient standalone launch there are three categories.
 | F | FHIR fetch + ingest (Bundle to `UpsertRawResource`) | no |
 | G | UI to initiate connect and handle success/error | no |
 
-**Gateway** answers "where does the provider redirect to?" (component B only). **SMART on FHIR**
-answers "how do we get authorized and pull the records?" — the gateway is just step 4.
+**Gateway** answers "where does the provider redirect to?" (component B only). **SMART on FHIR** answers "how do we get authorized and pull the records?" — the gateway is just step 4.
 
 ## The core problem
 
-SMART requires a publicly reachable `redirect_uri`, but a self-hosted instance often is not
-publicly reachable. Upstream solved this with Fasten Lighthouse — a hosted relay moved into the
-commercial Fasten Connect product (upstream issue #629) — which is why the fork's `fasten-sources`
-is a stub today and live sync is non-functional.
+SMART requires a publicly reachable `redirect_uri`, but a self-hosted instance often is not publicly reachable. Upstream solved this with Fasten Lighthouse — a hosted relay moved into the commercial Fasten Connect product (upstream issue #629) — which is why the fork's `fasten-sources` is a stub today and live sync is non-functional.
 
 Two framings matter:
 
-- **The demo platform.** `yourphr.nerdsbythehour.com` is a development/demo, not a locked-down LAN
-  production box, so the "maximal LAN isolation" rationale is weak for it. For the demo we can make
-  a callback public (or just use a sandbox) with little concern.
-- **The distributed product.** End users each run their own instance at different, often
-  non-public, URLs. "One app needs thousands of redirect URIs" is the classic self-hosted-OAuth
-  problem. A **shared relay** (one registration per provider, fan-out by `state`) is the
-  low-friction answer and is exactly what Lighthouse was.
+- **The demo platform.** `yourphr.nerdsbythehour.com` is a development/demo, not a locked-down LAN production box, so the "maximal LAN isolation" rationale is weak for it. For the demo we can make a callback public (or just use a sandbox) with little concern.
+- **The distributed product.** End users each run their own instance at different, often non-public, URLs. "One app needs thousands of redirect URIs" is the classic self-hosted-OAuth problem. A **shared relay** (one registration per provider, fan-out by `state`) is the low-friction answer and is exactly what Lighthouse was.
 
 ## What the repo already implements (reuse, do not rebuild)
 
-- `frontend/src/app/services/lighthouse.service.ts` implements the **Lighthouse relay protocol**:
-  `generateSourceAuthorizeUrl()`, then `redirectWithOriginAndDestination()` which registers an
-  `origin_url` + `dest_url` with a relay and forwards through a `redirect/{state}` URL.
-- **Desktop poll mode** is already coded: it routes to a `desktop/callback/{state}` path and
-  **polls** with `waitForDesktopCodeOrTimeout(state)` then `redirectWithDesktopCode()`. This is the
-  same "store the code, client polls for it" design as the gateway plan — already implemented on
-  the client.
-- Build configs exist for `desktop_sandbox`, `desktop_prod`, `offline_sandbox`, plus a
-  `desktop-callback` page wired into routing.
+- `frontend/src/app/services/lighthouse.service.ts` implements the **Lighthouse relay protocol**: `generateSourceAuthorizeUrl()`, then `redirectWithOriginAndDestination()` which registers an `origin_url` + `dest_url` with a relay and forwards through a `redirect/{state}` URL.
+- **Desktop poll mode** is already coded: it routes to a `desktop/callback/{state}` path and **polls** with `waitForDesktopCodeOrTimeout(state)` then `redirectWithDesktopCode()`. This is the same "store the code, client polls for it" design as the gateway plan — already implemented on the client.
+- Build configs exist for `desktop_sandbox`, `desktop_prod`, `offline_sandbox`, plus a `desktop-callback` page wired into routing.
 - `@panva/oauth4webapi` is already a dependency (`frontend/package.json`).
-- Backend scaffolding exists: `SourceCredential` carries OAuth token fields and a
-  `RefreshDynamicClientAccessToken()` method (called in
-  `backend/pkg/web/handler/source.go`), and the Bundle-to-ingest path (component F) already exists
-  via `CreateManualSource`.
+- Backend scaffolding exists: `SourceCredential` carries OAuth token fields and a `RefreshDynamicClientAccessToken()` method (called in `backend/pkg/web/handler/source.go`), and the Bundle-to-ingest path (component F) already exists via `CreateManualSource`.
 
-**Implication:** the relay/poll design is largely existing frontend work. The main new task is a
-relay backend that speaks the protocol the frontend already expects, plus backend components
-C, D, E.
+**Implication:** the relay/poll design is largely existing frontend work. The main new task is a relay backend that speaks the protocol the frontend already expects, plus backend components C, D, E.
 
 ## Method options (be open)
 
@@ -118,122 +82,128 @@ C, D, E.
 | BYO-registration (each user registers their own SMART app) | their instance URL | most decentralized; high user friction | not built |
 | Non-OAuth ingestion (manual export, Apple Health intermediary) | none | works today; sidesteps SMART | manual import works |
 
-For the distributed product, the central fork is **shared community relay** vs
-**per-user public-deploy / BYO**.
+For the distributed product, the central fork is **shared community relay** vs **per-user public-deploy / BYO**.
 
-## Relay architecture options (for component B)
+## Relay architecture
 
-Detailed in [`oauth-gateway.md`](./oauth-gateway.md). Summary:
+Deep dive in [`oauth-gateway.md`](./oauth-gateway.md).
 
-| Option | LAN isolation | Moving parts | Token exposure |
-|---|---|---|---|
-| Cloudflare Worker + KV + poll | total (outbound only) | Worker + KV + poll + shared secret | never leaves the instance |
-| Cloudflare Tunnel (scoped `/callback`) | one callback path is internet-reachable | tunnel config only | never leaves the instance |
+### The problem it solves
 
-Both keep tokens on the instance; the only real difference is whether one narrow,
-state-validated callback endpoint is reachable from the internet.
+SMART requires the provider to redirect the browser to a **pre-registered, publicly reachable HTTPS `redirect_uri`** carrying the authorization `code`. A self-hosted instance often cannot be that URL (LAN-only, behind NAT, dynamic address, or simply not registered). A **relay** is a small public service that *is* the registered URL and gets the `code` back to the instance. The instance then exchanges the code for tokens **directly with the provider** — the relay never sees tokens.
+
+### Three patterns
+
+1. **Web relay (browser-redirect bounce)** — the model the frontend already implements. One public relay URL is registered as the `redirect_uri` (one registration per provider, shared by all instances). Before redirecting, the instance registers `state -> origin_url` with the relay. The provider redirects to `relay/callback?code&state`; the relay looks up `state` and 302-redirects the browser to the instance's own callback, which exchanges the code locally. Requires the user's browser to be able to reach the instance (a LAN browser reaches a LAN instance fine).
+2. **Store-and-poll relay** — the model the frontend already implements for desktop mode, and the design in `oauth-gateway.md`. The relay **stores** `{state -> code}` with a short TTL; the instance **polls** the relay for the code, then exchanges it locally. Nothing is inbound to the instance — it only makes outbound calls. Maximal isolation.
+3. **No relay (inline public callback)** — if the instance itself is publicly reachable at a stable HTTPS URL (e.g. the demo via Cloudflare Tunnel or a public deploy), register *that* as the `redirect_uri`. The provider redirects straight to the instance, which exchanges inline. Simplest; requires the instance to be public.
+
+### Flow (store-and-poll variant)
+
+```text
+1.  User clicks "Connect provider"
+2.  Instance: generate state + PKCE verifier/challenge; store locally
+3.  Instance: redirect browser to provider authorize endpoint
+    (redirect_uri = https://relay.example/callback, state=S, code_challenge=...)
+4.  User logs in at provider, consents
+5.  Provider: redirect browser to https://relay.example/callback?code=C&state=S
+6.  Relay: store {S -> C} with ~60s TTL; show "you may close this window"
+7.  Instance: poll relay GET /pending?state=S   (gated by shared secret)
+8.  Relay: return C, delete the entry
+9.  Instance: POST provider token endpoint with C + code_verifier -> tokens
+10. Instance: store tokens (encrypted SQLite); scheduled refresh thereafter
+```
+
+### Decision and remaining options
+
+**Decided:** we will **not** use Fasten's hosted Lighthouse relay (commercial; see IP section), and per the **all-Go** decision the relay is a **self-hosted Go store-and-poll service** (not a Cloudflare Worker, which would be JS/TS). It is a small public Go HTTP service that stores `{state -> code}` with a short TTL and serves a shared-secret-gated poll endpoint; tokens never pass through it.
+
+Hosting — *DECIDED for dev/demo: the existing k8s cluster via [`mj-infra-flux`](https://github.com/jwilleke/mj-infra-flux)* behind the current Cloudflare ingress at **`relay.nerdsbythehour.com`** (the dev infra domain — `yourphr.org` is the static GitHub Pages site and cannot host a service): a Deployment + Service + Ingress + Secret under `apps/.../yourphr-relay/`, reconciled by Flux like the `fasten` app. Lowest friction, GitOps-consistent, no new vendor.
+
+The relay must be **publicly reachable** even though the app (`yourphr.nerdsbythehour.com`) is internal/LAN — it is the one public piece, served by its own ingress, and it must **not** be behind Authentik (`/callback` is unauthenticated; `/pending` is gated by the shared secret).
+
+*Revisit a managed runtime (Fly.io / Cloud Run) at `relay.yourphr.org` for the distributed product*, so the shared, brand-consistent relay isn't bound to homelab uptime — trivial to move since the relay is stateless (short-TTL codes only, never tokens). Rejected alternatives: Cloudflare Worker + KV (JS/TS), and a per-user Cloudflare Tunnel exposing the instance's own callback (viable for the public demo only, not for non-public user instances).
+
+### Security properties
+
+- The relay only ever sees the short-lived `code` (~60s TTL), never `access`/`refresh` tokens.
+- **PKCE** binds the code to the instance: a stolen code is useless without the `code_verifier`, which never leaves the instance.
+- **`state`** ties the callback to the originating session (CSRF) and routes to the right instance.
+- The poll endpoint is gated by a shared secret (store-and-poll variant).
+
+### Naming (trademark hygiene)
+
+Audit result: "Lighthouse" appears **only in internal code identifiers** (e.g. `LighthouseService`, `lighthouse_api_endpoint_base`) across 21 `.ts` files, **never in user-facing UI strings** — so trademark exposure is low (trademark targets user-facing use in commerce, not internal symbols). Still, because we build our **own** relay (not Fasten's), relay-specific identifiers should be renamed to neutral terms (a "connect gateway" / "OAuth relay") during the relay refactor, so we are not naming our component after Fasten's product. Deep upstream-interface identifiers we still interoperate with (`fasten-sources`, `FastenDisplayModel`) can stay per `CLAUDE.md`.
 
 ## Well-tested implementations to use
 
 Do not hand-roll OAuth.
 
+Decided: **all Go** (see open decision 2). No JS in the product path.
+
 | Layer | Use | Why |
 |---|---|---|
-| Backend token machinery (code exchange, PKCE, refresh) | `golang.org/x/oauth2` | canonical, battle-tested Go OAuth2 client; native PKCE and refresh. Covers components D and E |
-| Frontend / spike OAuth + OIDC | `@panva/oauth4webapi` + `jose` (already deps) | spec-compliant gold standard for JS |
-| Reference SMART client (spike / desktop) | `fhirclient` (SMART Health IT "client-js") | reference SMART-on-FHIR JS lib maintained by the SMART team |
+| SMART client — discovery, PKCE, token exchange, refresh (spike + production) | `golang.org/x/oauth2` (PKCE via `GenerateVerifier` / `S256ChallengeOption`) + `net/http` | all-Go, canonical, battle-tested; the Go spike exercises the same libraries the product uses |
 | FHIR parsing | existing `fastenhealth/gofhir-models` | already used; ingest path exists |
+| Frontend (optional) | existing `@panva/oauth4webapi` only if the frontend builds authorize URLs | not needed if the Go backend builds the authorize URL and handles the callback |
 | Dev/demo target | SMART sandboxes: SMART Health IT (`launch.smarthealthit.org`), Epic (`fhir.epic.com`), Cerner/Oracle, Logica | test patients, flexible registration, zero PHI |
 
-SMART on FHIR is roughly `.well-known` discovery (a plain GET) + OAuth2 auth-code-with-PKCE
-(`x/oauth2`) + FHIR fetch (existing models). No bespoke backend SMART library is needed; the only
-genuinely custom piece is the relay (about 50 lines).
+SMART on FHIR is roughly `.well-known` discovery (a plain GET) + OAuth2 auth-code-with-PKCE (`x/oauth2`) + FHIR fetch (existing models) — **all Go**. No bespoke SMART library is needed, and the relay is a small self-hosted **Go** store-and-poll service too (see [Relay architecture](#relay-architecture)).
 
 ## Recommended sequencing (de-risk first)
 
-1. **Spike against a SMART sandbox** (throwaway): prove the full PKCE flow end-to-end
-   (authorize, callback, token exchange, `GET /Patient/$everything`, save bundle) with test
-   patients and no PHI. Validates the protocol and the existing frontend relay/desktop code.
-2. **Spike against real Veradigm**: register the app, repeat the flow. De-risks the external
-   registration/approval long pole and surfaces real non-US-Core data.
+1. **Spike against a SMART sandbox** (throwaway): prove the full PKCE flow end-to-end (authorize, callback, token exchange, `GET /Patient/$everything`, save bundle) with test patients and no PHI. Validates the protocol and the existing frontend relay/desktop code.
+2. **Spike against real Veradigm**: register the app, repeat the flow. De-risks the external registration/approval long pole and surfaces real non-US-Core data.
 3. **Relay** (Worker or Tunnel) implementing the protocol the frontend already expects.
-4. **Backend SMART client**: generic SMART-R4 client in the `fasten-sources` stub + authorize /
-   callback / scheduled-refresh wiring (components C, D, E).
+4. **Backend SMART client**: generic SMART-R4 client in the `fasten-sources` stub + authorize / callback / scheduled-refresh wiring (components C, D, E).
 5. **Re-enable the "Add Source" UI** against the new endpoints (component G).
 6. **Add providers** (Epic, etc.) as separate registrations.
 
 ## Intellectual property and licensing
 
-Short version: **no copyright/IP-infringement risk** in building our own SMART client and relay on
-open standards and permissive libraries. The real obligations are contractual (per-provider terms)
-and license hygiene (GPLv3 + no reuse of Fasten's private/commercial code or marks).
+Short version: **no copyright/IP-infringement risk** in building our own SMART client and relay on open standards and permissive libraries. The real obligations are contractual (per-provider terms) and license hygiene (GPLv3 + no reuse of Fasten's private/commercial code or marks).
 
 ### Veradigm (and other providers)
 
-- Access is via SMART on FHIR under **patient-access rights** (21st Century Cures Act / ONC
-  info-blocking rules). The data is the patient's own; FHIR R4 is an open HL7 standard, free to
-  implement.
-- The obligation is **contractual, not copyright**: each provider runs a developer program with
-  Terms of Use / an API agreement (app registration, allowed use, rate limits, sometimes production
-  approval). We must read and comply with the `developer.veradigm.com` terms (and `fhir.epic.com`
-  for Epic).
-- We copy nothing from Veradigm — we are a standards client to their public patient API. No IP
-  concern there.
-- Watch for terms that restrict commercial use or redistribution, or require attribution; these
-  matter if YourPHR is distributed. Confirm per provider before production.
+- Access is via SMART on FHIR under **patient-access rights** (21st Century Cures Act / ONC info-blocking rules). The data is the patient's own; FHIR R4 is an open HL7 standard, free to implement.
+- The obligation is **contractual, not copyright**: each provider runs a developer program with Terms of Use / an API agreement (app registration, allowed use, rate limits, sometimes production approval). We must read and comply with the `developer.veradigm.com` terms (and `fhir.epic.com` for Epic).
+- We copy nothing from Veradigm — we are a standards client to their public patient API. No IP concern there.
+- Watch for terms that restrict commercial use or redistribution, or require attribution; these matter if YourPHR is distributed. Confirm per provider before production.
 
 ### Fasten Lighthouse
 
-- Lighthouse is Fasten Health's **proprietary** hosted relay, now part of the commercial Fasten
-  Connect product. Its server source was never open-sourced.
-- We do **not** have, use, or copy Fasten's Lighthouse server code, and we will **not** free-ride on
-  their hosted service. We build our **own** relay.
-- The relay **protocol** (`origin_url` / `dest_url` / `redirect/{state}`) is an interface.
-  Independently reimplementing an API/protocol is well-established as non-infringing
-  (cf. *Google v. Oracle*). We write our own server against the protocol the GPL client already
-  speaks.
-- The **client** that speaks it (`lighthouse.service.ts`) is part of `fasten-onprem`, GPLv3 — we
-  inherited it legally under GPL.
-- **Trademark:** "Fasten" and "Lighthouse" are Fasten's marks. Per `CLAUDE.md` we keep internal
-  identifiers (e.g. `FastenLighthouseEnvSandbox`) but user-facing product strings are YourPHR. Do
-  not brand the relay as "Lighthouse" or imply Fasten endorsement.
+- Lighthouse is Fasten Health's **proprietary** hosted relay, now part of the commercial Fasten Connect product. Its server source was never open-sourced.
+- **Decided (2026-06-04): we will not use Fasten's hosted Lighthouse server** under any circumstances. We do not have, use, or copy its server code, and we will not free-ride on the hosted service. We build our **own** relay (or use the no-relay option).
+- The relay **protocol** (`origin_url` / `dest_url` / `redirect/{state}`) is an interface. Independently reimplementing an API/protocol is well-established as non-infringing (cf. *Google v. Oracle*). We write our own server against the protocol the GPL client already speaks.
+- The **client** that speaks it (`lighthouse.service.ts`) is part of `fasten-onprem`, GPLv3 — we inherited it legally under GPL.
+- **Trademark:** "Fasten" and "Lighthouse" are Fasten's marks. Per `CLAUDE.md` we keep internal identifiers (e.g. `FastenLighthouseEnvSandbox`) but user-facing product strings are YourPHR. Do not brand the relay as "Lighthouse" or imply Fasten endorsement.
 
 ### fasten-sources and the provider catalog
 
-- Upstream `fasten-sources` was made private; our `fasten-sources-stub` is our own clean-room
-  reimplementation of the interface. Do **not** reintroduce upstream's private code or its
-  proprietary brand/endpoint catalog.
-- If we need a provider catalog, build it from **open** sources: each provider's
-  `.well-known/smart-configuration`, and public endpoint directories (ONC/CMS, Epic's open endpoint
-  list, CARIN / National Directory) — not a copied private catalog.
+- Upstream `fasten-sources` was made private; our `fasten-sources-stub` is our own clean-room reimplementation of the interface. Do **not** reintroduce upstream's private code or its proprietary brand/endpoint catalog.
+- If we need a provider catalog, build it from **open** sources: each provider's `.well-known/smart-configuration`, and public endpoint directories (ONC/CMS, Epic's open endpoint list, CARIN / National Directory) — not a copied private catalog.
 
 ### Our code and dependency licenses
 
-- The fork is **GPLv3**; new code (backend client, relay integration) inherits GPLv3 obligations
-  (publish source). Keep our relay GPL-compatible and, ideally, open-source it for community trust.
-- GPLv3 is not AGPLv3: running a network relay does not by itself force source disclosure, but we
-  intend to open it anyway.
-- Planned dependencies are permissive and GPLv3-compatible (verify exact license at adoption):
-  `golang.org/x/oauth2` (BSD-3-Clause), `@panva/oauth4webapi` and `jose` (MIT), SMART `fhirclient` /
-  client-js (permissive), `fastenhealth/gofhir-models` (verify). Apache-2.0 is GPLv3-compatible.
+- The fork is **GPLv3**; new code (backend client, relay integration) inherits GPLv3 obligations (publish source). Keep our relay GPL-compatible and, ideally, open-source it for community trust.
+- GPLv3 is not AGPLv3: running a network relay does not by itself force source disclosure, but we intend to open it anyway.
+- Per the all-Go decision, planned dependencies are just `golang.org/x/oauth2` (BSD-3-Clause) and `fastenhealth/gofhir-models` (verify license at adoption) — both permissive and GPLv3-compatible. No new JS OAuth dependencies (`fhirclient` dropped; `@panva/oauth4webapi` is only relevant if the existing Angular frontend builds authorize URLs).
 
 ### Action items
 
 - Read and record the Veradigm developer Terms of Use before registering the app.
-- Confirm `gofhir-models` and `fhirclient` exact licenses at adoption.
-- Decide whether our relay is open-sourced (recommended) and under which license (GPLv3 to match).
+- Confirm `fastenhealth/gofhir-models` exact license at adoption.
+- Add the Go relay to `mj-infra-flux` (`apps/.../yourphr-relay/`: Deployment + Service + Ingress + Secret) with DNS `relay.nerdsbythehour.com` (dev); ensure it is publicly reachable and excluded from Authentik forward-auth. Reserve `relay.yourphr.org` for a future product relay.
+- Open-source the Go relay (recommended) under GPLv3 to match the fork.
 
 ## Open decisions
 
-1. **Relay architecture** — Cloudflare Worker + KV + poll vs Cloudflare Tunnel (scoped callback).
-2. **Generic vs per-vendor client** — recommend one generic SMART-R4 client driven by `.well-known`
-   discovery + per-provider config; vendor quirks (Veradigm non-US-Core) belong in the
-   display/normalization layer (upstream #428 / #431 / #347), not the auth client.
-3. **Distribution model** — shared community relay vs per-user public-deploy / BYO-registration.
-4. **First provider target** — Veradigm/FollowMyHealth vs Epic vs catalog-driven. (Sandbox first
-   regardless.)
-5. **Sequencing vs display bugs** — the ecosystem doc prioritizes non-US-Core display fixes before
-   sync; confirm SMART is the near-term priority.
+1. **Relay architecture** — *DECIDED: store-and-poll, self-hosted **Go** relay, hosted on the existing k8s cluster via `mj-infra-flux` + Cloudflare ingress for dev/demo* (not Fasten Lighthouse, not a JS Cloudflare Worker). Revisit a managed runtime (Fly.io / Cloud Run) for the distributed product.
+2. **Where the production SMART client runs** — *DECIDED (2026-06-04): all Go.* The full SMART flow (discovery, PKCE, token exchange, refresh, FHIR fetch) is built in the **Go backend** with `golang.org/x/oauth2` + `net/http` + `gofhir-models`. `fhirclient` is dropped; the de-risk spike is also written in Go so it exercises the production libraries. The relay is Go as well — a self-hosted store-and-poll service (decision 1).
+3. **Generic vs per-vendor client** — recommend one generic SMART-R4 client driven by `.well-known` discovery + per-provider config; vendor quirks (Veradigm non-US-Core) belong in the display/normalization layer (upstream #428 / #431 / #347), not the auth client.
+4. **Distribution model** — shared community relay vs per-user public-deploy / BYO-registration.
+5. **First provider target** — Veradigm/FollowMyHealth vs Epic vs catalog-driven. (Sandbox first regardless.)
+6. **Sequencing vs display bugs** — the ecosystem doc prioritizes non-US-Core display fixes before sync; confirm SMART is the near-term priority.
 
 ## Files likely to change (in `jwilleke/yourphr`)
 
@@ -243,21 +213,21 @@ and license hygiene (GPLv3 + no reuse of Fasten's private/commercial code or mar
 | `fasten-sources-stub/clients/models/models.go` | implement `SourceClient` interface methods |
 | `backend/pkg/web/handler/source.go` | OAuth initiation + token-exchange (and/or code-poll) endpoints |
 | `backend/pkg/web/server.go` | register new OAuth routes |
-| relay (new) | Cloudflare Worker source, or Cloudflare Tunnel config in `mj-infra-flux` |
-| `frontend/src/app/services/lighthouse.service.ts` + medical-sources components | point at the new relay; re-enable provider connect UI |
+| relay (new) | self-hosted **Go** store-and-poll service + its deploy manifest (e.g. in `mj-infra-flux` behind Cloudflare ingress) |
+| `frontend/src/app/services/lighthouse.service.ts` + medical-sources components | rename to a neutral "connect gateway", point at the new relay, re-enable provider connect UI |
 
 ## References
 
-- Issues: [#20](https://github.com/jwilleke/yourphr/issues/20) (this feature),
-  [#15](https://github.com/jwilleke/yourphr/issues/15) (mission).
+- Issues: [#20](https://github.com/jwilleke/yourphr/issues/20) (this feature), [#15](https://github.com/jwilleke/yourphr/issues/15) (mission).
 - Upstream: `fastenhealth/fasten-onprem` #629 (Lighthouse moved to commercial Fasten Connect).
 - Specs: HL7 SMART App Launch; OAuth 2.0 for Native Apps (RFC 8252); PKCE (RFC 7636).
-- Sibling docs: [`oauth-gateway.md`](./oauth-gateway.md),
-  [`../personal-health/health-record-aggregation.md`](../personal-health/health-record-aggregation.md),
-  [`../personal-health/fastenhealth-ecosystem.md`](../personal-health/fastenhealth-ecosystem.md).
+- Sibling docs: [`oauth-gateway.md`](./oauth-gateway.md), [`../personal-health/health-record-aggregation.md`](../personal-health/health-record-aggregation.md), [`../personal-health/fastenhealth-ecosystem.md`](../personal-health/fastenhealth-ecosystem.md).
 
 ## Decision log
 
 Append dated entries as decisions are made.
 
-- *(none yet)*
+- **2026-06-04 — No Fasten Lighthouse server.** We will not use Fasten's hosted Lighthouse relay (commercial; not open). We run our own relay or use the no-relay (inline public callback) option. Resolves part of open decision 1.
+- **2026-06-04 — DECIDED: all Go (client and relay).** The full SMART flow is built in the Go backend with `golang.org/x/oauth2` + `net/http` + `gofhir-models`; the de-risk spike is written in Go too; `fhirclient` and other JS OAuth deps are dropped. Resolves open decision 2.
+- **2026-06-04 — DECIDED: store-and-poll relay, self-hosted Go service, hosted via `mj-infra-flux`.** Maximal isolation (only outbound polls from the instance), matches the desktop-poll flow the frontend already implements, consistent with "no Fasten Lighthouse" and "all Go." The relay is a small public Go HTTP service (not a JS Cloudflare Worker); tokens never pass through it. For dev/demo it deploys to the existing k8s cluster via `mj-infra-flux` behind Cloudflare ingress at `relay.nerdsbythehour.com` (the dev domain; `yourphr.org` is static GitHub Pages), excluded from Authentik. Revisit Fly.io / Cloud Run at `relay.yourphr.org` for the distributed product (stateless, so trivial to move). Resolves open decision 1.
+- **2026-06-04 — Rename "Lighthouse" identifiers (trademark hygiene).** Audit found "Lighthouse" only in internal `.ts` identifiers, never user-facing — so legal risk is low, but since we build our own relay we will rename relay-specific identifiers (e.g. `LighthouseService`, `lighthouse_api_endpoint_base`) to neutral terms during the relay refactor. Keep deep upstream-interface identifiers (`fasten-sources`, `FastenDisplayModel`) per `CLAUDE.md`. This is a scoped exception to the "do not rename internal identifiers" guidance, justified because we are replacing the component they name.

--- a/frontend/src/app/components/medical-sources-connected/medical-sources-connected.component.spec.ts
+++ b/frontend/src/app/components/medical-sources-connected/medical-sources-connected.component.spec.ts
@@ -39,8 +39,10 @@ describe('MedicalSourcesConnectedComponent', () => {
     const tokenResponse = {
       token_type: "Bearer",
       expires_in: "3600",
-      access_token: "OXgK8mrfvMrxIMK38T6CAjKiLMDV",
-      refresh_token: "5Oq5ZgcTgi9-xxxxxxx",
+      // Dummy values — this test only exercises expires_in; the token strings are
+      // unused by the assertion. Kept obviously-fake so secret scanners don't flag them.
+      access_token: "fake-access-token-for-test",
+      refresh_token: "fake-refresh-token-for-test",
       patient: "a-80000.xxxx"
     }
 


### PR DESCRIPTION
Two commits.

## 1. `docs(smart-on-fhir)` — record architecture decisions
Updates the master plan (`docs/planning/smart-on-fhir/smart-on-fhir.md`) with the decisions from the design discussion:
- **All Go** — backend SMART client (`golang.org/x/oauth2` + `net/http` + `gofhir-models`) and the spike; `fhirclient`/JS OAuth deps dropped.
- **Relay** — store-and-poll, **self-hosted Go** service (not Fasten Lighthouse, not a JS Cloudflare Worker). Dev host = existing k8s via `mj-infra-flux` + Cloudflare ingress at `relay.nerdsbythehour.com` (`yourphr.org` is static GitHub Pages); `relay.yourphr.org` / managed runtime reserved for the distributed product.
- **No Fasten Lighthouse server**; rename internal `Lighthouse` identifiers during the relay refactor (trademark hygiene — never user-facing).
- Reflow prose to one line per paragraph (`MD013` 900).

## 2. `test` — neutralize mock OAuth token fixture (GitGuardian false positive)
GitGuardian flagged a high-entropy `access_token` in `medical-sources-connected.component.spec.ts` (an upstream 2023 test). It's a **mock token-response**; the test only reads `expires_in` (asserts `getAccessTokenExpiration` length), so the token strings are never used. Replaced with obviously-fake values. **Not a real secret — no rotation needed**; the historical occurrence (commit `c9b482d`) should be marked false-positive in the GitGuardian dashboard (no history rewrite warranted).

Verified locally: docs pass `markdownlint`; the spec change is value-independent of the assertion.

Refs #20, #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)