### PR TITLE
feat(security): add security response headers middleware (#105, H4)

### DIFF
--- a/backend/pkg/web/middleware/security_headers.go
+++ b/backend/pkg/web/middleware/security_headers.go
@@ -1,0 +1,40 @@
+package middleware
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// SecurityHeadersMiddleware sets baseline security response headers (issue #105 / H4).
+//
+// The Content-Security-Policy is sent in REPORT-ONLY mode to start: browsers report
+// violations (to the console) without blocking, so we can observe and tighten without
+// risking the Angular SPA. Flip Content-Security-Policy-Report-Only to
+// Content-Security-Policy once the policy is verified clean. A strict CSP also shrinks
+// the XSS surface for the localStorage-stored token (issue #103 / H2).
+//
+// HSTS is only emitted when HTTPS is enabled (it's meaningless/inappropriate over plain HTTP).
+func SecurityHeadersMiddleware(httpsEnabled bool) gin.HandlerFunc {
+	const cspReportOnly = "default-src 'self'; " +
+		"script-src 'self'; " +
+		"style-src 'self' 'unsafe-inline'; " +
+		"img-src 'self' data:; " +
+		"font-src 'self' data:; " +
+		"connect-src 'self'; " +
+		"object-src 'none'; " +
+		"frame-ancestors 'none'; " +
+		"base-uri 'self'; " +
+		"form-action 'self'"
+
+	return func(c *gin.Context) {
+		h := c.Writer.Header()
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("X-Frame-Options", "DENY")
+		h.Set("Referrer-Policy", "no-referrer")
+		h.Set("Content-Security-Policy-Report-Only", cspReportOnly)
+		if httpsEnabled {
+			// HTTPS is on by default (web.listen.https.enabled). 1 year, include subdomains.
+			h.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		}
+		c.Next()
+	}
+}

--- a/backend/pkg/web/middleware/security_headers_test.go
+++ b/backend/pkg/web/middleware/security_headers_test.go
@@ -1,0 +1,43 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func newSecurityHeadersEngine(httpsEnabled bool) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(SecurityHeadersMiddleware(httpsEnabled))
+	r.GET("/", func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+	return r
+}
+
+func Test_SecurityHeadersMiddleware(t *testing.T) {
+	w := httptest.NewRecorder()
+	newSecurityHeadersEngine(true).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	require.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+	require.Equal(t, "DENY", w.Header().Get("X-Frame-Options"))
+	require.Equal(t, "no-referrer", w.Header().Get("Referrer-Policy"))
+	require.Contains(t, w.Header().Get("Content-Security-Policy-Report-Only"), "default-src 'self'")
+	require.Contains(t, w.Header().Get("Content-Security-Policy-Report-Only"), "frame-ancestors 'none'")
+	//enforcing CSP must NOT be set yet (report-only only)
+	require.Empty(t, w.Header().Get("Content-Security-Policy"))
+	//HSTS present when HTTPS enabled
+	require.Equal(t, "max-age=31536000; includeSubDomains", w.Header().Get("Strict-Transport-Security"))
+}
+
+func Test_SecurityHeadersMiddleware_NoHSTSWithoutHTTPS(t *testing.T) {
+	w := httptest.NewRecorder()
+	newSecurityHeadersEngine(false).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	//HSTS must be omitted over plain HTTP
+	require.Empty(t, w.Header().Get("Strict-Transport-Security"))
+	//other headers still present
+	require.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+}

--- a/backend/pkg/web/server.go
+++ b/backend/pkg/web/server.go
@@ -68,6 +68,9 @@ func (ae *AppEngine) Reinitialize() error {
 func (ae *AppEngine) Setup() (*gin.RouterGroup, *gin.Engine) {
 	r := gin.New()
 
+	// Security response headers on every response (#105 / H4). First, so it covers the SPA + API.
+	r.Use(middleware.SecurityHeadersMiddleware(ae.Config.GetBool("web.listen.https.enabled")))
+
 	if !ae.StandbyMode {
 		r.Use(middleware.RepositoryMiddleware(ae.deviceRepo))
 	}


### PR DESCRIPTION
Closes **#105** (High / H4). No security response headers were set anywhere in the backend. Adds `SecurityHeadersMiddleware`, registered **first** in `Setup()` so it covers both the SPA and the API.

## Headers
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY` (clickjacking — a PHR shouldn't be framed)
- `Referrer-Policy: no-referrer` (don't leak URLs)
- `Strict-Transport-Security: max-age=31536000; includeSubDomains` — **only when HTTPS is enabled**
- `Content-Security-Policy-Report-Only` — strict baseline (`default-src 'self'`, `frame-ancestors 'none'`, `object-src 'none'`, …)

## Why CSP is report-only (for now)
Per the review's recommendation: ship CSP **report-only** so browsers report violations without blocking — we observe, confirm the Angular SPA is clean, then flip to enforcing `Content-Security-Policy`. A strict CSP also shrinks the XSS surface for the `localStorage` token (**#103 / H2**), so this lands part of that mitigation too.

## Verified
- Middleware unit tests: headers present; HSTS gated on HTTPS; enforcing CSP not set yet.
- Full backend build + `web` suite green.

Refs the architecture/security review finding H4 (#106).

🤖 Generated with [Claude Code](https://claude.com/claude-code)