### PR TITLE
feat(auth): session-cookie fallback (header-primary) — Phase 1 of #103 (H2)

### DIFF
--- a/backend/pkg/constants.go
+++ b/backend/pkg/constants.go
@@ -26,6 +26,11 @@ const (
 	ContextKeyTypeAuthToken       string = "AUTH_TOKEN"
 	ContextKeyTypeBackgroundJobID string = "BACKGROUND_JOB_ID"
 
+	// SessionCookieName is the HttpOnly/Secure/SameSite cookie that carries YourPHR's
+	// own session JWT for browser clients. The Authorization: Bearer header remains the
+	// primary transport (RFC 6750 / SMART); this cookie is an optional fallback (#103).
+	SessionCookieName string = "fasten_session"
+
 	FhirResourceTypeComposition string = "Composition"
 
 	ResourceGraphTypeMedicalHistory ResourceGraphType = "MedicalHistory"

--- a/backend/pkg/web/handler/auth.go
+++ b/backend/pkg/web/handler/auth.go
@@ -71,6 +71,7 @@ func AuthSignup(c *gin.Context) {
 		utils.JoinNewsletter(userWizard.FullName, userWizard.Email, "", "")
 	}
 
+	setSessionCookie(c, appConfig, userFastenToken)
 	c.JSON(http.StatusOK, gin.H{"success": true, "data": userFastenToken})
 }
 
@@ -104,5 +105,26 @@ func AuthSignin(c *gin.Context) {
 		return
 	}
 
+	setSessionCookie(c, appConfig, userFastenToken)
 	c.JSON(http.StatusOK, gin.H{"success": true, "data": userFastenToken})
+}
+
+// setSessionCookie stores the session JWT as an HttpOnly/Secure/SameSite=Strict cookie for
+// browser clients (#103 / H2). The Authorization: Bearer header remains the primary transport
+// (RFC 6750 / SMART); this cookie is an optional fallback that keeps the token out of JS to
+// shrink the XSS-theft surface. Secure is gated on HTTPS so local http dev still works;
+// SameSite=Strict mitigates CSRF. Max-age matches the 1h token lifetime.
+func setSessionCookie(c *gin.Context, appConfig config.Interface, token string) {
+	c.SetSameSite(http.SameSiteStrictMode)
+	c.SetCookie(pkg.SessionCookieName, token, 3600, "/", "", appConfig.GetBool("web.listen.https.enabled"), true)
+}
+
+// AuthLogout clears the session cookie. The session JWT is otherwise stateless, and an
+// HttpOnly cookie can't be cleared from JavaScript, so this endpoint is what lets a browser
+// fully sign out (the SPA calls it in addition to dropping its localStorage token) (#103).
+func AuthLogout(c *gin.Context) {
+	appConfig := c.MustGet(pkg.ContextKeyTypeConfig).(config.Interface)
+	c.SetSameSite(http.SameSiteStrictMode)
+	c.SetCookie(pkg.SessionCookieName, "", -1, "/", "", appConfig.GetBool("web.listen.https.enabled"), true)
+	c.JSON(http.StatusOK, gin.H{"success": true})
 }

--- a/backend/pkg/web/handler/auth_test.go
+++ b/backend/pkg/web/handler/auth_test.go
@@ -32,6 +32,7 @@ func TestAuthSignup(t *testing.T) {
 			assert.Equal(t, pkg.UserRoleAdmin, user.Role)
 		}).Return(nil)
 		mockConfig.EXPECT().GetString("jwt.issuer.key").Return("test_key")
+		mockConfig.EXPECT().GetBool("web.listen.https.enabled").Return(false) // setSessionCookie (#103)
 
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
@@ -66,6 +67,7 @@ func TestAuthSignup(t *testing.T) {
 			assert.Equal(t, pkg.UserRoleUser, user.Role)
 		}).Return(nil)
 		mockConfig.EXPECT().GetString("jwt.issuer.key").Return("test_key")
