### PR TITLE
feat(frontend): BYO SMART source connect flow (#52/#53)

### DIFF
--- a/frontend/src/app/models/fasten/smart-authorize.ts
+++ b/frontend/src/app/models/fasten/smart-authorize.ts
@@ -1,0 +1,15 @@
+// Payloads for POST /secure/source/authorize — the backend performs SMART on FHIR discovery and
+// builds the PKCE authorize URL. The browser opens authorize_url and never handles tokens.
+// EPIC #20, issue #52.
+export interface SmartAuthorizeRequest {
+  api_endpoint_base_url: string;
+  client_id: string;
+  scopes: string;
+  redirect_uri: string;
+}
+
+export interface SmartAuthorizeResponse {
+  authorize_url: string;
+  state: string;
+  code_verifier: string;
+}

--- a/frontend/src/app/models/fasten/smart-connect-request.ts
+++ b/frontend/src/app/models/fasten/smart-connect-request.ts
@@ -6,7 +6,8 @@ export interface SmartConnectRequest {
   client_id: string;
   scopes: string;
   redirect_uri?: string;
-  code: string;
+  code?: string;
+  state?: string;
   code_verifier: string;
   display?: string;
 }

--- a/frontend/src/app/pages/medical-sources/medical-sources.component.html
+++ b/frontend/src/app/pages/medical-sources/medical-sources.component.html
@@ -22,7 +22,7 @@
         </span>
       </div>
 
-      <app-medical-sources-connected></app-medical-sources-connected>
+      <app-medical-sources-connected *ngIf="showConnectedList"></app-medical-sources-connected>
 
 
       <h2 class="az-content-title mg-t-40">Medical Record Sources</h2>
@@ -52,6 +52,17 @@
           <div *ngIf="uploadErrorMsg" class="alert alert-danger mt-3" role="alert">
             <strong>Error:</strong> {{uploadErrorMsg}}
           </div>
+        </div><!-- col -->
+      </div><!-- row -->
+
+      <div class="az-content-label mg-b-5 mg-t-40">Connect a SMART source (beta)</div>
+      <p class="mg-b-20">Connect directly to a provider's SMART on FHIR patient API using your own registered client. You will log in at the provider in a popup window; YourPHR never sees your password or tokens.</p>
+
+      <div class="row row-sm">
+        <div class="col-lg">
+          <button type="button" class="btn btn-az-primary" (click)="openSmartConnectModal()">
+            <i class="fas fa-plug mg-r-5"></i> Connect a SMART source
+          </button>
         </div><!-- col -->
       </div><!-- row -->
 
@@ -139,6 +150,67 @@
     <button (click)="modal.dismiss('cancel')" type="button" class="btn btn-outline-light">Cancel</button>
   </div>
 
+</ng-template>
+
+
+<ng-template #smartConnectModal let-modal>
+  <div class="modal-header">
+    <h6 class="modal-title" id="smart-connect-title">Connect a SMART source (beta)</h6>
+    <button type="button" class="btn close" aria-label="Close" (click)="modal.dismiss('Cross click')">
+      <span aria-hidden="true">×</span>
+    </button>
+  </div>
+
+  <div class="modal-body">
+    <form (ngSubmit)="connectSmartSource()" #smartConnectForm="ngForm">
+      <div class="form-group">
+        <label class="form-label" for="smart-api-endpoint">FHIR base URL</label>
+        <input id="smart-api-endpoint" name="api_endpoint_base_url" type="url" class="form-control"
+               placeholder="https://fhir.example.com/r4"
+               [(ngModel)]="smartForm.api_endpoint_base_url" [disabled]="smartConnecting" required>
+      </div>
+
+      <div class="form-group">
+        <label class="form-label" for="smart-client-id">Client ID</label>
+        <input id="smart-client-id" name="client_id" type="text" class="form-control"
+               placeholder="your-registered-client-id"
+               [(ngModel)]="smartForm.client_id" [disabled]="smartConnecting" required>
+      </div>
+
+      <div class="form-group">
+        <label class="form-label" for="smart-scopes">Scopes</label>
+        <input id="smart-scopes" name="scopes" type="text" class="form-control"
+               [(ngModel)]="smartForm.scopes" [disabled]="smartConnecting" required>
+      </div>
+
+      <div class="form-group">
+        <label class="form-label" for="smart-display">Display name <small class="tx-gray-500">(optional)</small></label>
+        <input id="smart-display" name="display" type="text" class="form-control"
+               placeholder="My Clinic"
+               [(ngModel)]="smartForm.display" [disabled]="smartConnecting">
+      </div>
+
+      <div *ngIf="smartErrorMsg" class="alert alert-danger" role="alert">
+        {{smartErrorMsg}}
+      </div>
+      <div *ngIf="smartSuccessMsg" class="alert alert-success" role="alert">
+        {{smartSuccessMsg}}
+      </div>
+
+      <p *ngIf="smartConnecting" class="tx-gray-600 mg-b-0">
+        <span class="spinner-border spinner-border-sm text-primary mg-r-5" role="status" aria-hidden="true"></span>
+        Waiting for you to complete login in the popup window, then importing your records...
+      </p>
+    </form>
+  </div>
+
+  <div class="modal-footer">
+    <button type="button" class="btn btn-az-primary" (click)="connectSmartSource()" [disabled]="smartConnecting">
+      <span *ngIf="smartConnecting" class="spinner-border spinner-border-sm mg-r-5" role="status" aria-hidden="true"></span>
+      Connect
+    </button>
+    <button type="button" class="btn btn-outline-light" (click)="modal.dismiss('cancel')" [disabled]="smartConnecting">Cancel</button>
+  </div>
 </ng-template>
 
 

--- a/frontend/src/app/pages/medical-sources/medical-sources.component.ts
+++ b/frontend/src/app/pages/medical-sources/medical-sources.component.ts
@@ -20,6 +20,8 @@ import {PatientAccessBrand} from '../../models/patient-access-brands';
 import {PlatformService} from '../../services/platform.service';
 import {FormRequestHealthSystemComponent} from '../../components/form-request-health-system/form-request-health-system.component';
 import {extractErrorFromResponse} from '../../../lib/utils/error_extract';
+import {SmartAuthorizeResponse} from '../../models/fasten/smart-authorize';
+import {SmartConnectRequest} from '../../models/fasten/smart-connect-request';
 
 export const sourceConnectWindowTimeout = 24*5000 //wait 2 minutes (5 * 24 = 120)
 
@@ -69,6 +71,21 @@ export class MedicalSourcesComponent implements OnInit {
 
   // CCDA-FHIR modal
   @ViewChild('ccdaWarningModalRef') ccdaWarningModalRef : any;
+
+  // BYO SMART source connect modal (EPIC #20, issue #52)
+  @ViewChild('smartConnectModal') smartConnectModalRef : any;
+  // template-driven form model
+  smartForm = {
+    api_endpoint_base_url: '',
+    client_id: '',
+    scopes: 'launch/patient patient/*.read openid fhirUser offline_access',
+    display: '',
+  }
+  smartConnecting = false
+  smartErrorMsg = ''
+  smartSuccessMsg = ''
+  // toggled to destroy/recreate <app-medical-sources-connected> so it re-loads after a connect
+  showConnectedList = true
 
   constructor(
     private connectGatewayApi: ConnectGatewayService,
@@ -238,6 +255,103 @@ export class MedicalSourcesComponent implements OnInit {
       // x or cancel button clicked, .dismiss()
       return false
     })
+  }
+
+  // -------- Bring-Your-Own SMART source connect flow (EPIC #20, issue #52) --------
+
+  // Opens the BYO SMART connect modal, resetting per-attempt status.
+  public openSmartConnectModal(): void {
+    this.smartErrorMsg = ''
+    this.smartSuccessMsg = ''
+    this.smartConnecting = false
+    this.modalService.open(this.smartConnectModalRef, {ariaLabelledBy: 'smart-connect-title'})
+  }
+
+  // Forces <app-medical-sources-connected> to be destroyed and recreated so it re-runs its
+  // ngOnInit load (it appends sources on init, so a fresh instance is the simplest correct refresh).
+  private refreshConnectedList(): void {
+    this.showConnectedList = false
+    setTimeout(() => { this.showConnectedList = true }, 0)
+  }
+
+  // Runs the 6-step BYO SMART connect flow: authorize -> popup login -> connect (poll/exchange).
+  // The backend never exposes tokens to the browser. connectSource polls our relay (~30s) for the
+  // auth code; since login can outlast one poll, retry up to 3 total attempts before surfacing an error.
+  public async connectSmartSource(): Promise<void> {
+    if (this.smartConnecting) { return } //guard against double-submit
+
+    this.smartErrorMsg = ''
+    this.smartSuccessMsg = ''
+
+    const apiEndpoint = (this.smartForm.api_endpoint_base_url || '').trim()
+    const clientId = (this.smartForm.client_id || '').trim()
+    const scopes = (this.smartForm.scopes || '').trim()
+    const display = (this.smartForm.display || '').trim()
+
+    if (!apiEndpoint || !clientId || !scopes) {
+      this.smartErrorMsg = 'FHIR base URL, Client ID and Scopes are all required.'
+      return
+    }
+
+    const redirectUri = `${environment.relay_endpoint_base}/callback`
+
+    this.smartConnecting = true
+    try {
+      // Step 3: ask backend for the PKCE authorize URL (it does SMART discovery).
+      const authorize: SmartAuthorizeResponse = await this.fastenApi.authorizeSource({
+        api_endpoint_base_url: apiEndpoint,
+        client_id: clientId,
+        scopes: scopes,
+        redirect_uri: redirectUri,
+      }).toPromise()
+
+      if (!authorize?.authorize_url || !authorize?.state || !authorize?.code_verifier) {
+        this.smartErrorMsg = 'Authorization failed: the server did not return a valid authorize URL.'
+        this.smartConnecting = false
+        return
+      }
+
+      // Step 4: open the provider login in a popup; it redirects to our relay /callback when done.
+      window.open(authorize.authorize_url, '_blank')
+
+      // Step 5: complete the connection. The backend polls the relay for the code, exchanges it,
+      // stores the source and runs the initial sync. Retry up to 3 total attempts because login
+      // may take longer than a single ~30s poll window.
+      const connectReq: SmartConnectRequest = {
+        api_endpoint_base_url: apiEndpoint,
+        client_id: clientId,
+        scopes: scopes,
+        redirect_uri: redirectUri,
+        state: authorize.state,
+        code_verifier: authorize.code_verifier,
+        display: display || undefined,
+      }
+
+      let lastErr: any = null
+      for (let attempt = 1; attempt <= 3; attempt++) {
+        try {
+          await this.fastenApi.connectSource(connectReq).toPromise()
+          lastErr = null
+          break
+        } catch (err) {
+          lastErr = err
+        }
+      }
+
+      if (lastErr) {
+        this.smartErrorMsg = 'Connection failed: ' + (extractErrorFromResponse(lastErr) || 'Unknown Error') + ' Please complete the login in the popup window and try again.'
+        return
+      }
+
+      // Step 6: success.
+      this.smartSuccessMsg = 'Source connected successfully. Your records are being imported.'
+      this.refreshConnectedList()
+      this.modalService.dismissAll()
+    } catch (err) {
+      this.smartErrorMsg = 'Authorization failed: ' + (extractErrorFromResponse(err) || 'Unknown Error')
+    } finally {
+      this.smartConnecting = false
+    }
   }
 
 }

