### PR TITLE
fix(frontend): open SMART login popup synchronously (#82)

### DIFF
--- a/frontend/src/app/pages/medical-sources/medical-sources.component.spec.ts
+++ b/frontend/src/app/pages/medical-sources/medical-sources.component.spec.ts
@@ -9,6 +9,7 @@ import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import { LoadingSpinnerComponent } from 'src/app/components/loading-spinner/loading-spinner.component';
 import { MedicalSourcesFilterComponent } from 'src/app/components/medical-sources-filter/medical-sources-filter.component';
 import { MedicalSourcesConnectedComponent } from 'src/app/components/medical-sources-connected/medical-sources-connected.component';
+import { of } from 'rxjs';
 
 describe('MedicalSourcesComponent', () => {
   let component: MedicalSourcesComponent;
@@ -36,5 +37,46 @@ describe('MedicalSourcesComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  function fillSmartForm() {
+    component.smartForm.api_endpoint_base_url = 'https://launch.smarthealthit.org/v/r4/fhir';
+    component.smartForm.client_id = 'test-client';
+    component.smartForm.scopes = 'launch/patient patient/*.read openid fhirUser offline_access';
+  }
+
+  // The popup must be opened synchronously in the click handler; if the browser blocks it,
+  // surface a clear error and don't even start the authorize call.
+  it('connectSmartSource: errors clearly when the popup is blocked', async () => {
+    fillSmartForm();
+    spyOn(window, 'open').and.returnValue(null);
+    const authSpy = spyOn(component['fastenApi'], 'authorizeSource');
+
+    await component.connectSmartSource();
+
+    expect(authSpy).not.toHaveBeenCalled();
+    expect(component.smartErrorMsg.toLowerCase()).toContain('popup');
+    expect(component.smartConnecting).toBeFalse();
+  });
+
+  // Happy path: open a blank popup synchronously, then navigate it to the authorize URL once the
+  // backend responds (proves we don't call window.open *after* the await).
+  it('connectSmartSource: opens popup synchronously then navigates it to the authorize URL', async () => {
+    fillSmartForm();
+    const fakePopup: any = { location: { href: '' }, document: { write: () => {} }, close: () => {} };
+    const openSpy = spyOn(window, 'open').and.returnValue(fakePopup);
+    spyOn(component['fastenApi'], 'authorizeSource').and.returnValue(of({
+      authorize_url: 'https://provider.example/authorize?x=1',
+      state: 's1',
+      code_verifier: 'v1',
+    } as any));
+    spyOn(component['fastenApi'], 'connectSource').and.returnValue(of({} as any));
+
+    await component.connectSmartSource();
+
+    expect(openSpy).toHaveBeenCalledWith('', '_blank');          // opened blank, synchronously
+    expect(fakePopup.location.href).toBe('https://provider.example/authorize?x=1'); // navigated after authorize
+    expect(component.smartSuccessMsg.toLowerCase()).toContain('connected');
+    expect(component.smartConnecting).toBeFalse();
   });
 });

--- a/frontend/src/app/pages/medical-sources/medical-sources.component.ts
+++ b/frontend/src/app/pages/medical-sources/medical-sources.component.ts
@@ -295,9 +295,22 @@ export class MedicalSourcesComponent implements OnInit {
 
     const redirectUri = `${environment.relay_endpoint_base}/callback`
 
+    // Open the login popup SYNCHRONOUSLY, inside the click handler, so the browser doesn't block
+    // it. window.open() called *after* an `await` loses the user-gesture and gets blocked — that
+    // was the flaky "no popup opened". We point this already-open window at the authorize URL once
+    // the backend returns it.
+    const popup = window.open('', '_blank')
+    if (!popup) {
+      this.smartErrorMsg = 'Your browser blocked the login popup. Please allow popups for this site, then try Connect again.'
+      return
+    }
+    try {
+      popup.document.write('<!doctype html><title>Connecting…</title><p style="font:14px sans-serif;padding:1rem">Preparing secure sign-in…</p>')
+    } catch (_) { /* ignore — popup not navigable yet */ }
+
     this.smartConnecting = true
     try {
-      // Step 3: ask backend for the PKCE authorize URL (it does SMART discovery).
+      // Ask the backend for the PKCE authorize URL (it does SMART discovery).
       const authorize: SmartAuthorizeResponse = await this.fastenApi.authorizeSource({
         api_endpoint_base_url: apiEndpoint,
         client_id: clientId,
@@ -306,13 +319,13 @@ export class MedicalSourcesComponent implements OnInit {
       }).toPromise()
 
       if (!authorize?.authorize_url || !authorize?.state || !authorize?.code_verifier) {
+        popup.close()
         this.smartErrorMsg = 'Authorization failed: the server did not return a valid authorize URL.'
-        this.smartConnecting = false
         return
       }
 
-      // Step 4: open the provider login in a popup; it redirects to our relay /callback when done.
-      window.open(authorize.authorize_url, '_blank')
+      // Send the already-open popup to the provider login; it redirects to our relay /callback.
+      popup.location.href = authorize.authorize_url
 
       // Step 5: complete the connection. The backend polls the relay for the code, exchanges it,
       // stores the source and runs the initial sync. Retry up to 3 total attempts because login


### PR DESCRIPTION
**Layer 2 of #82** — fixes the flaky "no popup opened" we hit in live testing.

## Bug
`connectSmartSource()` called `window.open(authorize.authorize_url, '_blank')` **after** `await authorizeSource(...)`. Browsers block `window.open()` that isn't synchronously inside the click handler (the user-gesture is gone after an `await`), so the login popup was silently blocked — no popup, no error, connect just hung/timed out.

## Fix
- Open a **blank popup synchronously** in the click handler (with a "Preparing sign-in…" placeholder), **before** any `await`.
- After the backend returns the authorize URL, **navigate the already-open popup** (`popup.location.href = …`).
- If the browser still blocks it (`window.open` returns `null`), show a clear **"allow popups for this site"** message instead of silently hanging — and don't even start the authorize call.

## Tests
Added two specs:
- **popup blocked** → clear error containing "popup", and `authorizeSource` is *not* called.
- **happy path** → `window.open('', '_blank')` called synchronously, then `popup.location.href` set to the authorize URL (proves we don't open *after* the await).

`ng build -c sandbox` + `medical-sources.component.spec` (3/3) pass.

Refs #82, #52, #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)