### PR TITLE
feat(relay): self-hosted Go SMART OAuth store-and-poll relay (#50)

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -1,0 +1,14 @@
+# YourPHR SMART on FHIR OAuth store-and-poll relay (EPIC #20, issue #50).
+# A tiny static Go service (pure stdlib); see backend/cmd/relay and
+# docs/planning/smart-on-fhir/oauth-gateway.md.
+
+FROM golang:1.24 as build
+WORKDIR /src
+COPY . .
+RUN CGO_ENABLED=0 go build -buildvcs=false -o /relay ./backend/cmd/relay
+
+FROM gcr.io/distroless/static-debian12
+COPY --from=build /relay /relay
+EXPOSE 8080
+USER nonroot:nonroot
+ENTRYPOINT ["/relay"]

--- a/backend/cmd/relay/README.md
+++ b/backend/cmd/relay/README.md
@@ -1,0 +1,44 @@
+# yourphr-relay
+
+The YourPHR SMART on FHIR OAuth **store-and-poll relay** — EPIC #20, issue #50.
+
+A small, stateless public bouncer for the SMART authorization `code`. The provider redirects the user's browser to `/callback?code&state`; the relay stores `{state -> code}` in memory with a short TTL; the (possibly non-public) YourPHR instance polls `/pending?state=` (gated by a shared secret) to retrieve the `code` and completes the token exchange itself. The relay **never sees access/refresh tokens** and holds **no provider app registration** — it is provider-agnostic and client-agnostic (per-user / BYO model).
+
+See [`docs/planning/smart-on-fhir/oauth-gateway.md`](../../../docs/planning/smart-on-fhir/oauth-gateway.md).
+
+## Endpoints
+
+| Endpoint | Auth | Description |
+|---|---|---|
+| `GET /callback?code=C&state=S` | open (the provider must reach it) | stores `{state: code}` with a ~60s TTL; returns an HTML "you may close this window" page |
+| `GET /pending?state=S` | `X-Yourphr-Token: <secret>` | returns `{"code": "..."}` and deletes the entry, or `404` if absent/expired |
+| `GET /healthz` | open | liveness probe |
+
+## Configuration
+
+| Env var | Required | Default | Meaning |
+|---|---|---|---|
+| `YOURPHR_RELAY_SECRET` | yes | — | shared secret required on `/pending` |
+| `PORT` | no | `8080` | listen port |
+
+## Run locally
+
+```sh
+YOURPHR_RELAY_SECRET=dev-secret PORT=8088 go run ./backend/cmd/relay
+```
+
+## Build the image
+
+```sh
+docker build -f Dockerfile.relay -t yourphr-relay .
+```
+
+## Deploy
+
+For dev/demo it deploys to the existing k8s cluster via `mj-infra-flux` behind Cloudflare ingress at `relay.nerdsbythehour.com`. It must be **publicly reachable and excluded from Authentik forward-auth** (`/callback` is unauthenticated; `/pending` is shared-secret gated). An example manifest is in [`deploy/yourphr-relay.example.yaml`](./deploy/yourphr-relay.example.yaml) — copy it into `mj-infra-flux` and set the secret.
+
+## Security
+
+- The relay only ever holds the short-lived `code` (~60s TTL), never tokens.
+- `/pending` is gated by a constant-time shared-secret comparison.
+- Codes are single-use (deleted on read) and auto-expire; a background janitor evicts stragglers.

--- a/backend/cmd/relay/deploy/yourphr-relay.example.yaml
+++ b/backend/cmd/relay/deploy/yourphr-relay.example.yaml
@@ -1,0 +1,90 @@
+# Example manifests for the YourPHR SMART OAuth relay (EPIC #20, issue #50).
+# Copy into mj-infra-flux (apps/.../yourphr-relay/) and adjust. The relay must be PUBLIC and
+# EXCLUDED from Authentik forward-auth: /callback is unauthenticated; /pending is shared-secret
+# gated. Set the secret out-of-band (do not commit a real secret).
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: yourphr-relay
+  namespace: fasten
+type: Opaque
+stringData:
+  # Replace via SOPS / sealed-secrets — never commit a real value.
+  YOURPHR_RELAY_SECRET: "REPLACE_ME"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: yourphr-relay
+  namespace: fasten
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: yourphr-relay
+  template:
+    metadata:
+      labels:
+        app: yourphr-relay
+    spec:
+      containers:
+        - name: relay
+          image: ghcr.io/jwilleke/yourphr-relay:main
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - secretRef:
+                name: yourphr-relay
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 64Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: yourphr-relay
+  namespace: fasten
+spec:
+  selector:
+    app: yourphr-relay
+  ports:
+    - port: 80
+      targetPort: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: yourphr-relay
+  namespace: fasten
+  annotations:
+    # IMPORTANT: do NOT route this Ingress through Authentik forward-auth.
+    # The provider redirect to /callback must reach the relay unauthenticated.
+    cert-manager.io/cluster-issuer: letsencrypt
+spec:
+  rules:
+    - host: relay.nerdsbythehour.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: yourphr-relay
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - relay.nerdsbythehour.com
+      secretName: yourphr-relay-tls

--- a/backend/cmd/relay/main.go
+++ b/backend/cmd/relay/main.go
@@ -1,0 +1,167 @@
+// Command relay is the YourPHR SMART on FHIR OAuth store-and-poll relay (EPIC #20, issue #50).
+//
+// It is a small, stateless public bouncer for the SMART authorization code: the provider
+// redirects the user's browser to /callback with ?code&state; the relay stores {state -> code}
+// in memory with a short TTL; the (possibly non-public) YourPHR instance polls
+// /pending?state= (gated by a shared secret) to retrieve the code and completes the token
+// exchange itself. The relay never sees access/refresh tokens and holds no provider app
+// registration — it is provider-agnostic and client-agnostic (per-user/BYO model).
+//
+// See docs/planning/smart-on-fhir/oauth-gateway.md.
+package main
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"html"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+const defaultTTL = 60 * time.Second
+
+type codeEntry struct {
+	code   string
+	expiry time.Time
+}
+
+// store is an in-memory, TTL'd map of OAuth state -> authorization code. Safe for concurrent use.
+type store struct {
+	mu      sync.Mutex
+	entries map[string]codeEntry
+	ttl     time.Duration
+	now     func() time.Time // injectable for tests
+}
+
+func newStore(ttl time.Duration) *store {
+	return &store{entries: map[string]codeEntry{}, ttl: ttl, now: time.Now}
+}
+
+func (s *store) put(state, code string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries[state] = codeEntry{code: code, expiry: s.now().Add(s.ttl)}
+}
+
+// take returns the code for state and removes it. ok is false if missing or expired.
+func (s *store) take(state string) (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.entries[state]
+	if !ok {
+		return "", false
+	}
+	delete(s.entries, state)
+	if s.now().After(e.expiry) {
+		return "", false
+	}
+	return e.code, true
+}
+
+func (s *store) evictExpired() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+	for k, e := range s.entries {
+		if now.After(e.expiry) {
+			delete(s.entries, k)
+		}
+	}
+}
+
+// newServer builds the relay HTTP handler. secret gates /pending; ttl is the code lifetime.
+// The returned *store is exposed for tests (TTL injection) and the background janitor.
+func newServer(secret string, ttl time.Duration) (http.Handler, *store) {
+	st := newStore(ttl)
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	// /callback: the provider redirects the user's browser here with ?code&state. Open by
+	// design (the provider must reach it); it only stores a short-lived code keyed by state.
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if e := q.Get("error"); e != "" {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("<!doctype html><h1>Authorization failed</h1><p>" +
+				html.EscapeString(e+" "+q.Get("error_description")) + "</p>"))
+			return
+		}
+		code, state := q.Get("code"), q.Get("state")
+		if code == "" || state == "" {
+			http.Error(w, "missing code or state", http.StatusBadRequest)
+			return
+		}
+		st.put(state, code)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte("<!doctype html><h1>Connected</h1>" +
+			"<p>You may close this window and return to YourPHR.</p>"))
+	})
+
+	// /pending: the YourPHR instance polls here (shared-secret gated) to retrieve the code.
+	mux.HandleFunc("/pending", func(w http.ResponseWriter, r *http.Request) {
+		if !secretEqual(r.Header.Get("X-Yourphr-Token"), secret) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		state := r.URL.Query().Get("state")
+		if state == "" {
+			http.Error(w, "missing state", http.StatusBadRequest)
+			return
+		}
+		code, ok := st.take(state)
+		if !ok {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"code": code})
+	})
+
+	return mux, st
+}
+
+// secretEqual is a constant-time comparison that also rejects an empty configured secret.
+func secretEqual(got, want string) bool {
+	if want == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
+}
+
+func main() {
+	secret := os.Getenv("YOURPHR_RELAY_SECRET")
+	if secret == "" {
+		log.Fatal("YOURPHR_RELAY_SECRET is required")
+	}
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	handler, st := newServer(secret, defaultTTL)
+
+	// Background janitor: evict expired codes so the map cannot grow unbounded.
+	go func() {
+		t := time.NewTicker(defaultTTL)
+		defer t.Stop()
+		for range t.C {
+			st.evictExpired()
+		}
+	}()
+
+	srv := &http.Server{
+		Addr:              ":" + port,
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	log.Printf("yourphr relay listening on :%s (code TTL %s)", port, defaultTTL)
+	log.Fatal(srv.ListenAndServe())
+}

--- a/backend/cmd/relay/main_test.go
+++ b/backend/cmd/relay/main_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+const testSecret = "test-secret"
+
+func do(t *testing.T, h http.Handler, method, target string, secret string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, target, nil)
+	if secret != "" {
+		req.Header.Set("X-Yourphr-Token", secret)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestCallbackThenPending(t *testing.T) {
+	h, _ := newServer(testSecret, defaultTTL)
+
+	if rec := do(t, h, http.MethodGet, "/callback?code=ABC&state=S1", ""); rec.Code != http.StatusOK {
+		t.Fatalf("callback: got %d", rec.Code)
+	}
+
+	rec := do(t, h, http.MethodGet, "/pending?state=S1", testSecret)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("pending: got %d", rec.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["code"] != "ABC" {
+		t.Errorf("code = %q, want ABC", body["code"])
+	}
+
+	// Code is single-use: a second poll must 404.
+	if rec2 := do(t, h, http.MethodGet, "/pending?state=S1", testSecret); rec2.Code != http.StatusNotFound {
+		t.Errorf("second pending: got %d, want 404", rec2.Code)
+	}
+}
+
+func TestPendingRequiresSecret(t *testing.T) {
+	h, _ := newServer(testSecret, defaultTTL)
+	do(t, h, http.MethodGet, "/callback?code=ABC&state=S1", "")
+
+	if rec := do(t, h, http.MethodGet, "/pending?state=S1", ""); rec.Code != http.StatusUnauthorized {
+		t.Errorf("no secret: got %d, want 401", rec.Code)
+	}
+	if rec := do(t, h, http.MethodGet, "/pending?state=S1", "wrong"); rec.Code != http.StatusUnauthorized {
+		t.Errorf("wrong secret: got %d, want 401", rec.Code)
+	}
+}
+
+func TestPendingUnknownState(t *testing.T) {
+	h, _ := newServer(testSecret, defaultTTL)
+	if rec := do(t, h, http.MethodGet, "/pending?state=nope", testSecret); rec.Code != http.StatusNotFound {
+		t.Errorf("unknown state: got %d, want 404", rec.Code)
+	}
+}
+
+func TestCallbackValidation(t *testing.T) {
+	h, _ := newServer(testSecret, defaultTTL)
+	if rec := do(t, h, http.MethodGet, "/callback?state=S1", ""); rec.Code != http.StatusBadRequest {
+		t.Errorf("missing code: got %d, want 400", rec.Code)
+	}
+	if rec := do(t, h, http.MethodGet, "/callback?error=access_denied&error_description=nope", ""); rec.Code != http.StatusBadRequest {
+		t.Errorf("provider error: got %d, want 400", rec.Code)
+	}
+}
+
+func TestTTLExpiry(t *testing.T) {
+	h, st := newServer(testSecret, defaultTTL)
+	base := time.Now()
+	st.now = func() time.Time { return base }
+
+	do(t, h, http.MethodGet, "/callback?code=ABC&state=S1", "")
+
+	// Advance past the TTL; the code must be treated as expired.
+	st.now = func() time.Time { return base.Add(defaultTTL + time.Second) }
+	if rec := do(t, h, http.MethodGet, "/pending?state=S1", testSecret); rec.Code != http.StatusNotFound {
+		t.Errorf("expired code: got %d, want 404", rec.Code)
+	}
+}
+
+func TestHealthz(t *testing.T) {
+	h, _ := newServer(testSecret, defaultTTL)
+	if rec := do(t, h, http.MethodGet, "/healthz", ""); rec.Code != http.StatusOK {
+		t.Errorf("healthz: got %d", rec.Code)
+	}
+}
+
+func TestSecretEqual(t *testing.T) {
+	if secretEqual("x", "") {
+		t.Error("empty configured secret must never match")
+	}
+	if !secretEqual("abc", "abc") {
+		t.Error("equal secrets should match")
+	}
+	if secretEqual("abc", "abd") {
+		t.Error("different secrets should not match")
+	}
+}


### PR DESCRIPTION
**#50** — the self-hosted **Go store-and-poll relay**: the public bouncer that lets a non-public YourPHR instance complete SMART OAuth (all-Go, no Cloudflare Worker, no Fasten Lighthouse).

## How it works
Provider redirects the browser to `/callback?code&state` → relay stores `{state → code}` in memory (~60s TTL) → the YourPHR instance polls `/pending?state=` (shared-secret gated) to retrieve the code and does the token exchange itself (via #51's `/source/connect`). **The relay never sees tokens** and holds **no provider app registration** — provider-agnostic, per-user/BYO.

## What's here
- **`backend/cmd/relay`** — pure-stdlib Go service in the **root module** (so CI's `go test ./...` covers it). Endpoints: `/callback`, `/pending` (`X-Yourphr-Token`), `/healthz`. Constant-time secret check, single-use codes, TTL eviction janitor.
- **Tests** — callback→pending happy path, single-use 404, secret gating (none/wrong), unknown state, callback validation (missing code / provider error), TTL expiry (injected clock), healthz, secret compare.
- **`Dockerfile.relay`** — static build → distroless `static-debian12`.
- **README + `deploy/yourphr-relay.example.yaml`** — `mj-infra-flux` manifests for `relay.nerdsbythehour.com` (public, **excluded from Authentik**; secret via SOPS/sealed-secrets).

## Verified
`go vet`, `go test`, build, `gofmt` clean. **No new dependencies** (stdlib only).

Refs #50, #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)