+		mockConfig.EXPECT().GetBool("web.listen.https.enabled").Return(false) // setSessionCookie (#103)
 
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)

--- a/backend/pkg/web/middleware/require_auth.go
+++ b/backend/pkg/web/middleware/require_auth.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"log"
 	"net/http"
 	"strings"
 
@@ -16,20 +15,24 @@ func RequireAuth() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		appConfig := c.MustGet(pkg.ContextKeyTypeConfig).(config.Interface)
 
-		authHeader := c.GetHeader("Authorization")
-		authHeaderParts := strings.Split(authHeader, " ")
-
-		if len(authHeaderParts) != 2 {
-			log.Println("Authentication header is invalid: " + authHeader)
-			c.JSON(http.StatusUnauthorized, gin.H{"success": false, "error": "request does not contain a valid token"})
-			c.Abort()
-			return
+		// Token transport: Authorization: Bearer is primary (RFC 6750 / SMART App Launch);
+		// fall back to the HttpOnly session cookie for browser clients. The header wins if
+		// both are present, so non-browser/desktop/CLI clients are unaffected (#103 / H2).
+		tokenString := ""
+		if authHeader := c.GetHeader("Authorization"); authHeader != "" {
+			parts := strings.Split(authHeader, " ")
+			if len(parts) == 2 && strings.EqualFold(parts[0], "Bearer") {
+				tokenString = parts[1]
+			}
+		}
+		if tokenString == "" {
+			if cookieVal, err := c.Cookie(pkg.SessionCookieName); err == nil {
+				tokenString = cookieVal
+			}
 		}
 
-		tokenString := authHeaderParts[1]
-
 		if tokenString == "" {
-			c.JSON(http.StatusUnauthorized, gin.H{"success": false, "error": "request does not contain an access token"})
+			c.JSON(http.StatusUnauthorized, gin.H{"success": false, "error": "request does not contain a valid token"})
 			c.Abort()
 			return
 		}

--- a/backend/pkg/web/middleware/require_auth_test.go
+++ b/backend/pkg/web/middleware/require_auth_test.go
@@ -1,0 +1,68 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fastenhealth/fasten-onprem/backend/pkg"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/auth"
+	mock_config "github.com/fastenhealth/fasten-onprem/backend/pkg/config/mock"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/models"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/web/middleware"
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+const testJWTKey = "test_signing_key"
+
+func tokenFor(t *testing.T, username string) string {
+	t.Helper()
+	tok, err := auth.JwtGenerateFastenTokenFromUser(models.User{Username: username}, testJWTKey)
+	require.NoError(t, err)
+	return tok
+}
+
+func runRequireAuth(t *testing.T, build func(req *http.Request)) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+	mockConfig := mock_config.NewMockInterface(ctrl)
+	mockConfig.EXPECT().GetString("jwt.issuer.key").Return(testJWTKey).AnyTimes()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(pkg.ContextKeyTypeConfig, mockConfig)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/secure/x", nil)
+	build(c.Request)
+
+	middleware.RequireAuth()(c)
+	return c, w
+}
+
+// Cookie fallback: when there's no Authorization header, the HttpOnly session cookie is accepted (#103).
+func TestRequireAuth_CookieFallback(t *testing.T) {
+	c, _ := runRequireAuth(t, func(req *http.Request) {
+		req.AddCookie(&http.Cookie{Name: pkg.SessionCookieName, Value: tokenFor(t, "alice")})
+	})
+	require.False(t, c.IsAborted(), "a valid cookie token should be accepted")
+	require.Equal(t, "alice", c.GetString(pkg.ContextKeyTypeAuthUsername))
+}
+
+// The Authorization header is primary: it wins even if a (different) cookie is also present (RFC 6750).
+func TestRequireAuth_HeaderWinsOverCookie(t *testing.T) {
+	c, _ := runRequireAuth(t, func(req *http.Request) {
+		req.Header.Set("Authorization", "Bearer "+tokenFor(t, "bob"))
+		req.AddCookie(&http.Cookie{Name: pkg.SessionCookieName, Value: tokenFor(t, "alice")})
+	})
+	require.False(t, c.IsAborted())
+	require.Equal(t, "bob", c.GetString(pkg.ContextKeyTypeAuthUsername), "header token must take precedence")
+}
+
+// No header and no cookie → 401.
+func TestRequireAuth_NoToken(t *testing.T) {
+	c, w := runRequireAuth(t, func(req *http.Request) {})
+	require.True(t, c.IsAborted())
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/backend/pkg/web/server.go
+++ b/backend/pkg/web/server.go
@@ -157,6 +157,7 @@ func (ae *AppEngine) Setup() (*gin.RouterGroup, *gin.Engine) {
 				authGroup.Use(middleware.RateLimitMiddleware(10, time.Minute))
 				authGroup.POST("/signup", handler.AuthSignup)
 				authGroup.POST("/signin", handler.AuthSignin)
+				authGroup.POST("/logout", handler.AuthLogout) // clears the session cookie (#103)
 
 				//whitelisted CORS PROXY
 				api.GET("/cors/:endpointId/*proxyPath", handler.CORSProxy)

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -202,6 +202,14 @@ export class AuthService {
 
   public async Logout(): Promise<any> {
     this.publishAuthenticationState(false)
+    // Clear the HttpOnly session cookie server-side — it can't be cleared from JS (#103).
+    // Best-effort: never let a failed request block sign-out.
+    try {
+      const fastenApiEndpointBase = GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)
+      await this._httpClient.post<ResponseWrapper>(`${fastenApiEndpointBase}/auth/logout`, {}).toPromise()
+    } catch (e) {
+      // ignore — still clear the local token below
+    }
     return localStorage.removeItem(this.FASTEN_JWT_LOCALSTORAGE_KEY)
     // // let remotePouchDb = new PouchDB(this.getRemoteUserDb(localStorage.getItem("current_user")), {skip_setup: true});
     // if(this.pouchDb){


### PR DESCRIPTION
**Phase 1** of moving the session token off `localStorage` (#103 / H2), done the backward-compatible, standard-aligned way decided on the issue: the **`Authorization: Bearer` header stays primary** (RFC 6750 / SMART App Launch); an `HttpOnly`/`Secure`/`SameSite=Strict` cookie is added as an **optional fallback** for browsers. **Header wins if both are present**, so desktop/CLI/non-browser clients are unaffected.

## Backend
- `pkg.SessionCookieName` (`fasten_session`), shared by handler + middleware.
- `RequireAuth`: token from the `Authorization` header **first**, then cookie fallback.
- `AuthSignin`/`AuthSignup`: also set the cookie — `HttpOnly`; `Secure` gated on HTTPS (local http dev still works); `SameSite=Strict` (CSRF); 1h max-age (matches the token). Body still returns the token for header clients.
- **`POST /auth/logout`** (`AuthLogout`): clears the cookie. An `HttpOnly` cookie can't be cleared from JS, so a server endpoint is required for a full browser sign-out — otherwise the cookie fallback would keep a "logged-out" browser authenticated.

## Frontend
- `auth.service Logout()` now calls `POST /auth/logout` (best-effort) before clearing `localStorage`, so the cookie is actually cleared.

## Scope (what this is NOT)
It does **not** yet switch the SPA to *rely* on the cookie (drop `localStorage`, use `/secure/account/me` for current-user, `credentials:'include'` for SSE) — that's a later phase per the plan recorded on #103. This phase is purely the safe, reversible groundwork.

## Verified
- New `RequireAuth` tests: cookie fallback, **header-wins-over-cookie**, no-token→401.
- `auth_test.go` updated for the new `GetBool` call; full `go test ./backend/...` green.
- `auth.service.spec` green.

Refs #103 (H2). Part of the #106 security review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)