### PR TITLE
fix(relay): log error_description on /callback provider errors (#50)

### DIFF
--- a/backend/cmd/relay/main.go
+++ b/backend/cmd/relay/main.go
@@ -132,7 +132,7 @@ func newServer(secret string, ttl time.Duration) (http.Handler, *store, *metrics
 		q := r.URL.Query()
 		if e := q.Get("error"); e != "" {
 			m.callbackErrors.Add(1)
-			log.Printf("relay: /callback provider error for state=%q: %s", q.Get("state"), e)
+			log.Printf("relay: /callback provider error for state=%q: %s — %s", q.Get("state"), e, q.Get("error_description"))
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = w.Write([]byte("<!doctype html><h1>Authorization failed</h1><p>" +


### PR DESCRIPTION
While debugging a Veradigm/Allscripts connect, the relay logged only the bare OAuth error code:
```
relay: /callback provider error for state="…": invalid_request
```
…but not the **`error_description`**, which is where the provider explains *why* (the actual diagnostic). One-line fix to log both:
```
relay: /callback provider error for state="…": invalid_request — <error_description>
```

Now provider rejections are diagnosable straight from `kubectl -n yourphr logs deploy/yourphr-relay` without having to catch the popup error page. Build + relay tests pass.

Refs #50, #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)