### PR TITLE
feat(frontend): connectSource API client (#52 part 1)

### DIFF
--- a/frontend/src/app/models/fasten/smart-connect-request.ts
+++ b/frontend/src/app/models/fasten/smart-connect-request.ts
@@ -1,0 +1,12 @@
+// Payload for POST /secure/source/connect — completes a SMART on FHIR connection in the
+// backend, which performs the token exchange (the browser never handles tokens).
+// EPIC #20, issue #52. Fields match the backend handler.SmartConnectRequest.
+export interface SmartConnectRequest {
+  api_endpoint_base_url: string;
+  client_id: string;
+  scopes: string;
+  redirect_uri?: string;
+  code: string;
+  code_verifier: string;
+  display?: string;
+}

--- a/frontend/src/app/services/fasten-api.service.ts
+++ b/frontend/src/app/services/fasten-api.service.ts
@@ -25,6 +25,7 @@ import {ResourceGraphResponse} from '../models/fasten/resource-graph-response';
 import { fetchEventSource } from '@microsoft/fetch-event-source';
 import {BackgroundJob, BackgroundJobSyncData} from '../models/fasten/background-job';
 import {SupportRequest} from '../models/fasten/support-request';
+import {SmartConnectRequest} from '../models/fasten/smart-connect-request';
 import {
   List
 } from 'fhir/r4';
@@ -135,6 +136,19 @@ export class FastenApiService {
 
   createSource(source: Source): Observable<any> {
     return this._httpClient.post<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/source`, source)
+      .pipe(
+        map((response: ResponseWrapper) => {
+          // @ts-ignore
+          return {summary: response.data, source: response.source}
+        })
+      );
+  }
+
+  // connectSource completes a SMART on FHIR connection: the backend exchanges the authorization
+  // code (with PKCE verifier) for tokens, stores the source, and starts the initial sync. The
+  // browser never handles tokens. See backend handler.ConnectSource (#51) and the relay (#50).
+  connectSource(req: SmartConnectRequest): Observable<any> {
+    return this._httpClient.post<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/source/connect`, req)
       .pipe(
         map((response: ResponseWrapper) => {
           // @ts-ignore


### PR DESCRIPTION
**Part 1 of #52** — the frontend↔backend plumbing for the new backend-exchange SMART flow.

- `FastenApiService.connectSource(req)` → `POST /secure/source/connect` (the #51 backend handler), with a typed `SmartConnectRequest` model matching the backend payload.
- The backend performs the token exchange; the browser never handles tokens.

## Verified
`ng build -c sandbox` + `fasten-api.service` spec pass.

## Remaining #52 (best done once the relay is deployed (#50) + a provider is registered (#53), so the flow is end-to-end testable)
- BYO "add SMART source" UI (user enters FHIR base URL + `client_id` + scopes)
- Rewire the connect flow to **our** relay (every env currently points at the commercial `lighthouse.fastenhealth.com`) and call `connectSource()`
- Rename the 21 internal `Lighthouse` identifiers to a neutral connect-gateway

Refs #52, #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)