### PR TITLE
fix(frontend): modal sits above ng-bootstrap backdrop (z-index)

### DIFF
--- a/frontend/src/assets/scss/custom/_modal.scss
+++ b/frontend/src/assets/scss/custom/_modal.scss
@@ -6,7 +6,10 @@
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 1050;
+  // Must sit ABOVE ng-bootstrap's backdrop, which it sets inline to z-index:1055.
+  // The azia theme originally set this to 1050 (below the backdrop), so the backdrop
+  // captured all clicks and modal inputs were unusable. See yourphr#76 / the SMART connect modal.
+  z-index: 1056;
   display: none;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Problem
Modals open but their inputs are **completely unusable** — the "Connect a SMART source (beta)" form (`jwilleke/yourphr#76`) renders, but you can't click or type in any field.

## Root cause (DevTools-confirmed)
ng-bootstrap sets its `.modal-backdrop` to `z-index: 1055` **inline**, but the azia theme's `custom/_modal.scss` set `.modal` (the modal window) to `z-index: 1050` — *below* the backdrop. So the backdrop is painted on top of the modal and intercepts all clicks.

`document.elementFromPoint()` on the form's input returned:
```
<ngb-modal-backdrop style="z-index: 1055;" class="modal-backdrop fade show">
is it the input? false
input disabled? false   ← input is fine; it's just covered
```

## Fix
Raise `.modal` to `z-index: 1056` so the window sits above ng-bootstrap's backdrop — restoring Bootstrap's intended window-over-backdrop ordering. One-line CSS change; fixes **every** ng-bootstrap modal in the app, not just the SMART form.

## Verify after deploy
Open Medical Sources → "Connect a SMART source (beta)" → the fields should now be clickable/typeable.

## Separate follow-up (not this PR)
The console also shows `oauth4webapi … Uncaught SyntaxError: Unexpected token 'export'` — an unrelated real bug (an ESM-only dep served as a classic script). Tracking separately; it wasn't the cause of the locked modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)