### PR TITLE
feat(smart): backend authorize-initiation endpoint (#53/#51)

### DIFF
--- a/backend/pkg/ssrf/ssrf.go
+++ b/backend/pkg/ssrf/ssrf.go
@@ -1,0 +1,66 @@
+// Package ssrf provides a guard against Server-Side Request Forgery for the SMART on FHIR
+// connect flow, where the backend fetches a user-supplied FHIR base URL (SMART discovery,
+// token exchange). Without validation an authenticated user could point the server at internal
+// targets (cloud metadata 169.254.169.254, localhost, RFC1918/LAN services). EPIC #20, #51.
+package ssrf
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+)
+
+// ValidatePublicHTTPSURL returns an error unless rawURL is a safe, public https URL to fetch
+// server-side: the scheme must be https and the host must resolve exclusively to public IP
+// addresses (no loopback, private/RFC1918, link-local incl. the 169.254.169.254 metadata
+// endpoint, unique-local IPv6, unspecified, or multicast).
+//
+// Note: this is a point-in-time check; it does not by itself defeat DNS rebinding (the address
+// could change between this lookup and the actual request). It blocks the common SSRF targets
+// and rejects literal-IP and resolved-private hosts up front.
+func ValidatePublicHTTPSURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("URL must use https (got %q)", u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return errors.New("URL has no host")
+	}
+
+	// Literal IP host: validate directly.
+	if ip := net.ParseIP(host); ip != nil {
+		if !isPublicIP(ip) {
+			return fmt.Errorf("host resolves to a non-public address (%s)", ip)
+		}
+		return nil
+	}
+
+	// Hostname: resolve and require every address to be public.
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return fmt.Errorf("could not resolve host %q: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("host %q resolved to no addresses", host)
+	}
+	for _, ip := range ips {
+		if !isPublicIP(ip) {
+			return fmt.Errorf("host %q resolves to a non-public address (%s)", host, ip)
+		}
+	}
+	return nil
+}
+
+// isPublicIP reports whether ip is a globally routable, non-special address.
+func isPublicIP(ip net.IP) bool {
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsMulticast() {
+		return false
+	}
+	return true
+}

--- a/backend/pkg/ssrf/ssrf_test.go
+++ b/backend/pkg/ssrf/ssrf_test.go
@@ -1,0 +1,51 @@
+package ssrf
+
+import "testing"
+
+func TestValidatePublicHTTPSURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		// rejected: non-https scheme
+		{"http scheme", "http://example.com", true},
+		{"no scheme", "example.com", true},
+		{"ftp scheme", "ftp://example.com", true},
+		{"empty", "", true},
+		// rejected: SSRF targets by literal IP
+		{"loopback v4", "https://127.0.0.1/fhir", true},
+		{"loopback name", "https://localhost/fhir", true},
+		{"loopback v6", "https://[::1]/fhir", true},
+		{"private 10", "https://10.0.0.5/fhir", true},
+		{"private 192.168", "https://192.168.1.10/fhir", true},
+		{"private 172.16", "https://172.16.0.1/fhir", true},
+		{"link-local metadata", "https://169.254.169.254/latest/meta-data", true},
+		{"unspecified", "https://0.0.0.0/fhir", true},
+		{"unique-local v6", "https://[fd00::1]/fhir", true},
+		// allowed: public literal IPs
+		{"public v4 literal", "https://8.8.8.8/fhir", false},
+		{"public v6 literal", "https://[2001:4860:4860::8888]/fhir", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidatePublicHTTPSURL(tc.url)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error for %q, got nil", tc.url)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error for %q: %v", tc.url, err)
+			}
+		})
+	}
+}
+
+// A public hostname should pass (resolves to public IPs). Network-dependent; skip in -short.
+func TestValidatePublicHTTPSURL_PublicHostname(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping DNS-dependent test in -short mode")
+	}
+	if err := ValidatePublicHTTPSURL("https://launch.smarthealthit.org/v/r4/fhir"); err != nil {
+		t.Errorf("expected the public SMART sandbox host to pass, got: %v", err)
+	}
+}

