### PR TITLE
feat(relay): observability — log + Prometheus metrics on code arrival (#50)

### DIFF
--- a/backend/cmd/relay/main.go
+++ b/backend/cmd/relay/main.go
@@ -13,11 +13,13 @@ package main
 import (
 	"crypto/subtle"
 	"encoding/json"
+	"fmt"
 	"html"
 	"log"
 	"net/http"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -72,10 +74,38 @@ func (s *store) evictExpired() {
 	}
 }
 
+// metrics holds the relay's Prometheus counters. Hand-rolled (text exposition) to keep the
+// relay pure-stdlib / zero-dependency. Exposed on a separate, in-cluster-only metrics port.
+type metrics struct {
+	callbacks           atomic.Int64 // codes received + stored at /callback ("a secret arrived")
+	callbackErrors      atomic.Int64 // /callback rejected (provider error or missing code/state)
+	pendingFound        atomic.Int64 // /pending delivered a code
+	pendingNotFound     atomic.Int64 // /pending had no (live) code for the state
+	pendingUnauthorized atomic.Int64 // /pending rejected (missing/bad shared secret)
+}
+
+// writeProm emits the counters in Prometheus text exposition format (v0.0.4).
+func (m *metrics) writeProm(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	fmt.Fprintf(w, "# HELP yourphr_relay_callbacks_total Authorization codes received and stored at /callback.\n")
+	fmt.Fprintf(w, "# TYPE yourphr_relay_callbacks_total counter\n")
+	fmt.Fprintf(w, "yourphr_relay_callbacks_total %d\n", m.callbacks.Load())
+	fmt.Fprintf(w, "# HELP yourphr_relay_callback_errors_total Rejected /callback requests (provider error or missing params).\n")
+	fmt.Fprintf(w, "# TYPE yourphr_relay_callback_errors_total counter\n")
+	fmt.Fprintf(w, "yourphr_relay_callback_errors_total %d\n", m.callbackErrors.Load())
+	fmt.Fprintf(w, "# HELP yourphr_relay_pending_total Poll requests at /pending, by result.\n")
+	fmt.Fprintf(w, "# TYPE yourphr_relay_pending_total counter\n")
+	fmt.Fprintf(w, "yourphr_relay_pending_total{result=\"found\"} %d\n", m.pendingFound.Load())
+	fmt.Fprintf(w, "yourphr_relay_pending_total{result=\"not_found\"} %d\n", m.pendingNotFound.Load())
+	fmt.Fprintf(w, "yourphr_relay_pending_total{result=\"unauthorized\"} %d\n", m.pendingUnauthorized.Load())
+}
+
 // newServer builds the relay HTTP handler. secret gates /pending; ttl is the code lifetime.
-// The returned *store is exposed for tests (TTL injection) and the background janitor.
-func newServer(secret string, ttl time.Duration) (http.Handler, *store) {
+// The returned *store is exposed for tests (TTL injection) and the background janitor; the
+// returned *metrics is served on the separate metrics port and asserted in tests.
+func newServer(secret string, ttl time.Duration) (http.Handler, *store, *metrics) {
 	st := newStore(ttl)
+	m := &metrics{}
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -101,6 +131,8 @@ func newServer(secret string, ttl time.Duration) (http.Handler, *store) {
 	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
 		if e := q.Get("error"); e != "" {
+			m.callbackErrors.Add(1)
+			log.Printf("relay: /callback provider error for state=%q: %s", q.Get("state"), e)
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = w.Write([]byte("<!doctype html><h1>Authorization failed</h1><p>" +
@@ -109,10 +141,14 @@ func newServer(secret string, ttl time.Duration) (http.Handler, *store) {
 		}
 		code, state := q.Get("code"), q.Get("state")
 		if code == "" || state == "" {
+			m.callbackErrors.Add(1)
 			http.Error(w, "missing code or state", http.StatusBadRequest)
 			return
 		}
 		st.put(state, code)
+		m.callbacks.Add(1)
+		// Log that a code arrived (state only — never the code, which is the secret).
+		log.Printf("relay: stored authorization code for state=%q (ttl %s)", state, ttl)
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		_, _ = w.Write([]byte("<!doctype html><h1>Connected</h1>" +
 			"<p>You may close this window and return to YourPHR.</p>"))
@@ -121,6 +157,7 @@ func newServer(secret string, ttl time.Duration) (http.Handler, *store) {
 	// /pending: the YourPHR instance polls here (shared-secret gated) to retrieve the code.
 	mux.HandleFunc("/pending", func(w http.ResponseWriter, r *http.Request) {
 		if !secretEqual(r.Header.Get("X-Yourphr-Token"), secret) {
+			m.pendingUnauthorized.Add(1)
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -131,14 +168,17 @@ func newServer(secret string, ttl time.Duration) (http.Handler, *store) {
 		}
 		code, ok := st.take(state)
 		if !ok {
+			m.pendingNotFound.Add(1)
 			http.Error(w, "not found", http.StatusNotFound)
 			return
 		}
+		m.pendingFound.Add(1)
+		log.Printf("relay: delivered authorization code for state=%q", state)
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]string{"code": code})
 	})
 
-	return mux, st
+	return mux, st, m
 }
 
 // secretEqual is a constant-time comparison that also rejects an empty configured secret.
@@ -158,8 +198,12 @@ func main() {
 	if port == "" {
 		port = "8080"
 	}
+	metricsPort := os.Getenv("METRICS_PORT")
+	if metricsPort == "" {
+		metricsPort = "9090"
+	}
 
-	handler, st := newServer(secret, defaultTTL)
+	handler, st, m := newServer(secret, defaultTTL)
 
 	// Background janitor: evict expired codes so the map cannot grow unbounded.
 	go func() {
@@ -167,6 +211,19 @@ func main() {
 		defer t.Stop()
 		for range t.C {
 			st.evictExpired()
+		}
+	}()
+
+	// Metrics server on a separate port — scraped in-cluster only, NOT exposed via the public
+	// tunnel (which routes the relay's main :PORT). Keeps callback/poll counts off the internet.
+	go func() {
+		mmux := http.NewServeMux()
+		mmux.HandleFunc("/metrics", func(w http.ResponseWriter, _ *http.Request) { m.writeProm(w) })
+		mmux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("ok")) })
+		msrv := &http.Server{Addr: ":" + metricsPort, Handler: mmux, ReadHeaderTimeout: 5 * time.Second}
+		log.Printf("yourphr relay metrics listening on :%s", metricsPort)
+		if err := msrv.ListenAndServe(); err != nil {
+			log.Printf("relay: metrics server stopped: %v", err)
 		}
 	}()
 

--- a/backend/cmd/relay/main_test.go
+++ b/backend/cmd/relay/main_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -22,7 +23,7 @@ func do(t *testing.T, h http.Handler, method, target string, secret string) *htt
 }
 
 func TestCallbackThenPending(t *testing.T) {
-	h, _ := newServer(testSecret, defaultTTL)
+	h, _, _ := newServer(testSecret, defaultTTL)
 
 	if rec := do(t, h, http.MethodGet, "/callback?code=ABC&state=S1", ""); rec.Code != http.StatusOK {
 		t.Fatalf("callback: got %d", rec.Code)
@@ -47,7 +48,7 @@ func TestCallbackThenPending(t *testing.T) {
 }
 
 func TestPendingRequiresSecret(t *testing.T) {
-	h, _ := newServer(testSecret, defaultTTL)
+	h, _, _ := newServer(testSecret, defaultTTL)
 	do(t, h, http.MethodGet, "/callback?code=ABC&state=S1", "")
 
 	if rec := do(t, h, http.MethodGet, "/pending?state=S1", ""); rec.Code != http.StatusUnauthorized {
@@ -59,7 +60,7 @@ func TestPendingRequiresSecret(t *testing.T) {
 }
 
 func TestRoot(t *testing.T) {
-	h, _ := newServer(testSecret, defaultTTL)
+	h, _, _ := newServer(testSecret, defaultTTL)
 	// Exact root: friendly 200.
 	if rec := do(t, h, http.MethodGet, "/", ""); rec.Code != http.StatusOK {
 		t.Errorf("root: got %d, want 200", rec.Code)
@@ -71,14 +72,14 @@ func TestRoot(t *testing.T) {
 }
 
 func TestPendingUnknownState(t *testing.T) {
-	h, _ := newServer(testSecret, defaultTTL)
+	h, _, _ := newServer(testSecret, defaultTTL)
 	if rec := do(t, h, http.MethodGet, "/pending?state=nope", testSecret); rec.Code != http.StatusNotFound {
 		t.Errorf("unknown state: got %d, want 404", rec.Code)
 	}
 }
 
 func TestCallbackValidation(t *testing.T) {
-	h, _ := newServer(testSecret, defaultTTL)
+	h, _, _ := newServer(testSecret, defaultTTL)
 	if rec := do(t, h, http.MethodGet, "/callback?state=S1", ""); rec.Code != http.StatusBadRequest {
 		t.Errorf("missing code: got %d, want 400", rec.Code)
 	}
@@ -88,7 +89,7 @@ func TestCallbackValidation(t *testing.T) {
 }
 
 func TestTTLExpiry(t *testing.T) {
-	h, st := newServer(testSecret, defaultTTL)
+	h, st, _ := newServer(testSecret, defaultTTL)
 	base := time.Now()
 	st.now = func() time.Time { return base }
 
@@ -102,7 +103,7 @@ func TestTTLExpiry(t *testing.T) {
 }
 
 func TestHealthz(t *testing.T) {
-	h, _ := newServer(testSecret, defaultTTL)
+	h, _, _ := newServer(testSecret, defaultTTL)
 	if rec := do(t, h, http.MethodGet, "/healthz", ""); rec.Code != http.StatusOK {
 		t.Errorf("healthz: got %d", rec.Code)
 	}
@@ -117,5 +118,51 @@ func TestSecretEqual(t *testing.T) {
 	}
 	if secretEqual("abc", "abd") {
 		t.Error("different secrets should not match")
+	}
+}
+
+func TestMetrics(t *testing.T) {
+	h, _, m := newServer(testSecret, defaultTTL)
+
+	// A code arrives.
+	if rec := do(t, h, http.MethodGet, "/callback?code=ABC&state=S1", ""); rec.Code != http.StatusOK {
+		t.Fatalf("callback: got %d", rec.Code)
+	}
+	// Unauthorized poll.
+	do(t, h, http.MethodGet, "/pending?state=S1", "")
+	// Authorized poll that finds the code.
+	if rec := do(t, h, http.MethodGet, "/pending?state=S1", testSecret); rec.Code != http.StatusOK {
+		t.Fatalf("pending: got %d", rec.Code)
+	}
+	// Authorized poll for an unknown state.
+	do(t, h, http.MethodGet, "/pending?state=missing", testSecret)
+
+	if got := m.callbacks.Load(); got != 1 {
+		t.Errorf("callbacks = %d, want 1", got)
+	}
+	if got := m.pendingUnauthorized.Load(); got != 1 {
+		t.Errorf("pendingUnauthorized = %d, want 1", got)
+	}
+	if got := m.pendingFound.Load(); got != 1 {
+		t.Errorf("pendingFound = %d, want 1", got)
+	}
+	if got := m.pendingNotFound.Load(); got != 1 {
+		t.Errorf("pendingNotFound = %d, want 1", got)
+	}
+
+	// The exposition output reflects the counters and is well-formed.
+	rec := httptest.NewRecorder()
+	m.writeProm(rec)
+	body := rec.Body.String()
+	for _, want := range []string{
+		"yourphr_relay_callbacks_total 1",
+		`yourphr_relay_pending_total{result="found"} 1`,
+		`yourphr_relay_pending_total{result="not_found"} 1`,
+		`yourphr_relay_pending_total{result="unauthorized"} 1`,
+		"# TYPE yourphr_relay_callbacks_total counter",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("metrics output missing %q\n---\n%s", want, body)
+		}
 	}
 }


### PR DESCRIPTION
Surfaces **when a SMART authorization code arrives** at the relay (and the poll side) — the "alert/log when a secret arrives" ask. Kept **zero-dependency** to preserve the relay's pure-stdlib footprint (hand-rolled Prometheus text exposition, no `client_golang`).

## What
- **Metrics** (`/metrics`, Prometheus text format):
  - `yourphr_relay_callbacks_total` — a code arrived and was stored at `/callback`.
  - `yourphr_relay_callback_errors_total` — rejected callbacks (provider error / missing params).
  - `yourphr_relay_pending_total{result="found|not_found|unauthorized"}` — the poll side.
- **Logs** a line when a code is stored and when one is delivered — **by `state` only, never the code** (the code is the secret).
- Metrics served on a **separate `METRICS_PORT` (default 9090)** so counts are scraped **in-cluster only** and are NOT exposed via the public tunnel (`:8080`).
- `newServer` now returns the `*metrics`; tests updated + `TestMetrics` asserting increments and exposition output.

## Verified
`go build` + `go vet` clean; all 9 relay tests pass (incl. `TestMetrics`). No new go.mod deps.

## Follow-up (separate mj-infra-flux PR)
Expose the metrics port on the relay Service + a `ServiceMonitor` to scrape it + a `PrometheusRule` that **alerts when `yourphr_relay_callbacks_total` increases** (a code arrived). Building that next.

Refs #50, #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)