### PR TITLE
chore: untrack the accidentally-committed relay binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,8 @@ secrets.*
 /sample-data/
 /phi/
 /patient-data/
+
+# Compiled Go binaries left at the repo root by `go build ./backend/cmd/...`
+# (e.g. `go build ./backend/cmd/relay` writes ./relay). Never commit build artifacts.
+/relay
+/fasten


### PR DESCRIPTION
An **8 MB compiled `relay` Mach-O binary** was accidentally committed to the repo root in #79 (`8fb8d27c`) — `go build ./backend/cmd/relay` writes `./relay` and it got picked up during that PR.

- `git rm --cached relay` (removes it from tracking; the source stays in `backend/cmd/relay`).
- `.gitignore`: add `/relay` and `/fasten` so root-level `go build` artifacts can't be committed again.

No functional change — just repo hygiene (drops 8 MB of binary from the tree going forward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)