### PR TITLE
feat(security): enforce CSP (externalize index.html inline scripts)

### DIFF
--- a/backend/pkg/web/middleware/security_headers.go
+++ b/backend/pkg/web/middleware/security_headers.go
@@ -6,20 +6,25 @@ import (
 
 // SecurityHeadersMiddleware sets baseline security response headers (issue #105 / H4).
 //
-// The Content-Security-Policy is sent in REPORT-ONLY mode to start: browsers report
-// violations (to the console) without blocking, so we can observe and tighten without
-// risking the Angular SPA. Flip Content-Security-Policy-Report-Only to
-// Content-Security-Policy once the policy is verified clean. A strict CSP also shrinks
-// the XSS surface for the localStorage-stored token (issue #103 / H2).
+// The Content-Security-Policy is now ENFORCING. script-src 'self' (no 'unsafe-inline',
+// no nonce) is the key XSS defense and the main mitigation for the localStorage-stored
+// session token (#103 / H2); the index.html bootstrap scripts were externalized so this
+// is safe. Notes on the directives:
+//   - style-src allows 'unsafe-inline' (Angular emits inline component styles).
+//   - img-src allows https: so externally-referenced images in imported FHIR records
+//     still render (images don't execute, so the XSS risk is negligible).
+//   - connect-src allows the hello.coop origins for the IdpConnect (third-party) login;
+//     everything else (backend API, SSE, the SMART flow) is same-origin. SMART provider
+//     auth happens via top-level navigation/backend, not browser fetch.
 //
 // HSTS is only emitted when HTTPS is enabled (it's meaningless/inappropriate over plain HTTP).
 func SecurityHeadersMiddleware(httpsEnabled bool) gin.HandlerFunc {
-	const cspReportOnly = "default-src 'self'; " +
+	const csp = "default-src 'self'; " +
 		"script-src 'self'; " +
 		"style-src 'self' 'unsafe-inline'; " +
-		"img-src 'self' data:; " +
+		"img-src 'self' data: https:; " +
 		"font-src 'self' data:; " +
-		"connect-src 'self'; " +
+		"connect-src 'self' https://wallet.hello.coop https://issuer.hello.coop; " +
 		"object-src 'none'; " +
 		"frame-ancestors 'none'; " +
 		"base-uri 'self'; " +
@@ -30,7 +35,7 @@ func SecurityHeadersMiddleware(httpsEnabled bool) gin.HandlerFunc {
 		h.Set("X-Content-Type-Options", "nosniff")
 		h.Set("X-Frame-Options", "DENY")
 		h.Set("Referrer-Policy", "no-referrer")
-		h.Set("Content-Security-Policy-Report-Only", cspReportOnly)
+		h.Set("Content-Security-Policy", csp)
 		if httpsEnabled {
 			// HTTPS is on by default (web.listen.https.enabled). 1 year, include subdomains.
 			h.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")

--- a/backend/pkg/web/middleware/security_headers_test.go
+++ b/backend/pkg/web/middleware/security_headers_test.go
@@ -24,10 +24,12 @@ func Test_SecurityHeadersMiddleware(t *testing.T) {
 	require.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
 	require.Equal(t, "DENY", w.Header().Get("X-Frame-Options"))
 	require.Equal(t, "no-referrer", w.Header().Get("Referrer-Policy"))
-	require.Contains(t, w.Header().Get("Content-Security-Policy-Report-Only"), "default-src 'self'")
-	require.Contains(t, w.Header().Get("Content-Security-Policy-Report-Only"), "frame-ancestors 'none'")
-	//enforcing CSP must NOT be set yet (report-only only)
-	require.Empty(t, w.Header().Get("Content-Security-Policy"))
+	//CSP is now enforcing (not report-only)
+	csp := w.Header().Get("Content-Security-Policy")
+	require.Contains(t, csp, "default-src 'self'")
+	require.Contains(t, csp, "script-src 'self'")
+	require.Contains(t, csp, "frame-ancestors 'none'")
+	require.Empty(t, w.Header().Get("Content-Security-Policy-Report-Only"), "should be enforcing, not report-only")
 	//HSTS present when HTTPS enabled
 	require.Equal(t, "max-age=31536000; includeSubDomains", w.Header().Get("Strict-Transport-Security"))
 }

--- a/frontend/src/assets/js/base-href.js
+++ b/frontend/src/assets/js/base-href.js
@@ -1,0 +1,19 @@
+// Externalized from index.html so a strict CSP can use script-src 'self' with no
+// 'unsafe-inline' (#105/#103). Must stay a parser-blocking <script src> in <head>
+// (no defer/async) so document.write runs during parse, before Angular reads <base>.
+(function () {
+  var baseHref = "/";
+
+  // if the pathname includes /web, everything before `/web` (and including web) should be set as the base path.
+  if (window.location.pathname.includes('/web')) {
+    baseHref = "/web/";
+    // probably running locally, and *may* include a subpath
+    var subPath = window.location.pathname.split('/web').slice(0, 1)[0];
+    if (subPath != "/") {
+      // subpath, so we need to update the absolutePath with the subpath before adding the relative path to the end
+      baseHref = subPath + '/web/';
+    }
+  }
+
+  document.write('<base href="' + baseHref + '"/>');
+})();

--- a/frontend/src/assets/js/lforms-guard.js
+++ b/frontend/src/assets/js/lforms-guard.js
@@ -1,0 +1,8 @@
+// Externalized from index.html so a strict CSP can use script-src 'self' (#105/#103).
+// Must stay a parser-blocking <script src> at the same position, immediately before the
+// "closing marker" HTML comment in index.html: if the browser lacks Custom Elements,
+// document.write('<!--') opens a comment that the following marker closes, disabling the
+// lforms web-component loader. (lhncbc/lforms requirement.)
+if (!window.customElements) {
+  document.write('<!--');
+}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -18,30 +18,12 @@
   <title>YourPHR</title>
   <link href="./assets/lforms/styles.css" rel="stylesheet">
   <script src="./assets/js/asmcrypto-2.3.2.all.es5.min.js"></script>
-  <script>
-    var baseHref = "/"
-
-    // if the pathname includes /web, everthing before `/web` (and including web) should be set as the base path.
-    if(window.location.pathname.includes('/web')){
-      baseHref = "/web/"
-      // probably running locally, and *may* include a subpath
-      var subPath = window.location.pathname.split('/web').slice(0, 1)[0]
-      if(subPath != "/"){
-        //subpath, so we need to update the absolutePath with the subpath before adding the relative path to the end
-        baseHref = subPath + '/web/'
-      }
-    }
-
-    document.write(`<base href="${baseHref}"/>`);  </script>
+  <script src="./assets/js/base-href.js"></script>
 
   <!-- required for lhncbc/lforms -->
   <script src="./assets/js/webcomponents/webcomponents-loader.js"></script>
 
-  <script>
-    if (!window.customElements) {
-      document.write('<!--');
-    }
-  </script>
+  <script src="./assets/js/lforms-guard.js"></script>
   <!-- ! DO NOT REMOVE THIS COMMENT, WE NEED ITS CLOSING MARKER -->
 </head>
 <body>


### PR DESCRIPTION
Fast-follow on #105: flips `Content-Security-Policy` from **report-only → enforcing**.

## The blocker (now fixed)
`index.html` had **two inline `<script>` blocks** (the `base-href` bootstrap + the lforms web-components guard) that enforcing `script-src 'self'` would block, breaking the app. Externalized both into `src/assets/js/{base-href,lforms-guard}.js`, kept as **parser-blocking `<script src>` in the same positions** so their `document.write` still runs during parse. Verified the built `index.html` has **no remaining inline scripts** and the files are copied to `dist/assets/js/`.

## CSP changes
- `…-Report-Only` → `Content-Security-Policy` (enforcing).
- `script-src 'self'` — no `'unsafe-inline'`/`'unsafe-eval'`. The key XSS defense and the main mitigation for the localStorage session token (#103). Build is **AOT** and the main bundle is **eval-free**, so no `'unsafe-eval'` needed.
- `connect-src` adds `https://wallet.hello.coop https://issuer.hello.coop` for **IdpConnect** (client-side `oauth4webapi` token exchange); everything else is same-origin (backend API, SSE; SMART provider auth is navigation/backend, not browser fetch).
- `img-src` adds `https:` so externally-referenced images in imported FHIR records still render (images don't execute → negligible XSS risk).

## Residual risk + rollback
We never collected report-only violation data from a live instance, so **after deploy, watch the browser console for CSP violations** — especially the **lforms questionnaire** feature and the **IdpConnect** flow. **Rollback is a one-liner**: set the header name back to `Content-Security-Policy-Report-Only`.

## Verified
- Externalized scripts present in built `index.html`; no inline scripts remain; `ng build` clean.
- AOT build, main bundle eval-free (no `unsafe-eval` needed).
- Security-headers test updated (enforcing set, report-only empty); full `go test ./backend/...` green.

Refs #105, #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)