### PR TITLE
feat(smart): backend SMART connect/token-exchange endpoint (#51 part 1)

### DIFF
--- a/backend/pkg/web/handler/source.go
+++ b/backend/pkg/web/handler/source.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/fastenhealth/fasten-onprem/backend/pkg"
 	"github.com/fastenhealth/fasten-onprem/backend/pkg/database"
@@ -13,12 +14,95 @@ import (
 	"github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	"github.com/fastenhealth/fasten-sources/clients/factory"
 	sourceModels "github.com/fastenhealth/fasten-sources/clients/models"
+	"github.com/fastenhealth/fasten-sources/clients/smart"
 	sourceDefinitions "github.com/fastenhealth/fasten-sources/definitions"
 	sourcePkg "github.com/fastenhealth/fasten-sources/pkg"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 )
+
+// SmartConnectRequest is the payload to complete a SMART on FHIR connection: the self-describing
+// provider config plus the authorization code (and its PKCE verifier) obtained via the relay.
+type SmartConnectRequest struct {
+	ApiEndpointBaseUrl string `json:"api_endpoint_base_url"`
+	ClientId           string `json:"client_id"`
+	Scopes             string `json:"scopes"`
+	RedirectUri        string `json:"redirect_uri"`
+	Code               string `json:"code"`
+	CodeVerifier       string `json:"code_verifier"`
+	Display            string `json:"display"`
+}
+
+// ConnectSource completes a SMART on FHIR connection entirely in the backend (EPIC #20, #51):
+// it discovers the provider endpoints, exchanges the authorization code (with PKCE verifier) for
+// tokens, stores a self-describing SourceCredential, and kicks off the initial sync. The browser
+// never handles tokens. The authorization code is obtained via the relay (#50); how it arrives
+// (relay poll vs direct) is the caller's concern.
+func ConnectSource(c *gin.Context) {
+	logger := c.MustGet(pkg.ContextKeyTypeLogger).(*logrus.Entry)
+	databaseRepo := c.MustGet(pkg.ContextKeyTypeDatabase).(database.DatabaseRepository)
+
+	var req SmartConnectRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": fmt.Sprintf("invalid request: %s", err)})
+		return
+	}
+	if req.ApiEndpointBaseUrl == "" || req.ClientId == "" || req.Code == "" || req.CodeVerifier == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "api_endpoint_base_url, client_id, code, and code_verifier are required"})
+		return
+	}
+
+	cfg := smart.Config{
+		FHIRBaseURL: req.ApiEndpointBaseUrl,
+		ClientID:    req.ClientId,
+		Scopes:      strings.Fields(req.Scopes),
+		RedirectURI: req.RedirectUri,
+	}
+	ep, err := cfg.Discover(c)
+	if err != nil {
+		logger.Errorln(err)
+		c.JSON(http.StatusBadGateway, gin.H{"success": false, "error": fmt.Sprintf("SMART discovery failed: %s", err)})
+		return
+	}
+	tok, err := cfg.ExchangeCode(c, ep, req.Code, req.CodeVerifier)
+	if err != nil {
+		logger.Errorln(err)
+		c.JSON(http.StatusBadGateway, gin.H{"success": false, "error": fmt.Sprintf("token exchange failed: %s", err)})
+		return
+	}
+	patientId, _ := tok.Extra("patient").(string)
+	if patientId == "" {
+		c.JSON(http.StatusBadGateway, gin.H{"success": false, "error": "token response did not include a patient id (check the launch/patient scope)"})
+		return
+	}
+
+	sourceCred := models.SourceCredential{
+		PlatformType:       sourcePkg.PlatformTypeEhr,
+		Display:            req.Display,
+		ApiEndpointBaseUrl: req.ApiEndpointBaseUrl,
+		ClientId:           req.ClientId,
+		Scopes:             req.Scopes,
+		Patient:            patientId,
+		AccessToken:        tok.AccessToken,
+		RefreshToken:       tok.RefreshToken,
+		ExpiresAt:          tok.Expiry.Unix(),
+	}
+	if err := databaseRepo.CreateSource(c, &sourceCred); err != nil {
+		err = fmt.Errorf("an error occurred while storing source credential: %w", err)
+		logger.Errorln(err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+
+	summary, err := BackgroundJobSyncResources(GetBackgroundContext(c), logger, databaseRepo, &sourceCred)
+	if err != nil {
+		logger.Errorln(err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "initial record sync failed. See background jobs page for more details"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true, "source": sourceCred, "data": summary})
+}
 
 func CreateReconnectSource(c *gin.Context) {
 	logger := c.MustGet(pkg.ContextKeyTypeLogger).(*logrus.Entry)

--- a/backend/pkg/web/server.go
+++ b/backend/pkg/web/server.go
@@ -26,10 +26,10 @@ import (
 )
 
 type AppEngine struct {
-	Config     config.Interface
-	Logger     *logrus.Entry
-	EventBus   event_bus.Interface
-	deviceRepo database.DatabaseRepository
+	Config      config.Interface
+	Logger      *logrus.Entry
+	EventBus    event_bus.Interface
+	deviceRepo  database.DatabaseRepository
 	StandbyMode bool
 
 	RelatedVersions map[string]string //related versions metadata provided & embedded by the build process
@@ -99,8 +99,8 @@ func (ae *AppEngine) Setup() (*gin.RouterGroup, *gin.Engine) {
 					c.JSON(http.StatusOK, gin.H{
 						"success": true,
 						"data": gin.H{
-							"first_run_wizard":   firstRunWizard,
-							"standby_mode":       true,
+							"first_run_wizard": firstRunWizard,
+							"standby_mode":     true,
 						},
 					})
 					return
@@ -125,8 +125,8 @@ func (ae *AppEngine) Setup() (*gin.RouterGroup, *gin.Engine) {
 				c.JSON(http.StatusOK, gin.H{
 					"success": true,
 					"data": gin.H{
-						"first_run_wizard":   firstRunWizard,
-						"standby_mode":       false,
+						"first_run_wizard": firstRunWizard,
+						"standby_mode":     false,
 					},
 				})
 			})
@@ -167,6 +167,7 @@ func (ae *AppEngine) Setup() (*gin.RouterGroup, *gin.Engine) {
 					secure.GET("/summary/ips", handler.GetIPSSummary)
 
 					secure.POST("/source", handler.CreateReconnectSource)
+					secure.POST("/source/connect", handler.ConnectSource)
 					secure.POST("/source/manual", handler.CreateManualSource)
 					secure.GET("/source", handler.ListSource)
 					secure.GET("/source/:sourceId", handler.GetSource)

--- a/fasten-sources-stub/clients/smart/client_test.go
+++ b/fasten-sources-stub/clients/smart/client_test.go
@@ -136,3 +136,34 @@ func TestFetchEverythingPagination(t *testing.T) {
 		t.Errorf("did not expect a token refresh for a non-expired token")
 	}
 }
+
+func TestExchangeCode(t *testing.T) {
+	var gotCode, gotVerifier, gotGrant string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotCode = r.Form.Get("code")
+		gotVerifier = r.Form.Get("code_verifier")
+		gotGrant = r.Form.Get("grant_type")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"access_token":"AT","refresh_token":"RT","token_type":"Bearer","expires_in":3600,"patient":"pat-123"}`)
+	}))
+	defer srv.Close()
+
+	cfg := Config{FHIRBaseURL: "https://fhir.example/r4", ClientID: "cid", RedirectURI: "https://relay/callback", HTTPClient: srv.Client()}
+	ep := Endpoints{Token: srv.URL}
+
+	tok, err := cfg.ExchangeCode(context.Background(), ep, "the-code", "the-verifier")
+	if err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if tok.AccessToken != "AT" || tok.RefreshToken != "RT" {
+		t.Errorf("unexpected tokens: access=%q refresh=%q", tok.AccessToken, tok.RefreshToken)
+	}
+	if pid, _ := tok.Extra("patient").(string); pid != "pat-123" {
+		t.Errorf("patient extra = %q, want pat-123", pid)
+	}
+	// PKCE verifier and code must be sent in the token request body.
+	if gotCode != "the-code" || gotVerifier != "the-verifier" || gotGrant != "authorization_code" {
+		t.Errorf("token request form: code=%q verifier=%q grant=%q", gotCode, gotVerifier, gotGrant)
+	}
+}


### PR DESCRIPTION
**Part 1 of #51** — moves the SMART **token exchange into the Go backend** (it was done in the browser). The browser never handles tokens.

## What
- New **`POST /api/secure/source/connect`** (`handler.ConnectSource`): given the self-describing provider config + authorization `code` + PKCE `code_verifier`, it:
  1. discovers the provider endpoints (`.well-known`),
  2. exchanges the code for tokens **in Go** (`smart.ExchangeCode`),
  3. stores a self-describing `SourceCredential` (`platform=ehr`, `api_endpoint_base_url`/`client_id`/`scopes` + tokens + `patient` from the token response),
  4. kicks off the initial sync via `BackgroundJobSyncResources` — which drives the generic SMART client (#49) and persists refreshed tokens.
  
  Bypasses the dead `GetSourceDefinition` catalog lookup (the existing `CreateReconnectSource` errors there in the stub).
- **Test**: `smart.ExchangeCode` unit test (httptest token endpoint) asserting the PKCE `code_verifier` + `code` + `grant_type` are sent and the access/refresh tokens and `patient` extra are parsed.

## Verified
`smart` tests pass; backend vet (incl. tests) + binary build clean.

## Follow-ups (tracked on #51)
- Relay-poll delivery of the code (#50) — how `code` arrives is pluggable; the exchange logic is shared.
- Optional backend authorize-initiation endpoint (frontend currently builds the URL).
- Standalone scheduled-refresh worker — sync-time refresh already covers the core via #49.

Refs #51, #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)