### PR TITLE
ci: skip heavy workflows on docs-only changes (paths-ignore)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,11 @@ name: CI
 on:
   push:
     branches: [ main, beta ]
+    # Docs-only pushes don't need the test suite + coverage upload (this calls development.yaml).
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
     # Publish semver tags as releases.
   release:
     types: [published]

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -7,6 +7,11 @@ on:
       - edited
       - synchronize
       - reopened
+    # Docs-only PRs don't need the Go/Angular test suite. (A mixed code+docs PR still runs.)
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
   workflow_call:
 
 jobs:

--- a/.github/workflows/docker-jwilleke.yaml
+++ b/.github/workflows/docker-jwilleke.yaml
@@ -8,6 +8,11 @@ name: Docker (YourPHR)
 on:
   push:
     branches: [main]
+    # Docs-only pushes don't change the image — skip the build/push (and the Flux redeploy).
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Docs-only changes were running the full Go/Angular test suite and even rebuilding + redeploying the app image. Add `paths-ignore` so docs skip them.

| Workflow | Trigger | Change |
|---|---|---|
| `development.yaml` | `pull_request` | skip docs PRs (full test suite) |
| `ci.yaml` | `push: [main, beta]` | skip docs pushes (it calls the test suite + coverage) |
| `docker-jwilleke.yaml` | `push: [main]` | skip docs pushes (image build/push → Flux redeploy) |

Globs: `**/*.md`, `docs/**`, `LICENSE`. **Mixed code+docs changes still run** (paths-ignore only skips when *all* changed files match). Mirrors `docker-relay.yaml`, which already path-filters.

`release-please.yaml` is `workflow_dispatch`-only → no filter needed. Safe because `main` has **no required status checks**, so a skipped workflow doesn't leave a stuck "pending" check (note: if required checks are ever added, path-ignored required checks need the "stub job" pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)