### PR TITLE
docs: update documents to YourPHR branding (#16)

### DIFF
--- a/.github/workflows/docker-jwilleke.yaml
+++ b/.github/workflows/docker-jwilleke.yaml
@@ -49,7 +49,7 @@ jobs:
             type=raw,value=main-${{ github.run_number }},enable=${{ github.ref_name == 'main' }}
           labels: |
             org.opencontainers.image.title=YourPHR
-            org.opencontainers.image.description=YourPHR — self-hosted Personal Health Record (community continuation of Fasten OnPrem)
+            org.opencontainers.image.description=YourPHR — your medical records, immediately and in your hands, for free. A self-hosted Personal Health Record (community continuation of Fasten OnPrem).
             org.opencontainers.image.source=https://github.com/jwilleke/yourphr
             org.opencontainers.image.revision=${{ github.sha }}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 # Tech Stack
 
-Fasten is made up of a handful of different components. Here's a summary of the technologies & languages used in Fasten:
+YourPHR is made up of a handful of different components. Here's a summary of the technologies & languages used in YourPHR:
 
 ## Frontend
 
@@ -58,7 +58,7 @@ go install github.com/gzuidhof/tygo@latest
 
 # Running Tests
 
-Before making changes to Fasten, you'll want to run the test suites to ensure that your environment is setup correctly:
+Before making changes to YourPHR, you'll want to run the test suites to ensure that your environment is setup correctly:
 
 ```bash
 make test
@@ -74,7 +74,7 @@ make test-backend
 
 # Start Development Environment
 
-To run Fasten from source, you'll need to create 2 separate processes:
+To run YourPHR from source, you'll need to create 2 separate processes:
 
 - Angular Frontend
 - Go Backend
@@ -112,23 +112,23 @@ make serve-backend
 
 ```
 
-_Note_: Fasten can run in 2 modes: sandbox or production (prod). In sandbox mode, it can only communicate with test servers (full of synthetic health data).
+_Note_: YourPHR can run in 2 modes: sandbox or production (prod). In sandbox mode, it can only communicate with test servers (full of synthetic health data).
 By default, the dev environment will run in sandbox mode.
 
-Now you can open a browser to `http://localhost:4200` to see the Fasten UI.
+Now you can open a browser to `http://localhost:4200` to see the YourPHR UI.
 
 _Note_: By default in `dev` mode, you view the frontend server and that will proxy API requests to the backend. It is also possible to build the frontend and serve it from the backend server, but this is much slower to make changes to the frontend.
 
 ## Credentials
 
-Fasten stores all user data locally, including your account information. That means on first start you'll need to register a new account.
+YourPHR stores all user data locally, including your account information. That means on first start you'll need to register a new account.
 Once you've done that, you'll want to go to the Sources tab and connect a healthcare provider.
 
 See [Connecting a new Source](https://docs.fastenhealth.com/getting-started/sandbox.html#connecting-a-new-source) for credentials to use.
 
 # Source Code Folder Structure
 
-The Fasten source code is organized into a handful of important folders, which we'll describe below:
+The YourPHR source code is organized into a handful of important folders, which we'll describe below:
 
 ## Frontend
 

--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ By default, YourPHR runs with HTTPS enabled to ensure your data is secure. It us
 
 To establish a secure connection, your browser needs to trust the server's TLS certificate. Here’s how the process works in YourPHR:
 
-1. **Root Certificate Authority (CA):** When the application first starts, it generates its own self-contained Certificate Authority, called `"Fasten Health CA"`. Think of this as the highest level of trust. The public part of this CA is the `rootCA.pem` file.
-2. **Server Certificate:** The application then uses the `"Fasten Health CA"` to issue and sign a specific certificate for the web server (e.g., for `localhost`).
-3. **Browser Verification:** When you connect to the server, it presents the server certificate to your browser. Your browser checks who signed it and sees it was `"Fasten Health CA"`. The browser then asks, "Do I trust the 'Fasten Health CA'?"
+1. **Root Certificate Authority (CA):** When the application first starts, it generates its own self-contained Certificate Authority, called `"YourPHR CA"`. Think of this as the highest level of trust. The public part of this CA is the `rootCA.pem` file.
+2. **Server Certificate:** The application then uses the `"YourPHR CA"` to issue and sign a specific certificate for the web server (e.g., for `localhost`).
+3. **Browser Verification:** When you connect to the server, it presents the server certificate to your browser. Your browser checks who signed it and sees it was `"YourPHR CA"`. The browser then asks, "Do I trust the 'YourPHR CA'?"
 
 Initially, the answer is no, which is why you see a security warning. By following the steps below to import the `rootCA.pem` file, you are telling your browser or operating system to trust our self-generated CA. Once the CA is trusted, any certificates it signs—including the server certificate—will also be trusted, and the connection will be secure without any warnings.
 
@@ -152,7 +152,7 @@ You will need to import this certificate into your operating system's or browser
 1. Open the **Keychain Access** application.
 2. Select the **System** keychain.
 3. Go to **File > Import Items** and select the `certs/rootCA.pem` file.
-4. Find the "Fasten Health CA" certificate in the list, double-click it, and under the **Trust** section, set "When using this certificate" to **Always Trust**.
+4. Find the "YourPHR CA" certificate in the list, double-click it, and under the **Trust** section, set "When using this certificate" to **Always Trust**.
 
 ##### Windows
 
@@ -166,7 +166,7 @@ You will need to import this certificate into your operating system's or browser
 1. Copy the certificate to the trusted certificates directory:
 
     ```bash
-    sudo cp certs/rootCA.pem /usr/local/share/ca-certificates/fasten-health-ca.crt
+    sudo cp certs/rootCA.pem /usr/local/share/ca-certificates/yourphr-ca.crt
     ```
 
 2. Update the system's certificate store:

--- a/backend/pkg/tls/tls.go
+++ b/backend/pkg/tls/tls.go
@@ -96,8 +96,8 @@ func generateCA(caCertPath, caKeyPath string) error {
 	ca := &x509.Certificate{
 		SerialNumber: big.NewInt(2023),
 		Subject: pkix.Name{
-			Organization: []string{"Fasten Health"},
-			CommonName:   "Fasten Health CA",
+			Organization: []string{"YourPHR"},
+			CommonName:   "YourPHR CA",
 		},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().AddDate(10, 0, 0), // 10 years
@@ -174,7 +174,7 @@ func generateServerCert(caCertPath, caKeyPath, serverCertPath, serverKeyPath str
 	serverCert := &x509.Certificate{
 		SerialNumber: big.NewInt(2024),
 		Subject: pkix.Name{
-			Organization: []string{"Fasten Health"},
+			Organization: []string{"YourPHR"},
 			CommonName:   "localhost", // Use localhost for local development
 		},
 		NotBefore:   time.Now(),

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -54,7 +54,7 @@ Upstream PR [#594](https://github.com/fastenhealth/fasten-onprem/pull/594) (open
 | Item | Upstream ref | Notes |
 |---|---|---|
 | **OIDC / SSO login** | [PR #613](https://github.com/fastenhealth/fasten-onprem/pull/613) | Native OIDC (Google, Auth0, Authentik, Okta) alongside username/password. Could replace reverse-proxy SSO (forward-auth) middleware. ~23 files, 16 commits. |
-| **Delegated access** | [PR #614](https://github.com/fastenhealth/fasten-onprem/pull/614) | Grant editing permissions on specific FHIR resources to other Fasten users. Settings → Delegated Access. ~29 files, 24 commits. |
+| **Delegated access** | [PR #614](https://github.com/fastenhealth/fasten-onprem/pull/614) | Grant editing permissions on specific FHIR resources to other YourPHR users. Settings → Delegated Access. ~29 files, 24 commits. |
 | Multi-user permissions management | [PR #514](https://github.com/fastenhealth/fasten-onprem/pull/514) | |
 
 ---
@@ -71,11 +71,11 @@ Upstream PR [#609](https://github.com/fastenhealth/fasten-onprem/pull/609) (open
 
 ## Planned — Phase 5: Live provider sync (OAuth gateway)
 
-Replace the commercial Fasten Lighthouse with a self-hosted Cloudflare Worker relay. The Worker acts as the public OAuth callback endpoint; it stores the short-lived authorization code in KV (60s TTL) and the local Fasten instance polls and exchanges directly with the provider.
+Replace the commercial Fasten Lighthouse with a self-hosted Cloudflare Worker relay. The Worker acts as the public OAuth callback endpoint; it stores the short-lived authorization code in KV (60s TTL) and the local YourPHR instance polls and exchanges directly with the provider.
 
 | Item | Notes |
 |---|---|
-| **Cloudflare Worker OAuth relay** | Public callback endpoint; stores code in KV (60s TTL); Fasten polls and exchanges locally. |
+| **Cloudflare Worker OAuth relay** | Public callback endpoint; stores code in KV (60s TTL); YourPHR polls and exchanges locally. |
 | SMART on FHIR client (Veradigm) | Replace `fasten-sources` stub with real `GetSourceClient` for Veradigm/FollowMyHealth |
 | SMART on FHIR client (Epic MyChart) | Second provider |
 | Background refresh worker | Re-auth via refresh token; periodic `$everything` sync |

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,4 +1,4 @@
-# fastenhealth
+# YourPHR Frontend
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 9.1.4.
 


### PR DESCRIPTION
Closes #16.

Ensures non-attribution uses of "Fasten" read **YourPHR**, and surfaces the mission statement on the docs/container called out in the issue. Technical identifiers and attribution stay intact.

## Changes
- **`refactor(tls)`** — generated CA identity renamed to **"YourPHR CA"** (Organization `YourPHR`; server-cert Organization to match). It's user-facing (shown in the OS/browser trust store), so the README trust-store walkthrough + cert filename were updated to match. Cosmetic in the cert chain — a fresh CA/key is generated per deployment regardless.
- **`docs`** — product-name "Fasten" prose → "YourPHR" in `CONTRIBUTING.md`, `docs/Roadmap.md`, and the boilerplate `frontend/README.md` title.
- **`ci(docker)`** — the ghcr image description (`org.opencontainers.image.description`) now leads with the mission: *"your medical records, immediately and in your hands, for free."*

## Mission-statement coverage
README ✅ (already present) · Roadmap ✅ · container ✅ (added). Left out of CONTRIBUTING / frontend README — purely technical docs.

## Left intact (per CLAUDE.md)
Attribution lines, the "not affiliated with Fasten Health, Inc. / Fasten Connect" disclaimer, upstream tracker links, the "Fasten Lighthouse" commercial-product name, and technical identifiers (`fasten.db`, `fasten-sources`, `cmd/fasten/fasten.go`, `/opt/fasten/`, `FASTEN_ISSUER_JWT_KEY`).

## Verification
- `go build ./backend/pkg/tls/` and `go vet ./backend/pkg/tls/` clean
- Full repo sweep confirms every remaining "Fasten" is attribution, an upstream link, or a technical identifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)