--- a/backend/pkg/web/handler/source.go
+++ b/backend/pkg/web/handler/source.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fastenhealth/fasten-onprem/backend/pkg/event_bus"
 	"github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	"github.com/fastenhealth/fasten-onprem/backend/pkg/relay"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/ssrf"
 	"github.com/fastenhealth/fasten-sources/clients/factory"
 	sourceModels "github.com/fastenhealth/fasten-sources/clients/models"
 	"github.com/fastenhealth/fasten-sources/clients/smart"
@@ -23,6 +24,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 )
+
+// validatePublicHTTPSURL guards the user-supplied FHIR base URL against SSRF before the backend
+// fetches it. It is a package var so tests can point discovery at an httptest loopback server.
+var validatePublicHTTPSURL = ssrf.ValidatePublicHTTPSURL
 
 // SmartConnectRequest is the payload to complete a SMART on FHIR connection: the self-describing
 // provider config plus the authorization code (and its PKCE verifier).
@@ -57,6 +62,12 @@ func ConnectSource(c *gin.Context) {
 	}
 	if req.ApiEndpointBaseUrl == "" || req.ClientId == "" || req.CodeVerifier == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "api_endpoint_base_url, client_id, and code_verifier are required"})
+		return
+	}
+	// SSRF guard: the backend fetches this user-supplied URL (discovery + token exchange).
+	// Reject non-public targets (metadata/loopback/LAN) before any server-side request. (#51)
+	if err := validatePublicHTTPSURL(req.ApiEndpointBaseUrl); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": fmt.Sprintf("invalid api_endpoint_base_url: %s", err)})
 		return
 	}
 	if req.Code == "" && req.State == "" {
@@ -158,6 +169,12 @@ func AuthorizeSource(c *gin.Context) {
 	}
 	if req.ApiEndpointBaseUrl == "" || req.ClientId == "" || req.RedirectUri == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "api_endpoint_base_url, client_id, and redirect_uri are required"})
+		return
+	}
+	// SSRF guard: the backend is about to fetch this user-supplied URL (discovery). Reject
+	// non-public targets (metadata/loopback/LAN) before any server-side request. (#51)
+	if err := validatePublicHTTPSURL(req.ApiEndpointBaseUrl); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": fmt.Sprintf("invalid api_endpoint_base_url: %s", err)})
 		return
 	}
 

--- a/backend/pkg/web/handler/source.go
+++ b/backend/pkg/web/handler/source.go
@@ -133,6 +133,62 @@ func ConnectSource(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"success": true, "source": sourceCred, "data": summary})
 }
 
