### PR TITLE
feat(smart): backend polls the relay for the auth code (#51)

### DIFF
--- a/backend/pkg/relay/relay.go
+++ b/backend/pkg/relay/relay.go
@@ -1,0 +1,123 @@
+// Package relay is a tiny client for the YourPHR SMART on FHIR OAuth store-and-poll
+// relay (EPIC #20, issue #50). The relay is a small public service that receives the
+// provider's authorization redirect at /callback (storing {state -> code} briefly) and
+// serves a shared-secret-gated /pending endpoint that the (internal) YourPHR backend
+// polls to retrieve the code. The backend then completes the token exchange itself; the
+// relay never sees tokens. See backend/cmd/relay and docs/planning/smart-on-fhir.
+package relay
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// DefaultBaseURL is the project's dev/demo relay (overridable via YOURPHR_RELAY_URL).
+const DefaultBaseURL = "https://relay.nerdsbythehour.com"
+
+// ErrNotReady means the relay has no code for this state yet (HTTP 404) — poll again.
+var ErrNotReady = errors.New("relay: code not yet available")
+
+// Client polls a YourPHR relay's /pending endpoint.
+type Client struct {
+	BaseURL string // e.g. https://relay.nerdsbythehour.com
+	Secret  string // shared secret presented as X-Yourphr-Token; gates /pending
+
+	// HTTPClient is optional; defaults to http.DefaultClient. Override in tests.
+	HTTPClient *http.Client
+}
+
+// FromEnv builds a Client from YOURPHR_RELAY_URL (default DefaultBaseURL) and the required
+// YOURPHR_RELAY_SECRET (the same shared secret configured on the relay). It returns an error
+// if the secret is unset, so callers can fall back to a directly-supplied code.
+func FromEnv() (Client, error) {
+	secret := os.Getenv("YOURPHR_RELAY_SECRET")
+	if secret == "" {
+		return Client{}, errors.New("relay: YOURPHR_RELAY_SECRET is not set")
+	}
+	baseURL := os.Getenv("YOURPHR_RELAY_URL")
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	return Client{BaseURL: baseURL, Secret: secret}, nil
+}
+
+func (c Client) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return http.DefaultClient
+}
+
+// Poll does a single GET /pending?state=. It returns the authorization code on success,
+// ErrNotReady if the code has not arrived (or already expired/consumed), or another error.
+func (c Client) Poll(ctx context.Context, state string) (string, error) {
+	if c.BaseURL == "" || c.Secret == "" {
+		return "", errors.New("relay: BaseURL and Secret are required")
+	}
+	if state == "" {
+		return "", errors.New("relay: state is required")
+	}
+
+	endpoint := strings.TrimRight(c.BaseURL, "/") + "/pending?state=" + url.QueryEscape(state)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("X-Yourphr-Token", c.Secret)
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return "", fmt.Errorf("relay: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var body struct {
+			Code string `json:"code"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			return "", fmt.Errorf("relay: decoding response: %w", err)
+		}
+		if body.Code == "" {
+			return "", errors.New("relay: response contained an empty code")
+		}
+		return body.Code, nil
+	case http.StatusNotFound:
+		return "", ErrNotReady
+	case http.StatusUnauthorized:
+		return "", errors.New("relay: unauthorized — the shared secret does not match the relay's")
+	default:
+		return "", fmt.Errorf("relay: unexpected status %d", resp.StatusCode)
+	}
+}
+
+// PollUntil polls every interval until the code arrives, the context is cancelled, or timeout
+// elapses. It tries immediately, then on each tick. The relay holds codes for only ~60s, so a
+// timeout beyond that is pointless.
+func (c Client) PollUntil(ctx context.Context, state string, interval, timeout time.Duration) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for {
+		code, err := c.Poll(ctx, state)
+		if err == nil {
+			return code, nil
+		}
+		if !errors.Is(err, ErrNotReady) {
+			return "", err
+		}
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf("relay: timed out waiting for authorization code: %w", ctx.Err())
+		case <-time.After(interval):
+		}
+	}
+}

--- a/backend/pkg/relay/relay_test.go
+++ b/backend/pkg/relay/relay_test.go
@@ -1,0 +1,110 @@
+package relay
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const testSecret = "test-secret"
+
+func newClient(srv *httptest.Server) Client {
+	return Client{BaseURL: srv.URL, Secret: testSecret, HTTPClient: srv.Client()}
+}
+
+func TestPollSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/pending" {
+			t.Errorf("path = %q, want /pending", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Yourphr-Token"); got != testSecret {
+			t.Errorf("token header = %q, want %q", got, testSecret)
+		}
+		if got := r.URL.Query().Get("state"); got != "S1" {
+			t.Errorf("state = %q, want S1", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":"ABC123"}`))
+	}))
+	defer srv.Close()
+
+	code, err := newClient(srv).Poll(context.Background(), "S1")
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if code != "ABC123" {
+		t.Errorf("code = %q, want ABC123", code)
+	}
+}
+
+func TestPollNotReady(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := newClient(srv).Poll(context.Background(), "S1")
+	if !errors.Is(err, ErrNotReady) {
+		t.Errorf("err = %v, want ErrNotReady", err)
+	}
+}
+
+func TestPollUnauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	if _, err := newClient(srv).Poll(context.Background(), "S1"); err == nil || errors.Is(err, ErrNotReady) {
+		t.Errorf("expected a hard auth error, got %v", err)
+	}
+}
+
+func TestPollValidation(t *testing.T) {
+	if _, err := (Client{}).Poll(context.Background(), "S1"); err == nil {
+		t.Error("expected error when BaseURL/Secret unset")
+	}
+	if _, err := (Client{BaseURL: "http://x", Secret: "s"}).Poll(context.Background(), ""); err == nil {
+		t.Error("expected error when state empty")
+	}
+}
+
+func TestPollUntilSucceedsAfterRetries(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 404 for the first two polls, then the code on the third.
+		if atomic.AddInt32(&hits, 1) < 3 {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(`{"code":"LATE"}`))
+	}))
+	defer srv.Close()
+
+	code, err := newClient(srv).PollUntil(context.Background(), "S1", 5*time.Millisecond, 2*time.Second)
+	if err != nil {
+		t.Fatalf("PollUntil: %v", err)
+	}
+	if code != "LATE" {
+		t.Errorf("code = %q, want LATE", code)
+	}
+	if atomic.LoadInt32(&hits) < 3 {
+		t.Errorf("expected at least 3 polls, got %d", hits)
+	}
+}
+
+func TestPollUntilTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := newClient(srv).PollUntil(context.Background(), "S1", 5*time.Millisecond, 40*time.Millisecond)
+	if err == nil || errors.Is(err, ErrNotReady) {
+		t.Errorf("expected timeout error, got %v", err)
+	}
+}

