### PR TITLE
fix(relay): bump Dockerfile.relay to golang:1.26 (regression from #92)

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -2,7 +2,7 @@
 # A tiny static Go service (pure stdlib); see backend/cmd/relay and
 # docs/planning/smart-on-fhir/oauth-gateway.md.
 
-FROM golang:1.24 as build
+FROM golang:1.26 as build
 WORKDIR /src
 COPY . .
 RUN CGO_ENABLED=0 go build -buildvcs=false -o /relay ./backend/cmd/relay


### PR DESCRIPTION
The Go 1.26 toolchain upgrade (#92) set go.mod to `go 1.26.1` + bumped the main Dockerfile, but `Dockerfile.relay` still pinned `golang:1.24` — so the **Docker (YourPHR relay)** workflow has failed on *every* push to main since (`go build ./backend/cmd/relay` exits 1: base toolchain older than the go.mod directive).

Bumps `Dockerfile.relay` → `golang:1.26`. Relay binary builds clean locally at 1.26.

> Note: `docker-relay.yaml` only triggers on push to `main`, so this verifies post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)