--- a/frontend/src/app/services/fasten-api.service.ts
+++ b/frontend/src/app/services/fasten-api.service.ts
@@ -26,6 +26,7 @@ import { fetchEventSource } from '@microsoft/fetch-event-source';
 import {BackgroundJob, BackgroundJobSyncData} from '../models/fasten/background-job';
 import {SupportRequest} from '../models/fasten/support-request';
 import {SmartConnectRequest} from '../models/fasten/smart-connect-request';
+import {SmartAuthorizeRequest, SmartAuthorizeResponse} from '../models/fasten/smart-authorize';
 import {
   List
 } from 'fhir/r4';
@@ -140,6 +141,23 @@ export class FastenApiService {
         map((response: ResponseWrapper) => {
           // @ts-ignore
           return {summary: response.data, source: response.source}
+        })
+      );
+  }
+
+  // authorizeSource asks the backend to perform SMART on FHIR discovery and build the PKCE
+  // authorize URL. The browser opens authorize_url so the user logs in at the provider; the
+  // returned state + code_verifier are then passed to connectSource() to complete the exchange.
+  // See backend handler.AuthorizeSource (#51) and the relay (#50).
+  authorizeSource(req: SmartAuthorizeRequest): Observable<SmartAuthorizeResponse> {
+    return this._httpClient.post<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/source/authorize`, req)
+      .pipe(
+        map((response: any) => {
+          return {
+            authorize_url: response.authorize_url,
+            state: response.state,
+            code_verifier: response.code_verifier,
+          } as SmartAuthorizeResponse
         })
       );
   }

--- a/frontend/src/environments/environment.cloud_sandbox.ts
+++ b/frontend/src/environments/environment.cloud_sandbox.ts
@@ -9,4 +9,7 @@ export const environment = {
 
   //used to specify the api server that we're going to use (can be relative or absolute). Must not have trailing slash
   fasten_api_endpoint_base: 'https://api.sandbox.fastenhealth.com/v1',
+
+  // self-hosted Go SMART OAuth store-and-poll relay; ${relay_endpoint_base}/callback is the OAuth redirect_uri (EPIC #20, issue #50)
+  relay_endpoint_base: 'https://relay.nerdsbythehour.com',
 };

--- a/frontend/src/environments/environment.desktop_prod.ts
+++ b/frontend/src/environments/environment.desktop_prod.ts
@@ -9,4 +9,7 @@ export const environment = {
 
   //used to specify the api server that we're going to use (can be relative or absolute). Must not have trailing slash
   fasten_api_endpoint_base: '/api',
+
+  // self-hosted Go SMART OAuth store-and-poll relay; ${relay_endpoint_base}/callback is the OAuth redirect_uri (EPIC #20, issue #50)
+  relay_endpoint_base: 'https://relay.nerdsbythehour.com',
 };

--- a/frontend/src/environments/environment.desktop_sandbox.ts
+++ b/frontend/src/environments/environment.desktop_sandbox.ts
@@ -9,4 +9,7 @@ export const environment = {
 
   //used to specify the api server that we're going to use (can be relative or absolute). Must not have trailing slash
   fasten_api_endpoint_base: '/api',
+
+  // self-hosted Go SMART OAuth store-and-poll relay; ${relay_endpoint_base}/callback is the OAuth redirect_uri (EPIC #20, issue #50)
+  relay_endpoint_base: 'https://relay.nerdsbythehour.com',
 };

--- a/frontend/src/environments/environment.dev.ts
+++ b/frontend/src/environments/environment.dev.ts
@@ -9,4 +9,7 @@ export const environment = {
 
   //used to specify the api server that we're going to use (can be relative or absolute). Must not have trailing slash
   fasten_api_endpoint_base: '/api',
+
+  // self-hosted Go SMART OAuth store-and-poll relay; ${relay_endpoint_base}/callback is the OAuth redirect_uri (EPIC #20, issue #50)
+  relay_endpoint_base: 'https://relay.nerdsbythehour.com',
 };

--- a/frontend/src/environments/environment.offline_sandbox.ts
+++ b/frontend/src/environments/environment.offline_sandbox.ts
@@ -10,4 +10,7 @@ export const environment = {
 
   //used to specify the api server that we're going to use (can be relative or absolute). Must not have trailing slash
   fasten_api_endpoint_base: '/api',
+
+  // self-hosted Go SMART OAuth store-and-poll relay; ${relay_endpoint_base}/callback is the OAuth redirect_uri (EPIC #20, issue #50)
+  relay_endpoint_base: 'https://relay.nerdsbythehour.com',
 };

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -9,4 +9,7 @@ export const environment = {
 
   //used to specify the api server that we're going to use (can be relative or absolute). Must not have trailing slash
   fasten_api_endpoint_base: '/api',
+
+  // self-hosted Go SMART OAuth store-and-poll relay; ${relay_endpoint_base}/callback is the OAuth redirect_uri (EPIC #20, issue #50)
+  relay_endpoint_base: 'https://relay.nerdsbythehour.com',
 };

--- a/frontend/src/environments/environment.sandbox.ts
+++ b/frontend/src/environments/environment.sandbox.ts
@@ -13,4 +13,7 @@ export const environment = {
 
   //used to specify the api server that we're going to use (can be relative or absolute). Must not have trailing slash
   fasten_api_endpoint_base: '/api',
+
+  // self-hosted Go SMART OAuth store-and-poll relay; ${relay_endpoint_base}/callback is the OAuth redirect_uri (EPIC #20, issue #50)
+  relay_endpoint_base: 'https://relay.nerdsbythehour.com',
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -24,4 +24,7 @@ export const environment = {
   // fasten_api_endpoint_base: 'https://api.sandbox.fastenhealth.com/v1',
   // if relative, must start with /
   fasten_api_endpoint_base: '/api',
+
+  // self-hosted Go SMART OAuth store-and-poll relay; ${relay_endpoint_base}/callback is the OAuth redirect_uri (EPIC #20, issue #50)
+  relay_endpoint_base: 'https://relay.nerdsbythehour.com',
 };


### PR DESCRIPTION
**Part 2 of the sandbox connect flow** — the clickable end. Adds a "Connect a SMART source (beta)" form on the Medical Sources page that drives the live relay + the backend endpoints end-to-end.

## Flow
1. User enters FHIR base URL, client_id, scopes (prefilled `launch/patient patient/*.read openid fhirUser offline_access`), optional display.
2. `authorizeSource()` → `POST /secure/source/authorize` (#75) → backend discovers + builds the PKCE authorize URL, returns `{authorize_url, state, code_verifier}`.
3. Opens `authorize_url` in a popup → provider login → relay `/callback` (#50).
4. `connectSource({state, code_verifier, config})` → `POST /secure/source/connect` (#73) → backend polls the relay for the code, exchanges, stores, syncs. **Retries up to 3×** since user login may outlast one ~30s relay-poll window.
5. Success → refreshes the connected-sources list; errors shown inline.

## Changes
- `models/fasten/smart-connect-request.ts`: `code` now optional, add `state?`.
- `models/fasten/smart-authorize.ts` (new): request/response interfaces.
- `services/fasten-api.service.ts`: `authorizeSource()`.
- `environments/*.ts` (all 8): `relay_endpoint_base: 'https://relay.nerdsbythehour.com'` → `redirect_uri = ${relay_endpoint_base}/callback`.
- `medical-sources.component.{ts,html}`: BYO modal + form + orchestration (double-submit guard, spinner, inline status). Deprecated lighthouse catalog flow untouched.

## Verified / pending
- ✅ `ng build -c sandbox` + `medical-sources`/`fasten-api` specs pass.
- ⚠️ **Runtime depends on #75** (the `/source/authorize` endpoint) being merged/deployed.
- ⏭️ **In-browser end-to-end verification against `launch.smarthealthit.org`** is the remaining step before calling #53 done.

## Merge order
Land #75 first (backend endpoint), then this.

Refs #52, #53, #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)