### PR TITLE
feat(smart): wire generic SMART-R4 client into the factory (#49 part 2)

### DIFF
--- a/backend/pkg/database/gorm_repository_migrations.go
+++ b/backend/pkg/database/gorm_repository_migrations.go
@@ -240,6 +240,14 @@ func (gr *GormRepository) Migrate() error {
 				)
 			},
 		},
+		{
+			ID: "20260604000000", // add SMART config fields (api_endpoint_base_url, scopes) to source_credential (#49)
+			Migrate: func(tx *gorm.DB) error {
+				return tx.AutoMigrate(
+					&models.SourceCredential{},
+				)
+			},
+		},
 	})
 
 	// run when database is empty

--- a/backend/pkg/models/source_credential.go
+++ b/backend/pkg/models/source_credential.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -44,6 +45,12 @@ type SourceCredential struct {
 	ExpiresAt     int64  `json:"expires_at"`
 	CodeChallenge string `json:"code_challenge"`
 	CodeVerifier  string `json:"code_verifier"`
+
+	// SMART config (self-describing credential — issue #49). ApiEndpointBaseUrl is the FHIR
+	// base URL; Scopes is the space-separated SMART scope string. The generic SMART client
+	// discovers authorize/token endpoints from {ApiEndpointBaseUrl}/.well-known/smart-configuration.
+	ApiEndpointBaseUrl string `json:"api_endpoint_base_url"`
+	Scopes             string `json:"scopes"`
 
 	//dynamic client auth/credential data
 	DynamicClientJWKS []map[string]string `json:"dynamic_client_jwks" gorm:"type:text;serializer:json"`
@@ -88,6 +95,18 @@ func (s *SourceCredential) GetAccessToken() string {
 
 func (s *SourceCredential) GetExpiresAt() int64 {
 	return s.ExpiresAt
+}
+
+func (s *SourceCredential) GetApiEndpointBaseUrl() string {
+	return s.ApiEndpointBaseUrl
+}
+
+// GetScopes splits the space-separated Scopes string into individual SMART scopes.
+func (s *SourceCredential) GetScopes() []string {
+	if strings.TrimSpace(s.Scopes) == "" {
+		return nil
+	}
+	return strings.Fields(s.Scopes)
 }
 
 func (s *SourceCredential) SetTokens(accessToken string, refreshToken string, expiresAt int64) {

--- a/fasten-sources-stub/clients/factory/factory.go
+++ b/fasten-sources-stub/clients/factory/factory.go
@@ -1,7 +1,7 @@
-// Stub for github.com/fastenhealth/fasten-sources/clients/factory
-// GetSourceClient returns a minimal implementation that handles manual FHIR file import
-// (JSON Bundle and NDJSON). Live provider sync is not available without the commercial
-// Fasten Lighthouse service (see fastenhealth/fasten-onprem#629).
+// Replacement for github.com/fastenhealth/fasten-sources/clients/factory.
+// GetSourceClient returns a file-import client for manual sources and the generic SMART on
+// FHIR R4 client (clients/smart) for live EHR sources — no commercial Fasten Lighthouse
+// dependency (see fastenhealth/fasten-onprem#629 and EPIC #20).
 package factory
 
 import (
@@ -18,8 +18,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// GetSourceClient returns a source client. For manual/fasten platform types it returns
-// a working file-import client. For live EHR sync it returns an error.
+// GetSourceClient returns a source client. For manual/fasten platform types it returns a
+// file-import client; for live EHR sources it returns the generic SMART-R4 client.
 func GetSourceClient(
 	env pkg.FastenLighthouseEnvType,
 	ctx context.Context,
@@ -30,7 +30,8 @@ func GetSourceClient(
 	if platformType == pkg.PlatformTypeManual || platformType == pkg.PlatformTypeFasten || platformType == "" {
 		return &fileImportClient{ctx: ctx, logger: logger, cred: cred}, nil
 	}
-	return nil, fmt.Errorf("live provider sync not available: fasten-sources is commercial (see fastenhealth/fasten-onprem#629)")
+	// EHR / live SMART on FHIR providers: drive the generic SMART-R4 client (EPIC #20, #49).
+	return newSmartClient(ctx, logger, cred), nil
 }
 
 // fileImportClient implements SourceClient for manual FHIR file import (JSON Bundle / NDJSON).
@@ -123,7 +124,7 @@ func extractResources(data []byte) ([]json.RawMessage, error) {
 	// json.Valid returns false for multi-line NDJSON (multiple root objects).
 	if json.Valid(trimmed) {
 		var bundle struct {
-			ResourceType string          `json:"resourceType"`
+			ResourceType string            `json:"resourceType"`
 			Contained    []json.RawMessage `json:"contained"`
 			Entry        []struct {
 				FullURL  string          `json:"fullUrl"`

--- a/fasten-sources-stub/clients/factory/smart_client.go
+++ b/fasten-sources-stub/clients/factory/smart_client.go
@@ -1,0 +1,127 @@
+package factory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/fastenhealth/fasten-sources/clients/models"
+	"github.com/fastenhealth/fasten-sources/clients/smart"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+)
+
+// smartClient is the generic SMART on FHIR R4 source client (EPIC #20, issue #49). It drives
+// the reusable clients/smart core using the self-describing SourceCredential, and embeds the
+// file-import client to reuse bundle parsing / patient-id extraction for the interface methods
+// it does not override.
+type smartClient struct {
+	*fileImportClient
+	cfg smart.Config
+}
+
+func newSmartClient(ctx context.Context, logger *logrus.Entry, cred models.SourceCredential) *smartClient {
+	return &smartClient{
+		fileImportClient: &fileImportClient{ctx: ctx, logger: logger, cred: cred},
+		cfg: smart.Config{
+			FHIRBaseURL: cred.GetApiEndpointBaseUrl(),
+			ClientID:    cred.GetClientId(),
+			Scopes:      cred.GetScopes(),
+		},
+	}
+}
+
+// SyncAll performs a full sync: discover endpoints, ensure a valid access token, fetch
+// Patient/$everything (paginated), and upsert every resource. Any refreshed token is written
+// back to the SourceCredential so the caller (BackgroundJobSyncResourcesWrapper) persists it.
+func (c *smartClient) SyncAll(db models.DatabaseRepository) (models.UpsertSummary, error) {
+	summary := models.UpsertSummary{}
+	if c.cfg.FHIRBaseURL == "" {
+		return summary, fmt.Errorf("source has no FHIR base URL (api_endpoint_base_url); reconnect the source")
+	}
+	if c.cred.GetPatientId() == "" {
+		return summary, fmt.Errorf("source has no patient id; reconnect the source")
+	}
+
+	ep, err := c.cfg.Discover(c.ctx)
+	if err != nil {
+		return summary, fmt.Errorf("SMART discovery failed: %w", err)
+	}
+	if err := c.ensureValidToken(ep); err != nil {
+		return summary, err
+	}
+
+	tok := &oauth2.Token{
+		AccessToken:  c.cred.GetAccessToken(),
+		RefreshToken: c.cred.GetRefreshToken(),
+		Expiry:       time.Unix(c.cred.GetExpiresAt(), 0),
+	}
+	pages, refreshed, err := c.cfg.FetchEverything(c.ctx, ep, tok, c.cred.GetPatientId())
+	if err != nil {
+		return summary, fmt.Errorf("Patient/$everything failed: %w", err)
+	}
+	if refreshed != nil {
+		c.cred.SetTokens(refreshed.AccessToken, refreshed.RefreshToken, refreshed.Expiry.Unix())
+	}
+
+	for _, page := range pages {
+		resources, perr := extractResources(page)
+		if perr != nil {
+			if c.logger != nil {
+				c.logger.Warnf("skipping unparseable $everything page: %v", perr)
+			}
+			continue
+		}
+		for _, raw := range resources {
+			var header struct {
+				ResourceType string `json:"resourceType"`
+				ID           string `json:"id"`
+			}
+			if err := json.Unmarshal(raw, &header); err != nil || header.ResourceType == "" || header.ID == "" {
+				continue
+			}
+			rawResource := models.RawResourceFhir{
+				SourceResourceType:  header.ResourceType,
+				SourceResourceID:    header.ID,
+				ResourceRaw:         raw,
+				ReferencedResources: extractFHIRReferences(raw),
+			}
+			if _, err := db.UpsertRawResource(c.ctx, c.cred, rawResource); err != nil {
+				if c.logger != nil {
+					c.logger.Warnf("error upserting %s/%s: %v", header.ResourceType, header.ID, err)
+				}
+				continue
+			}
+			summary.TotalResources++
+			summary.UpdatedResources = append(summary.UpdatedResources, fmt.Sprintf("%s/%s", header.ResourceType, header.ID))
+		}
+	}
+	return summary, nil
+}
+
+// ensureValidToken refreshes the access token if it is missing or within the skew window of expiry.
+func (c *smartClient) ensureValidToken(ep smart.Endpoints) error {
+	const skewSeconds = 60
+	if c.cred.GetAccessToken() != "" && c.cred.GetExpiresAt() > time.Now().Add(skewSeconds*time.Second).Unix() {
+		return nil // still valid
+	}
+
+	if c.cred.IsDynamicClient() {
+		// Dynamic-client (e.g. Epic JWT) refresh lives on the concrete credential.
+		if dc, ok := c.cred.(interface{ RefreshDynamicClientAccessToken() error }); ok {
+			return dc.RefreshDynamicClientAccessToken()
+		}
+		return fmt.Errorf("source uses dynamic client registration but token refresh is unavailable")
+	}
+
+	if c.cred.GetRefreshToken() == "" {
+		return fmt.Errorf("access token expired and no refresh token is available; reconnect the source")
+	}
+	tok, err := c.cfg.Refresh(c.ctx, ep, c.cred.GetRefreshToken())
+	if err != nil {
+		return fmt.Errorf("refreshing access token failed: %w", err)
+	}
+	c.cred.SetTokens(tok.AccessToken, tok.RefreshToken, tok.Expiry.Unix())
+	return nil
+}

--- a/fasten-sources-stub/clients/models/models.go
+++ b/fasten-sources-stub/clients/models/models.go
@@ -20,13 +20,13 @@ type UpsertSummary struct {
 // RawResourceFhir is the struct passed to UpsertRawResource.
 // Fields are flat (not embedded) to match composite literal usage in handlers.
 type RawResourceFhir struct {
-	SourceResourceID   string
-	SourceResourceType string
-	ResourceRaw        json.RawMessage
-	SourceUri          string
+	SourceResourceID    string
+	SourceResourceType  string
+	ResourceRaw         json.RawMessage
+	SourceUri           string
 	ReferencedResources []string
-	SortTitle          *string
-	SortDate           *time.Time
+	SortTitle           *string
+	SortDate            *time.Time
 }
 
 // SourceCredential is the interface implemented by models.SourceCredential.
@@ -43,6 +43,12 @@ type SourceCredential interface {
 	GetExpiresAt() int64
 	SetTokens(accessToken string, refreshToken string, expiresAt int64)
 	IsDynamicClient() bool
+
+	// SMART config (self-describing credential — issue #49): the FHIR base URL the client
+	// talks to, and the requested scopes. Authorize/token endpoints are discovered from
+	// {ApiEndpointBaseUrl}/.well-known/smart-configuration.
+	GetApiEndpointBaseUrl() string
+	GetScopes() []string
 }
 
 // DatabaseRepository is the subset of the DB interface needed by source clients.


### PR DESCRIPTION
**Part 2 of #49** — implements decision **A (self-describing `SourceCredential`)** and wires the [#49 part 1](https://github.com/jwilleke/yourphr/pull/57) client core into the `SourceClient` factory so live EHR sources actually sync.

## Changes
- **Model** (`SourceCredential`): add `ApiEndpointBaseUrl` + `Scopes` fields and `GetApiEndpointBaseUrl()` / `GetScopes()` getters; extend the stub `SourceCredential` interface with the same two getters.
- **Migration** `20260604000000`: `AutoMigrate(&models.SourceCredential{})` adds the two columns (non-destructive; mirrors the existing `AccessToken` migration).
- **Factory**: `GetSourceClient` returns a `smartClient` for live EHR sources (was an error). `smartClient` embeds the file-import client (reusing bundle parsing / patient-id extraction) and overrides `SyncAll`:
  > discover (`.well-known`) → ensure valid token (dynamic-client JWT *or* standard `refresh_token`) → `Patient/$everything` (paginated) → `extractResources` + `UpsertRawResource` per entry.
  
  Refreshed tokens are written back via `SetTokens`, so `BackgroundJobSyncResourcesWrapper` persists them in its finalizer.

## Where config comes from
`ApiEndpointBaseUrl` / `ClientId` / `Scopes` live on the credential (BYO model). Populating them at connect time is #51/#52.

## Verified
No new dependency or root `go.mod`/`go.sum` change (`x/oauth2 v0.11.0` already in the graph). Stub vet/test, **full backend vet (incl. tests)**, backend build, and model tests all pass; `gofmt` clean. CI's Test Backend exercises the new migration.

Refs #49, #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)