### PR TITLE
chore(deps): bump jose 4.11.2 → 6.2.3 (frontend, auth security)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,7 +50,7 @@
     "gridstack": "8.1.1",
     "humanize-duration": "^3.27.3",
     "idb": "^7.1.0",
-    "jose": "^4.10.4",
+    "jose": "6.2.3",
     "lforms": "34.0.0",
     "moment": "^2.29.4",
     "ng2-charts": "6",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9143,12 +9143,7 @@ jiti@^1.20.0:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.7.tgz#9dd81043424a3d28458b193d965f0d18a2300ba9"
   integrity sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==
 
-jose@^4.10.4:
-  version "4.11.2"
-  resolved "https://registry.npmjs.org/jose/-/jose-4.11.2.tgz#d9699307c02e18ff56825843ba90e2fae9f09e23"
-  integrity sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A==
-
-jose@^6.1.3:
+jose@6.2.3, jose@^6.1.3:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/jose/-/jose-6.2.3.tgz#0975197ad973251221c658a3cddc4b951a250c2d"
   integrity sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==


### PR DESCRIPTION
Lands the major `jose` bump tracked in **#98** / Dependabot **#34**. `jose` is the only JOSE/token library on the frontend and was on the old 4.x line.

## Migration impact: none
The only jose API the app uses is **`jose.decodeJwt()`** (`auth.service.ts`, ×2), whose signature `decodeJwt(jwt: string): JWTPayload` is **unchanged across v4 → v6**. No code changes required.

## The real risk (ESM-only v5+) — verified
A major jose bump's actual risk is the ESM-only v5+ build under the Angular 14 toolchain. Verified locally (Node 24 / yarn 1.22):
- `auth.service.spec.ts` passes (exercises `decodeJwt`)
- full `ng build --configuration sandbox` completes with **no resolution errors** (jose v6 routes the browser to its `webapi` build cleanly)

CI's full **Test Frontend** is the final gate.

Closes #98. Supersedes #34. Refs #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)