--- a/backend/pkg/web/handler/source.go
+++ b/backend/pkg/web/handler/source.go
@@ -7,11 +7,13 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/fastenhealth/fasten-onprem/backend/pkg"
 	"github.com/fastenhealth/fasten-onprem/backend/pkg/database"
 	"github.com/fastenhealth/fasten-onprem/backend/pkg/event_bus"
 	"github.com/fastenhealth/fasten-onprem/backend/pkg/models"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/relay"
 	"github.com/fastenhealth/fasten-sources/clients/factory"
 	sourceModels "github.com/fastenhealth/fasten-sources/clients/models"
 	"github.com/fastenhealth/fasten-sources/clients/smart"
@@ -23,13 +25,18 @@ import (
 )
 
 // SmartConnectRequest is the payload to complete a SMART on FHIR connection: the self-describing
-// provider config plus the authorization code (and its PKCE verifier) obtained via the relay.
+// provider config plus the authorization code (and its PKCE verifier).
+//
+// The code can arrive two ways: supplied directly in Code, or fetched by the backend from the
+// relay (#50) by State. Exactly one of Code/State is required; State is preferred (the code never
+// touches the browser).
 type SmartConnectRequest struct {
 	ApiEndpointBaseUrl string `json:"api_endpoint_base_url"`
 	ClientId           string `json:"client_id"`
 	Scopes             string `json:"scopes"`
 	RedirectUri        string `json:"redirect_uri"`
 	Code               string `json:"code"`
+	State              string `json:"state"`
 	CodeVerifier       string `json:"code_verifier"`
 	Display            string `json:"display"`
 }
