### PR TITLE
chore(go): upgrade toolchain to Go 1.26.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/tmp/lock,sharing=locked \
 #########################################################################################################
 # Backend Build
 #########################################################################################################
-FROM golang:1.25 as backend-build
+FROM golang:1.26 as backend-build
 
 WORKDIR /go/src/github.com/fastenhealth/fasten-onprem
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/fastenhealth/fasten-onprem
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.5
+toolchain go1.26.1
 
 // fasten-sources was made private (see fastenhealth/fasten-onprem#629). Use local stub.
 replace github.com/fastenhealth/fasten-sources => ./fasten-sources-stub


### PR DESCRIPTION
Follows #88 (Go 1.25). Bumps the toolchain again so dependency bumps that now require Go 1.26 can land — specifically **maroto/v2 2.4.0** (via pdfcpu 0.11.1), tracked as #32 / on #87.

## Changes
- `go.mod`: `go 1.26.0` + `toolchain go1.26.1`
- `Dockerfile`: `golang:1.26`

No other changes — this PR **isolates the toolchain bump** from the maroto dep bump that follows on top of it.

## Verified locally (go1.26.1)
- `go vet ./backend/...` — clean (no new 1.26 strictness in our code, unlike the 1.25 jump which needed format-string fixes)
- `go test ./backend/...` — all pass
- `CGO_ENABLED=0 go build -buildvcs=false ./backend/cmd/fasten/` — OK

## Next
A follow-up PR bumps maroto/v2 2.4.0 and regenerates the 15 IPS-PDF golden fixtures (maroto changed `prop_border_type` `"1"`→`15`; PDFs are unchanged). That lands #32.

Refs #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)