### PR TITLE
docs(smart-on-fhir): reconcile oauth-gateway.md with the Go relay decision

### DIFF
--- a/docs/planning/smart-on-fhir/oauth-gateway.md
+++ b/docs/planning/smart-on-fhir/oauth-gateway.md
@@ -1,104 +1,85 @@
-# OAuth callback gateway — plan
+# OAuth callback relay — deep dive
 
-Plan for adding live provider sync to the self-hosted Fasten instance without relying on the commercial Fasten Lighthouse service.
+Relay-specific deep dive for [EPIC #20](https://github.com/jwilleke/yourphr/issues/20). The overall plan and all decisions live in [`smart-on-fhir.md`](./smart-on-fhir.md); this file covers just the relay (component B — the public `redirect_uri`).
 
 ## Background
 
-The upstream `fasten-sources` library used Fasten Lighthouse — a hosted cloud OAuth relay — as the callback endpoint for SMART on FHIR provider authentication. Lighthouse was moved to the commercial Fasten Connect product (issue #629). Without it, provider sync is broken in the open-source build.
+Upstream `fasten-sources` used Fasten Lighthouse — a hosted cloud OAuth relay — as the callback endpoint for SMART on FHIR. Lighthouse moved to the commercial Fasten Connect product (`fastenhealth/fasten-onprem#629`), so provider sync is broken in the open-source build, and we will **not** use Fasten's hosted relay.
 
-The underlying problem: `fasten.nerdsbythehour.com` is LAN-only and unreachable from the internet. Hospital portals need a publicly accessible `redirect_uri` to complete OAuth. Lighthouse was that public endpoint. We need our own equivalent.
+The underlying problem: a self-hosted instance (e.g. `yourphr.nerdsbythehour.com`, internal/LAN behind Authentik) is unreachable from the internet, but provider portals need a publicly accessible `redirect_uri` to deliver the authorization `code`. We need our own public relay.
 
-## Chosen approach: Cloudflare Worker relay
+## Chosen approach: self-hosted Go store-and-poll relay
 
-A minimal stateless Cloudflare Worker sits at a public URL (e.g. `https://auth.nerdsbythehour.com/callback`) and acts as the OAuth relay. It stores the short-lived authorization code in Cloudflare KV, where the local Fasten instance polls for it and completes the token exchange directly with the provider.
+A small **Go** HTTP service at a public URL receives the provider's redirect, stores the short-lived authorization `code` keyed by `state`, and serves it to the local instance, which polls for it and completes the token exchange directly with the provider. The relay never sees tokens. This is the **store-and-poll** pattern; it matches the desktop-poll flow the frontend already implements.
+
+This reflects the project decisions (see [`smart-on-fhir.md`](./smart-on-fhir.md)): **all Go**, **store-and-poll**, **self-hosted** (not a JS Cloudflare Worker, not Fasten Lighthouse), **per-user / BYO `client_id`**.
 
 ### Why this approach
 
-- **No server to maintain** — Cloudflare Workers free tier is sufficient
-- **Codes never leave the relay** — the Worker stores the code for ≤60 seconds then deletes it; it never sees tokens
-- **Token exchange is local** — Fasten exchanges the code with the provider directly from the LAN; the Worker never touches access/refresh tokens
-- **LAN-only Fasten stays LAN-only** — only the `/callback` Worker endpoint is public
+- **All Go** — one language across client and relay; reuses the team's Go toolchain and `mj-infra-flux` GitOps.
+- **Codes never leave the relay as tokens** — the relay stores the `code` for ~60 seconds then deletes it; it never sees access/refresh tokens.
+- **Token exchange is local** — the instance exchanges the `code` with the provider directly; the relay never touches tokens.
+- **Nothing inbound to the instance** — the instance only makes outbound calls (the redirect and the poll), so a LAN/NAT instance stays reachable-free; only the relay is public.
+- **Provider-agnostic and client-agnostic** — the relay is a dumb bouncer keyed by `state`; it holds no provider app registration and no `client_id` (BYO model).
 
 ### Flow
 
-```
-1. User clicks "Connect provider" in Fasten UI
-2. Fasten generates a state token + PKCE challenge; stores locally
-3. Fasten redirects browser to provider's SMART authorization endpoint
-   (e.g. https://fhir.veradigm.com/authorize?...&redirect_uri=https://auth.nerdsbythehour.com/callback&state=<token>)
-4. User logs into provider portal and authorizes
-5. Provider redirects to: https://auth.nerdsbythehour.com/callback?code=<code>&state=<token>
-6. Worker stores {state → code} in KV with 60-second TTL
-7. Fasten polls its own /api/oauth/poll?state=<token> endpoint
-8. Fasten's backend polls Worker's GET /pending?state=<token>; Worker returns code
-9. Fasten exchanges code for access + refresh tokens directly with the provider's token endpoint
-10. Fasten stores tokens in SQLite; background worker uses refresh token for ongoing sync
+```text
+1.  User clicks "Connect provider" in the UI
+2.  Instance: generate state + PKCE verifier/challenge; store locally
+3.  Instance: redirect browser to the provider authorize endpoint
+    (redirect_uri = https://relay.nerdsbythehour.com/callback, state=S, code_challenge=...)
+4.  User logs into the provider portal and authorizes
+5.  Provider: redirect browser to https://relay.nerdsbythehour.com/callback?code=C&state=S
+6.  Relay: store {S -> C} in memory with ~60s TTL; return "you may close this window"
+7.  Instance: poll its own backend, which polls the relay GET /pending?state=S (shared-secret gated)
+8.  Relay: return C, delete the entry
+9.  Instance: exchange C (+ PKCE verifier) for access + refresh tokens at the provider token endpoint
+10. Instance: store tokens (encrypted SQLite); scheduled refresh drives ongoing sync
 ```
 
-### Worker API (two endpoints)
+### Relay API (two endpoints)
 
 | Endpoint | Method | Description |
 |---|---|---|
-| `/callback?code=X&state=Y` | GET | Receives redirect from provider; stores `{state: code}` in KV (60s TTL); returns 200 HTML "you may close this window" |
-| `/pending?state=Y` | GET | Called by local Fasten; returns `{code}` and deletes KV entry, or 404 if not yet arrived |
+| `/callback?code=C&state=S` | GET | Receives the provider redirect; stores `{state: code}` with ~60s TTL; returns 200 HTML "you may close this window" |
+| `/pending?state=S` | GET | Called by the local instance; returns `{code}` and deletes the entry, or 404 if not yet arrived. Gated by a shared secret header (`X-Yourphr-Token`) so codes cannot be harvested by guessing `state` |
 
-The `/pending` endpoint should require a shared secret header (`X-Fasten-Token`) to prevent anyone from polling for codes by guessing state values.
+State is held in memory with a TTL (no external KV needed); a single small replica is sufficient and entries are ephemeral.
 
-## Work required
+## Hosting
 
-### Phase 1 — Cloudflare Worker (standalone, ~1 day)
+For dev/demo, deploy via [`mj-infra-flux`](https://github.com/jwilleke/mj-infra-flux) to the existing k8s cluster behind the current Cloudflare ingress at **`relay.nerdsbythehour.com`** (the dev infra domain; `yourphr.org` is the static GitHub Pages site and cannot host a service). It is a Deployment + Service + Ingress + Secret under `apps/.../yourphr-relay/`, reconciled by Flux like the `fasten` app.
 
-1. Create `workers/oauth-relay/` in the fork (or a separate repo)
-2. Implement the two-endpoint Worker in TypeScript
-3. Configure KV namespace `OAUTH_CODES`
-4. Deploy to `auth.nerdsbythehour.com` via Cloudflare Pages/Workers
-5. Add `FASTEN_RELAY_SECRET` as a Worker secret
+The relay must be **publicly reachable and excluded from Authentik forward-auth** (`/callback` is unauthenticated; `/pending` is shared-secret gated). Even though the app is internal/LAN, the relay is the one public piece, served by its own ingress.
 
-### Phase 2 — SMART on FHIR client in Fasten (~1–2 weeks)
+For the eventual distributed product, reserve **`relay.yourphr.org`** on a managed runtime (Fly.io / Cloud Run) so the shared relay is not bound to homelab uptime — trivial to move since the relay is stateless.
 
-Replace the stubbed `fasten-sources` functionality with a real implementation:
+## Rejected alternative: Cloudflare Worker + KV
 
-1. **Provider registration:** store per-provider SMART app credentials (client_id, client_secret or PKCE-only) in a config file or encrypted in the DB
-2. **Authorization flow:** generate PKCE challenge, build authorize URL, open browser
-3. **Token exchange:** poll the Worker for the code, exchange with provider's token endpoint, store access + refresh tokens in `SourceCredential`
-4. **Background refresh:** scheduled worker that checks token expiry, refreshes via provider's token endpoint
-5. **Resource sync:** `GET /Patient/$everything` → parse Bundle → call `UpsertRawResource` for each entry
-
-### Phase 3 — Per-provider registrations (~ongoing)
-
-Each provider requires a separate SMART app registration:
-
-| Provider | Developer portal | Notes |
-|---|---|---|
-| Veradigm / FollowMyHealth | developer.veradigm.com | FHIR R4, non-US-Core; `$everything` supported |
-| Epic MyChart | fhir.epic.com | US Core R4; needs Epic app registration |
-| CommonWell / Carequality | varies | Network-level, more complex |
-
-### Phase 4 — Wire into Fasten UI (~1 week)
-
-- Re-enable the "Add Source" → provider search flow in the frontend
-- Connect to the new backend OAuth endpoints instead of the old `fasten-sources` factory
-- Handle the "connect provider" success/error states
+The original plan used a stateless Cloudflare Worker storing codes in Cloudflare KV. Rejected to satisfy the **all-Go** decision: a Worker is JS/TS, a second language and toolchain outside `mj-infra-flux`. A self-hosted Go service does the same job (store-and-poll, tokens never pass through) in one language on the existing infra. The Worker remains a viable option only if we later want zero-ops hosting for the product relay.
 
 ## Security considerations
 
-- The Worker never sees access or refresh tokens — only the short-lived authorization code (60s TTL)
-- PKCE is required for all flows (prevents code interception)
-- The `/pending` endpoint is gated by `X-Fasten-Token` (shared secret, set in Worker env)
-- State parameter ties the code to the originating session (prevents CSRF)
-- Cloudflare KV entries auto-expire; no manual cleanup needed
+- The relay only ever holds the short-lived `code` (~60s TTL), never access/refresh tokens.
+- **PKCE** is required: a stolen `code` is useless without the `code_verifier`, which never leaves the instance.
+- The `/pending` endpoint is gated by a shared secret.
+- The `state` parameter ties the `code` to the originating session (CSRF) and routes it to the right instance.
+- In-memory entries auto-expire; no manual cleanup and no durable store of codes.
 
-## Relationship to current state
+## Work breakdown (EPIC #20)
 
-The `fasten-sources` stub in the fork (`./fasten-sources-stub`) satisfies all compile-time imports with stub implementations that return clear errors. The stub is the bridge until Phase 2 is complete. Phases can be implemented incrementally — Phase 1 (the Worker) can be deployed and tested with a standalone script before any Fasten backend work begins.
+- **#50 — relay**: the Go store-and-poll service + `mj-infra-flux` deploy at `relay.nerdsbythehour.com`.
+- **#51 — backend**: authorize-initiation + callback/poll endpoints, token exchange, encrypted token storage, scheduled refresh.
+- **#52 — frontend**: rename the `Lighthouse` identifiers to a neutral connect-gateway, point at the new relay, re-enable the "Add Source" connect UI.
+- **#49 — client**: the generic Go SMART-R4 client the backend drives (core merged; see the master plan).
 
-## Files that will change (in jwilleke/yourphr)
+## Files that will change (in `jwilleke/yourphr`)
 
-| File | Change |
+| File / area | Change |
 |---|---|
-| `fasten-sources-stub/clients/factory/factory.go` | Replace stub `GetSourceClient` with real implementation |
-| `fasten-sources-stub/clients/models/models.go` | Implement `SourceClient` interface methods |
-| `backend/pkg/web/handler/source.go` | OAuth initiation + code polling endpoints |
-| `backend/pkg/web/server.go` | Register new OAuth routes |
-| `workers/oauth-relay/` | New: Cloudflare Worker source |
-| `frontend/src/app/components/...` | Re-enable provider connect UI |
+| relay (new) | self-hosted Go store-and-poll service + deploy manifest in `mj-infra-flux` |
+| `fasten-sources-stub/clients/...` | generic SMART-R4 client (core merged in `clients/smart`); factory wiring |
+| `backend/pkg/web/handler/source.go` | OAuth initiation + callback/poll endpoints, token exchange + refresh |
+| `backend/pkg/web/server.go` | register the new OAuth routes |
+| `frontend/src/app/services/lighthouse.service.ts` + medical-sources components | rename to a neutral connect-gateway; point at the relay; re-enable connect UI |


### PR DESCRIPTION
Reconciles the relay deep dive with the decisions in `smart-on-fhir.md`.

- Rewrites the chosen approach as a **self-hosted Go store-and-poll relay** (all-Go, per-user/BYO), hosted via `mj-infra-flux` at `relay.nerdsbythehour.com`.
- Moves **Cloudflare Worker + KV** to a *rejected alternative* (it's JS/TS, against the all-Go decision).
- Fixes the stale `fasten.nerdsbythehour.com` reference; adds the Authentik-exclusion note; reserves `relay.yourphr.org` for the future product relay.
- Maps the work to EPIC #20 issues (#49–#52).

Lint-clean.

Refs #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)