### PR TITLE
feat(relay): friendly root handler at / (#50)

### DIFF
--- a/backend/cmd/relay/main.go
+++ b/backend/cmd/relay/main.go
@@ -83,6 +83,19 @@ func newServer(secret string, ttl time.Duration) (http.Handler, *store) {
 		_, _ = w.Write([]byte("ok"))
 	})
 
+	// "/" is the ServeMux catch-all: respond with a friendly note at the exact root
+	// (a human landing here in a browser), but keep a real 404 for unknown paths.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte("<!doctype html><h1>YourPHR SMART relay</h1>" +
+			"<p>OAuth store-and-poll relay — no content here. " +
+			"See <a href=\"https://github.com/jwilleke/yourphr/issues/50\">YourPHR #50</a>.</p>"))
+	})
+
 	// /callback: the provider redirects the user's browser here with ?code&state. Open by
 	// design (the provider must reach it); it only stores a short-lived code keyed by state.
 	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {

--- a/backend/cmd/relay/main_test.go
+++ b/backend/cmd/relay/main_test.go
@@ -58,6 +58,18 @@ func TestPendingRequiresSecret(t *testing.T) {
 	}
 }
 
+func TestRoot(t *testing.T) {
+	h, _ := newServer(testSecret, defaultTTL)
+	// Exact root: friendly 200.
+	if rec := do(t, h, http.MethodGet, "/", ""); rec.Code != http.StatusOK {
+		t.Errorf("root: got %d, want 200", rec.Code)
+	}
+	// Unknown path still 404 (root handler is the catch-all but guards on path).
+	if rec := do(t, h, http.MethodGet, "/nope", ""); rec.Code != http.StatusNotFound {
+		t.Errorf("unknown path: got %d, want 404", rec.Code)
+	}
+}
+
 func TestPendingUnknownState(t *testing.T) {
 	h, _ := newServer(testSecret, defaultTTL)
 	if rec := do(t, h, http.MethodGet, "/pending?state=nope", testSecret); rec.Code != http.StatusNotFound {


### PR DESCRIPTION
Visiting `https://relay.nerdsbythehour.com/` in a browser returned Go's bare `404 page not found`, since the relay only routes `/healthz`, `/callback`, and `/pending`. This adds a small `/` handler that returns a short HTML note at the **exact root**, while still returning a real **404 for unknown paths** (Go's `/` mux entry is a catch-all, so it guards on `r.URL.Path`).

Cosmetic — the relay stays a machine endpoint; nothing functional depends on `/`.

## Test
Added `TestRoot`: `/` → 200, `/nope` → 404. Full relay suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)