### PR TITLE
chore(go): upgrade toolchain to Go 1.25 (unblocks Dependabot Go bumps)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/tmp/lock,sharing=locked \
 #########################################################################################################
 # Backend Build
 #########################################################################################################
-FROM golang:1.24 as backend-build
+FROM golang:1.25 as backend-build
 
 WORKDIR /go/src/github.com/fastenhealth/fasten-onprem
 COPY . .

--- a/backend/cmd/fasten/fasten.go
+++ b/backend/cmd/fasten/fasten.go
@@ -58,7 +58,7 @@ func main() {
 
 			subtitle := packagrUrl + utils.LeftPad2Len(versionInfo, " ", 53-len(packagrUrl))
 
-			fmt.Fprintf(c.App.Writer, fmt.Sprintf(utils.StripIndent(
+			fmt.Fprint(c.App.Writer, fmt.Sprintf(utils.StripIndent(
 				`
 			  o888o                       o8                          
 			o888oo ooooooo    oooooooo8 o888oo ooooooooo8 oo oooooo   

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -64,7 +64,7 @@ func (c *configuration) ReadConfig(configFilePath string) error {
 
 	if !utils.FileExists(configFilePath) {
 		message := fmt.Sprintf("The configuration file (%s) could not be found. Skipping", configFilePath)
-		log.Printf(message)
+		log.Print(message)
 		return errors.ConfigFileMissingError("The configuration file could not be found.")
 	}
 

--- a/backend/pkg/web/handler/cors_proxy.go
+++ b/backend/pkg/web/handler/cors_proxy.go
@@ -67,7 +67,7 @@ func CORSProxy(c *gin.Context) {
 		req.Host = remote.Host
 		req.URL.Scheme = remote.Scheme
 		req.URL.Host = remote.Host
-		log.Printf(c.Param("proxyPath"))
+		log.Print(c.Param("proxyPath"))
 		req.URL.Path = remote.Path
 		req.Body = c.Request.Body
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/fastenhealth/fasten-onprem
 
-go 1.23.3
+go 1.25.0
 
-toolchain go1.24.2
+toolchain go1.25.5
 
 // fasten-sources was made private (see fastenhealth/fasten-onprem#629). Use local stub.
 replace github.com/fastenhealth/fasten-sources => ./fasten-sources-stub


### PR DESCRIPTION
## Why

The entire Dependabot Go-module backlog — #7, #8, #10, #11, #29, #30, #32, #33 — fails CI's **Test Backend** for one shared, now root-caused reason (full diagnosis on #87):

1. **Newer deps require Go 1.25.** `pgx/v5@5.9.2` and transitive `x/text@0.35.0` both `require go >= 1.25.0`, so `go mod tidy` bumps the `go` directive `1.23.3 → 1.25.0`.
2. **Go 1.25's stricter `go vet`** then flags 3 **pre-existing** `non-constant format string` issues. `make test-backend` runs `go vet ./...` before the tests, so vet failure → **Test Backend red.** They pass on `main` today only because the `go 1.23` directive uses a lenient vet.
3. **`Dockerfile` pinned `golang:1.24`** — a `1.25` directive would break the image build.

The deps themselves are fine (`go build ./backend/...` compiles cleanly). The blocker is the toolchain.

## What this does

- `go.mod`: `go 1.25.0` + `toolchain go1.25.5`
- `Dockerfile`: `FROM golang:1.25`
- Fix the 3 already-formatted strings to use `Print`/`Fprint` (not `Printf`/`Fprintf`):
  - `backend/pkg/config/config.go:67`
  - `backend/pkg/web/handler/cors_proxy.go:70`
  - `backend/cmd/fasten/fasten.go:61`

## Verified locally (Go 1.25.5)

- `go vet ./backend/...` — clean
- `go test ./backend/...` — all pass
- `CGO_ENABLED=0 go build -buildvcs=false ./backend/cmd/fasten/` — OK

## After this merges

The 8 Dependabot Go bumps should go green and merge normally (still one at a time — each `go.sum` merge re-conflicts the others).

## Follow-up (needs `workflow` scope, do in UI)

`.github/workflows/cloud-deploy.yaml` still pins `setup-go: 1.21.1`. It only builds the Angular frontend and `GOTOOLCHAIN=auto` covers the toolchain directive, so it's non-blocking — bump it to `1.25.5` in the UI when convenient.

Refs #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)