### PR TITLE
feat(auth): current user/role from /me instead of decoding the JWT (#117, #103 Phase 2a)

### DIFF
--- a/frontend/src/app/components/header/header.component.spec.ts
+++ b/frontend/src/app/components/header/header.component.spec.ts
@@ -8,7 +8,6 @@ import { IconsModule } from 'src/app/icon-module';
 import { HTTP_CLIENT_TOKEN } from '../../dependency-injection';
 import { AuthService } from '../../services/auth.service';
 import { HeaderComponent } from './header.component';
-import { of } from 'rxjs';
 import { UserRegisteredClaims } from '../../models/fasten/user-registered-claims';
 
 describe('HeaderComponent', () => {
@@ -20,8 +19,9 @@ describe('HeaderComponent', () => {
     mockedAuthService = jasmine.createSpyObj(
       'AuthService',
       {
-        'getCurrentUser': of(new UserRegisteredClaims()),
-        'IsAdmin': of(false)
+        // GetCurrentUser/IsAdmin are now async (resolve from /me, #103 Phase 2a)
+        'GetCurrentUser': Promise.resolve(new UserRegisteredClaims()),
+        'IsAdmin': Promise.resolve(false)
       }
     )
     TestBed.configureTestingModule({

--- a/frontend/src/app/components/header/header.component.ts
+++ b/frontend/src/app/components/header/header.component.ts
@@ -19,7 +19,8 @@ import {ThemeService} from '../../theme.service';
     standalone: false
 })
 export class HeaderComponent implements OnInit, OnDestroy {
-  current_user_claims: UserRegisteredClaims
+  // default to an empty object so the template renders before the async /me resolves (#103 Phase 2a)
+  current_user_claims: UserRegisteredClaims = new UserRegisteredClaims()
   backgroundJobs: BackgroundJob[] = []
 
   newSupportRequest: SupportRequest = null
@@ -44,13 +45,12 @@ export class HeaderComponent implements OnInit, OnDestroy {
     }
 
   ngOnInit() {
-    try {
-      this.current_user_claims = this.authService.GetCurrentUser()
-    } catch(e){
-      this.current_user_claims = new UserRegisteredClaims()
-    }
+    // current-user + admin now resolve from the server (#103 Phase 2a); handle async.
+    this.authService.GetCurrentUser()
+      .then((claims) => this.current_user_claims = claims)
+      .catch(() => this.current_user_claims = new UserRegisteredClaims())
 
-    this.isAdmin = this.authService.IsAdmin();
+    this.authService.IsAdmin().then((isAdmin) => this.isAdmin = isAdmin);
 
     this.fastenApi.getBackgroundJobs().subscribe((data) => {
       this.backgroundJobs = data.filter((job) => {

--- a/frontend/src/app/pages/auth-signin/auth-signin.component.ts
+++ b/frontend/src/app/pages/auth-signin/auth-signin.component.ts
@@ -40,10 +40,11 @@ export class AuthSigninComponent implements OnInit {
 
       this.resetUrlOnCallback()
       this.authService.IdpCallback(idpType, state, code)
-        .then(() => {
+        .then(() => this.authService.GetCurrentUser())
+        .then((currentUser) => {
           //for cloud users ONLY, skip the encryption manager.
           //TODO: replace Pouchdb.
-          const userId = this.authService.GetCurrentUser().sub
+          const userId = currentUser.sub
           //TODO: static IV, must be removed/replaced.
           return {username: userId, key: userId}
         })

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -187,17 +187,23 @@ export class AuthService {
     return localStorage.getItem(this.FASTEN_JWT_LOCALSTORAGE_KEY);
   }
 
-  public GetCurrentUser(): UserRegisteredClaims {
-    const authToken = this.GetAuthToken()
-    if(!authToken){
-      throw new Error("no auth token found")
-    }
+  // Identity now comes from the server (GET /secure/account/me) rather than decoding the JWT
+  // client-side, so it no longer needs a JS-readable token (#103 Phase 2a / #117). The browser's
+  // session credential authenticates the call (Authorization header today; HttpOnly cookie after
+  // Phase 2b). /me is also server-authoritative — role reflects current DB state, not a token snapshot.
+  public async GetCurrentUser(): Promise<UserRegisteredClaims> {
+    const fastenApiEndpointBase = GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)
+    const resp = await this._httpClient.get<ResponseWrapper>(`${fastenApiEndpointBase}/secure/account/me`).toPromise()
+    const data: any = (resp && resp.data) || {}
 
-    //parse the authToken to get user information
-    const jwtClaims = jose.decodeJwt(authToken)
-
-    // @ts-ignore
-    return jwtClaims as UserRegisteredClaims
+    const claims = new UserRegisteredClaims()
+    claims.sub = data.username // the JWT subject is the username
+    claims.id = data.id
+    claims.full_name = data.full_name
+    claims.email = data.email
+    claims.picture = data.picture
+    claims.role = data.role
+    return claims
   }
 
   public async Logout(): Promise<any> {
@@ -218,9 +224,13 @@ export class AuthService {
     // await this.Close()
   }
 
-  public IsAdmin(): boolean {
-    const currentUser = this.GetCurrentUser();
-    return currentUser && currentUser.role === "admin";
+  public async IsAdmin(): Promise<boolean> {
+    try {
+      const currentUser = await this.GetCurrentUser();
+      return !!currentUser && currentUser.role === "admin";
+    } catch (e) {
+      return false;
+    }
   }
 
   /////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Prerequisite for #103 Phase 2b. Stops decoding the session JWT client-side for identity → works without a JS-readable token. `Authorization: Bearer` stays primary; this is plumbing, not the cutover.

- `GetCurrentUser()`: sync `jose.decodeJwt` → async `GET /secure/account/me` (server-authoritative; `sub`=`username`).
- `IsAdmin()`: async (the is-admin guard already `await`s it).
- `header.component`: async `ngOnInit`; `current_user_claims` defaults to an empty object so the template renders before `/me` resolves.
- `auth-signin`: `await GetCurrentUser()` in the IdpCallback chain.
- Fixed `header.component.spec` mock (the old `getCurrentUser` typo never matched).

Verified locally: `ng build` clean; auth.service/header/auth-signin specs green. localStorage + jose-for-expiry remain until #118.

Closes #117. Refs #103. **Browser spot-check after deploy:** header shows the user; admin routes gated correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)