+// SmartAuthorizeRequest initiates a SMART on FHIR standalone-launch connection: given the
+// self-describing provider config, the backend discovers the endpoints and builds the PKCE
+// authorization URL. The browser opens that URL; the provider redirects to the relay's
+// /callback (#50). The caller must hold the returned state + code_verifier and pass them back
+// to /source/connect, which polls the relay for the code and completes the exchange (#51).
+type SmartAuthorizeRequest struct {
+	ApiEndpointBaseUrl string `json:"api_endpoint_base_url"`
+	ClientId           string `json:"client_id"`
+	Scopes             string `json:"scopes"`
+	RedirectUri        string `json:"redirect_uri"`
+}
+
+// AuthorizeSource performs SMART discovery, generates a PKCE verifier + state, and returns the
+// provider authorization URL (with code_challenge/state/aud) for the browser to open. It holds
+// no server-side state; the caller round-trips state + code_verifier back to ConnectSource.
+func AuthorizeSource(c *gin.Context) {
+	logger := c.MustGet(pkg.ContextKeyTypeLogger).(*logrus.Entry)
+
+	var req SmartAuthorizeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": fmt.Sprintf("invalid request: %s", err)})
+		return
+	}
+	if req.ApiEndpointBaseUrl == "" || req.ClientId == "" || req.RedirectUri == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "api_endpoint_base_url, client_id, and redirect_uri are required"})
+		return
+	}
+
+	cfg := smart.Config{
+		FHIRBaseURL: req.ApiEndpointBaseUrl,
+		ClientID:    req.ClientId,
+		Scopes:      strings.Fields(req.Scopes),
+		RedirectURI: req.RedirectUri,
+	}
+	ep, err := cfg.Discover(c)
+	if err != nil {
+		logger.Errorln(err)
+		c.JSON(http.StatusBadGateway, gin.H{"success": false, "error": fmt.Sprintf("SMART discovery failed: %s", err)})
+		return
+	}
+	verifier, err := smart.GenerateVerifier()
+	if err != nil {
+		logger.Errorln(err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "could not generate PKCE verifier"})
+		return
+	}
+	state := uuid.New().String()
+
+	c.JSON(http.StatusOK, gin.H{
+		"success":       true,
+		"authorize_url": cfg.AuthCodeURL(ep, state, verifier),
+		"state":         state,
+		"code_verifier": verifier,
+	})
+}
+
 func CreateReconnectSource(c *gin.Context) {
 	logger := c.MustGet(pkg.ContextKeyTypeLogger).(*logrus.Entry)
 	databaseRepo := c.MustGet(pkg.ContextKeyTypeDatabase).(database.DatabaseRepository)

--- a/backend/pkg/web/handler/source_test.go
+++ b/backend/pkg/web/handler/source_test.go
@@ -116,6 +116,13 @@ func TestSourceHandlerTestSuite(t *testing.T) {
 func TestAuthorizeSource(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
+	// The stub provider runs on loopback, which the real SSRF guard rejects; bypass it here so
+	// the happy path exercises discovery + authorize-URL construction. (The guard itself is
+	// covered by backend/pkg/ssrf tests.)
+	orig := validatePublicHTTPSURL
+	validatePublicHTTPSURL = func(string) error { return nil }
+	defer func() { validatePublicHTTPSURL = orig }()
+
 	// Stub provider: serve .well-known/smart-configuration with authorize/token endpoints.
 	var provider *httptest.Server
 	provider = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -170,6 +177,31 @@ func TestAuthorizeSource(t *testing.T) {
 	require.Equal(t, "S256", q.Get("code_challenge_method"))
 	require.NotEmpty(t, q.Get("code_challenge"))
 	require.Equal(t, provider.URL, q.Get("aud"))
+}
+
+// TestAuthorizeSourceRejectsSSRF confirms the handler wires the SSRF guard: a non-public
+// (loopback) api_endpoint_base_url is rejected with 400 before any server-side request.
+func TestAuthorizeSourceRejectsSSRF(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Set(pkg.ContextKeyTypeLogger, logrus.WithField("test", t.Name()))
+
+	body, _ := json.Marshal(SmartAuthorizeRequest{
+		ApiEndpointBaseUrl: "https://127.0.0.1/fhir",
+		ClientId:           "c",
+		Scopes:             "patient/*.read",
+		RedirectUri:        "https://relay.nerdsbythehour.com/callback",
+	})
+	req, _ := http.NewRequest("POST", "/source/authorize", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+
+	AuthorizeSource(ctx)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	require.Contains(t, w.Body.String(), "invalid api_endpoint_base_url")
 }
 
 func (suite *SourceHandlerTestSuite) TestCreateManualSourceHandler() {

--- a/backend/pkg/web/handler/source_test.go
+++ b/backend/pkg/web/handler/source_test.go
@@ -21,6 +21,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -108,6 +109,67 @@ func CreateManualSourceHttpRequestFromFile(fileName string) (*http.Request, erro
 // a normal test function and pass our suite to suite.Run
 func TestSourceHandlerTestSuite(t *testing.T) {
 	suite.Run(t, new(SourceHandlerTestSuite))
+}
+
+// TestAuthorizeSource exercises the SMART authorize-initiation endpoint against a stub provider:
+// it should discover the endpoints and return a PKCE authorization URL plus the state/verifier.
+func TestAuthorizeSource(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Stub provider: serve .well-known/smart-configuration with authorize/token endpoints.
+	var provider *httptest.Server
+	provider = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/smart-configuration" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(
+				`{"authorization_endpoint":%q,"token_endpoint":%q}`,
+				provider.URL+"/authorize", provider.URL+"/token")))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer provider.Close()
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Set(pkg.ContextKeyTypeLogger, logrus.WithField("test", t.Name()))
+
+	body, _ := json.Marshal(SmartAuthorizeRequest{
+		ApiEndpointBaseUrl: provider.URL,
+		ClientId:           "my-client-id",
+		Scopes:             "launch/patient patient/*.read openid fhirUser offline_access",
+		RedirectUri:        "https://relay.nerdsbythehour.com/callback",
+	})
+	req, _ := http.NewRequest("POST", "/source/authorize", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+
+	AuthorizeSource(ctx)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var resp struct {
+		Success      bool   `json:"success"`
+		AuthorizeURL string `json:"authorize_url"`
+		State        string `json:"state"`
+		CodeVerifier string `json:"code_verifier"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.True(t, resp.Success)
+	require.NotEmpty(t, resp.State)
+	require.NotEmpty(t, resp.CodeVerifier)
+
+	authURL, err := url.Parse(resp.AuthorizeURL)
+	require.NoError(t, err)
+	require.Equal(t, provider.URL+"/authorize", authURL.Scheme+"://"+authURL.Host+authURL.Path)
+	q := authURL.Query()
+	require.Equal(t, "my-client-id", q.Get("client_id"))
+	require.Equal(t, "code", q.Get("response_type"))
+	require.Equal(t, "https://relay.nerdsbythehour.com/callback", q.Get("redirect_uri"))
+	require.Equal(t, resp.State, q.Get("state"))
+	require.Equal(t, "S256", q.Get("code_challenge_method"))
+	require.NotEmpty(t, q.Get("code_challenge"))
+	require.Equal(t, provider.URL, q.Get("aud"))
 }
 
 func (suite *SourceHandlerTestSuite) TestCreateManualSourceHandler() {

--- a/backend/pkg/web/server.go
+++ b/backend/pkg/web/server.go
@@ -167,6 +167,7 @@ func (ae *AppEngine) Setup() (*gin.RouterGroup, *gin.Engine) {
 					secure.GET("/summary/ips", handler.GetIPSSummary)
 
 					secure.POST("/source", handler.CreateReconnectSource)
+					secure.POST("/source/authorize", handler.AuthorizeSource)
 					secure.POST("/source/connect", handler.ConnectSource)
 					secure.POST("/source/manual", handler.CreateManualSource)
 					secure.GET("/source", handler.ListSource)


### PR DESCRIPTION
**Part 1 of the sandbox connect flow** (#53 "end-to-end integration", and the deferred authorize bit of #51). The keystone the BYO "Add Source" UI needs.

## What
New **`POST /api/secure/source/authorize`** (`handler.AuthorizeSource`): given the self-describing provider config (`api_endpoint_base_url`, `client_id`, `scopes`, `redirect_uri`), the backend:
1. runs SMART discovery (`.well-known/smart-configuration`),
2. generates a PKCE `code_verifier` + `state`,
3. returns the provider **authorization URL** (with `code_challenge`/`code_challenge_method=S256`/`state`/`aud`), plus `state` and `code_verifier`.

It holds **no server-side state** — the caller round-trips `state` + `code_verifier` back to `/source/connect` (#73), which polls the relay (#50) for the code and completes the token exchange. Browser → provider → relay `/callback` → backend poll.

## Why backend-side
Building the authorize URL on the backend avoids browser CORS to the provider's `.well-known` (real providers don't send CORS headers), per the decided design in `docs/planning/smart-on-fhir`.

## Verified
- `go build` + `go vet` clean; `TestAuthorizeSource` (stub discovery, asserts the URL params) passes.
- **Confirmed against the live SMART Health IT sandbox** (`launch.smarthealthit.org/v/r4/fhir`): its `.well-known/smart-configuration` advertises `authorization_endpoint`, `token_endpoint`, and `code_challenge_methods_supported` (PKCE) — so `Discover()` + `AuthCodeURL()` work against it as-is.

## Next (part 2)
Frontend BYO "Add Source" form → calls `authorizeSource()`, opens the authorize URL in a popup, then calls `connectSource({state, code_verifier, config})`. I'll verify that one in-browser against the sandbox.

Refs #53, #51, #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)