@@ -48,9 +55,31 @@ func ConnectSource(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": fmt.Sprintf("invalid request: %s", err)})
 		return
 	}
-	if req.ApiEndpointBaseUrl == "" || req.ClientId == "" || req.Code == "" || req.CodeVerifier == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "api_endpoint_base_url, client_id, code, and code_verifier are required"})
+	if req.ApiEndpointBaseUrl == "" || req.ClientId == "" || req.CodeVerifier == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "api_endpoint_base_url, client_id, and code_verifier are required"})
 		return
+	}
+	if req.Code == "" && req.State == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "one of code or state is required"})
+		return
+	}
+
+	// When no code is supplied directly, fetch it from the relay (#50) by state. The relay holds
+	// the code for ~60s; poll briefly to absorb the redirect→connect race.
+	if req.Code == "" {
+		relayClient, err := relay.FromEnv()
+		if err != nil {
+			logger.Errorln(err)
+			c.JSON(http.StatusServiceUnavailable, gin.H{"success": false, "error": fmt.Sprintf("relay not configured: %s", err)})
+			return
+		}
+		code, err := relayClient.PollUntil(c, req.State, time.Second, 30*time.Second)
+		if err != nil {
+			logger.Errorln(err)
+			c.JSON(http.StatusBadGateway, gin.H{"success": false, "error": fmt.Sprintf("could not retrieve authorization code from relay: %s", err)})
+			return
+		}
+		req.Code = code
 	}
 
 	cfg := smart.Config{


### PR DESCRIPTION
**Part 2 of #51** (EPIC #20). Now that the relay (#50) is live and verified, this lets the **backend fetch the authorization `code` from the relay** by `state`, instead of the browser carrying it. The browser never touches the code or tokens.

## What
- **New `backend/pkg/relay` client:**
  - `Poll(state)` — `GET /pending?state=` with the `X-Yourphr-Token` header. 200 → code; 404 → `ErrNotReady`; 401 → hard error.
  - `PollUntil(state, interval, timeout)` — retries until the code arrives or the budget elapses (the relay holds codes ~60s).
  - `FromEnv()` — `YOURPHR_RELAY_URL` (default `https://relay.nerdsbythehour.com`) + required `YOURPHR_RELAY_SECRET`.
  - 6 unit tests (success, not-ready, unauthorized, validation, retry-then-succeed, timeout).
- **`ConnectSource` now accepts `state`:** when no `code` is supplied directly, it polls the relay by `state` (1s interval, 30s budget to absorb the redirect→connect race), then runs the existing discover → exchange → store → sync flow. **Backward-compatible** — a direct `code` still works; exactly one of `code`/`state` is required.

## Config / follow-up
The same `YOURPHR_RELAY_SECRET` set on the relay must also be on the YourPHR app (env) so the poll authenticates. Wiring that secret into the app deployment in `mj-infra-flux` is a follow-up infra step (the relay-secret already exists from mj-infra-flux#105; the app side needs the same value).

## Verified
`go build` + `go vet` clean on the handler + relay packages; all relay tests pass.

## Still open on #51
Backend-initiated authorize endpoint (frontend builds the URL today) and a standalone scheduled-refresh worker (sync-time refresh already covers the core via #49).

Refs #51, #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)