### PR TITLE
fix(auth): stop username enumeration + rate-limit auth endpoints (#104, H3)

### DIFF
--- a/backend/pkg/web/handler/auth.go
+++ b/backend/pkg/web/handler/auth.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/fastenhealth/fasten-onprem/backend/pkg"
@@ -85,15 +84,16 @@ func AuthSignin(c *gin.Context) {
 		return
 	}
 
+	// Return an identical generic response for "unknown user" and "wrong password",
+	// and never echo the attempted username, to prevent username enumeration (#104 / H3).
 	foundUser, err := databaseRepo.GetUserByUsername(c, user.Username)
 	if err != nil || foundUser == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": fmt.Sprintf("could not find user: %s", user.Username)})
+		c.JSON(http.StatusUnauthorized, gin.H{"success": false, "error": "invalid username or password"})
 		return
 	}
 
-	err = foundUser.CheckPassword(user.Password)
-	if err != nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"success": false, "error": fmt.Sprintf("username or password does not match: %s", user.Username)})
+	if err = foundUser.CheckPassword(user.Password); err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"success": false, "error": "invalid username or password"})
 		return
 	}
 

--- a/backend/pkg/web/middleware/rate_limit.go
+++ b/backend/pkg/web/middleware/rate_limit.go
@@ -1,0 +1,63 @@
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type rateLimitEntry struct {
+	count       int
+	windowStart time.Time
+}
+
+// RateLimitMiddleware throttles requests per client IP using a fixed window, to blunt
+// online password guessing against the auth endpoints (#104 / H3). It's a brute-force
+// backstop, not a precise limiter — bcrypt already slows each attempt; this caps how
+// many an IP can make per window, and effectively locks that IP out for the remainder
+// of the window once exceeded (HTTP 429 + Retry-After).
+//
+// No background goroutine (safe to construct on every Setup()/Reinitialize()); memory
+// is bounded by opportunistic sweeping of expired entries.
+//
+// NOTE: the client IP comes from gin's c.ClientIP(), which honors X-Forwarded-For.
+// Behind a reverse proxy, configure trusted proxies, or all clients may share the
+// proxy's IP (and thus one bucket).
+func RateLimitMiddleware(maxRequests int, window time.Duration) gin.HandlerFunc {
+	var mu sync.Mutex
+	entries := make(map[string]*rateLimitEntry)
+
+	return func(c *gin.Context) {
+		ip := c.ClientIP()
+		now := time.Now()
+
+		mu.Lock()
+		e := entries[ip]
+		if e == nil || now.Sub(e.windowStart) >= window {
+			e = &rateLimitEntry{windowStart: now}
+			entries[ip] = e
+		}
+		e.count++
+		over := e.count > maxRequests
+		// Opportunistic cleanup so the map can't grow without bound.
+		if len(entries) > 1024 {
+			for k, v := range entries {
+				if now.Sub(v.windowStart) >= window {
+					delete(entries, k)
+				}
+			}
+		}
+		mu.Unlock()
+
+		if over {
+			c.Header("Retry-After", strconv.Itoa(int(window.Seconds())))
+			c.JSON(http.StatusTooManyRequests, gin.H{"success": false, "error": "too many requests, please try again later"})
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}

--- a/backend/pkg/web/middleware/rate_limit_test.go
+++ b/backend/pkg/web/middleware/rate_limit_test.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_RateLimitMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(RateLimitMiddleware(2, time.Minute))
+	r.GET("/", func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+
+	do := func(ip string) (int, string) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = ip + ":1111"
+		r.ServeHTTP(w, req)
+		return w.Code, w.Header().Get("Retry-After")
+	}
+
+	// first two requests from an IP are allowed, the third is throttled
+	code, _ := do("203.0.113.5")
+	require.Equal(t, http.StatusOK, code)
+	code, _ = do("203.0.113.5")
+	require.Equal(t, http.StatusOK, code)
+	code, retryAfter := do("203.0.113.5")
+	require.Equal(t, http.StatusTooManyRequests, code)
+	require.NotEmpty(t, retryAfter, "429 should advertise Retry-After")
+
+	// a different IP has its own independent bucket
+	code, _ = do("198.51.100.9")
+	require.Equal(t, http.StatusOK, code)
+}

--- a/backend/pkg/web/server.go
+++ b/backend/pkg/web/server.go
@@ -146,8 +146,13 @@ func (ae *AppEngine) Setup() (*gin.RouterGroup, *gin.Engine) {
 
 			if !ae.StandbyMode { // Check ae.StandbyMode for non-standby mode
 				api.Use(middleware.CacheMiddleware())
-				api.POST("/auth/signup", handler.AuthSignup)
-				api.POST("/auth/signin", handler.AuthSignin)
+
+				// Rate-limit the unauthenticated auth endpoints to blunt online
+				// password guessing / account spraying (#104 / H3).
+				authGroup := api.Group("/auth")
+				authGroup.Use(middleware.RateLimitMiddleware(10, time.Minute))
+				authGroup.POST("/signup", handler.AuthSignup)
+				authGroup.POST("/signin", handler.AuthSignin)
 
 				//whitelisted CORS PROXY
 				api.GET("/cors/:endpointId/*proxyPath", handler.CORSProxy)


### PR DESCRIPTION
Closes **#104** (High / H3). Two hardening fixes on the unauthenticated auth surface.

## 1. Username enumeration
`AuthSignin` returned **different** responses for the two failure modes and **echoed the username**:
- unknown user → `500 "could not find user: X"`
- wrong password → `401 "username or password does not match: X"`

Both now return an identical generic **`401 {"error":"invalid username or password"}`** and never echo the attempted username.

## 2. No throttling → rate limiting
Adds `RateLimitMiddleware` (fixed-window, **per client IP**) on the `/auth` group (signin + signup) — a brute-force backstop on top of bcrypt cost 14. Over the limit returns **`429` + `Retry-After`**, effectively locking that IP out for the rest of the window. Default **10/min**.
- **No background goroutine** (safe to construct on every `Setup()`/`Reinitialize()`); memory bounded by opportunistic sweep.
- **Proxy note:** `c.ClientIP()` honors `X-Forwarded-For` — configure trusted proxies behind a reverse proxy so clients don't share one bucket.

## Verified
- Rate-limit unit test: allow N, then `429` + `Retry-After`, independent buckets per IP.
- `go vet` clean; full `go test ./backend/...` green. (`auth_test.go` doesn't assert the old messages, so unaffected.)

Refs the architecture/security review finding H3 (#106).

🤖 Generated with [Claude Code](https://claude.com/claude-code)