### PR TITLE
feat(auth): drop localStorage token; rely on HttpOnly cookie (#118, #103 Phase 2b)

### DIFF
--- a/frontend/src/app/services/auth-interceptor.service.ts
+++ b/frontend/src/app/services/auth-interceptor.service.ts
@@ -44,8 +44,12 @@ export class AuthInterceptorService implements HttpInterceptor {
       return next.handle(req)
     }
 
-    // Clone the request to add the new header.
-    const authReq = req.clone({headers: req.headers.set('Authorization', 'Bearer ' + this.authService.GetAuthToken())});
+    // Only attach a Bearer header if we actually have a token. In Phase 2b (#118) the session
+    // is the HttpOnly cookie (sent automatically same-origin), and GetAuthToken() returns null —
+    // so we send no Authorization header and let the cookie authenticate. (Sending "Bearer null"
+    // would defeat the backend's cookie fallback, since the header takes precedence.)
+    const token = this.authService.GetAuthToken();
+    const authReq = token ? req.clone({headers: req.headers.set('Authorization', 'Bearer ' + token)}) : req;
     // catch the error, make specific functions for catching specific errors and you can chain through them with more catch operators
     return next.handle(authReq).pipe(catchError(x=> this.handleAuthError(x))); //here use an arrow function, otherwise you may get "Cannot read property 'navigate' of undefined" on angular 4.4.2/net core 2/webpack 2.70
 

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -1,7 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import * as Oauth from '@panva/oauth4webapi';
-import * as jose from 'jose';
 import { BehaviorSubject, Observable, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
@@ -148,18 +147,16 @@ export class AuthService {
 
   //TODO: now that we've moved to remote-first database, we can refactor and simplify this function significantly.
   public async IsAuthenticated(): Promise<boolean> {
-    const authToken = this.GetAuthToken()
-    const hasAuthToken = !!authToken
-    if(!hasAuthToken){
+    // Phase 2b (#118): there is no JS-readable token to inspect — ask the server. A valid
+    // HttpOnly session cookie makes /me succeed (200); otherwise it 401s. Server-authoritative.
+    try {
+      await this.GetCurrentUser()
+      this.publishAuthenticationState(true)
+      return true
+    } catch (e) {
       this.publishAuthenticationState(false)
       return false
     }
-
-    //check if the authToken has expired
-    const jwtClaims = jose.decodeJwt(authToken)
-    const valid = Date.now() < (jwtClaims.exp * 1000);
-    this.publishAuthenticationState(valid)
-    return valid
 
 
     // //check if the authToken has expired.
@@ -184,7 +181,9 @@ export class AuthService {
   }
 
   public GetAuthToken(): string {
-    return localStorage.getItem(this.FASTEN_JWT_LOCALSTORAGE_KEY);
+    // Phase 2b (#118): the session is carried by the HttpOnly cookie, which JS cannot read,
+    // so there's no bearer token to expose. Kept for back-compat; always null now.
+    return null;
   }
 
   // Identity now comes from the server (GET /secure/account/me) rather than decoding the JWT
@@ -238,8 +237,11 @@ export class AuthService {
   /////////////////////////////////////////////////////////////////////////////////////////////////
 
   private setAuthToken(token: string) {
+    // Phase 2b (#118): the backend sets the HttpOnly session cookie on login, so the SPA no
+    // longer stores the JWT (XSS can't steal what isn't in JS). Just flip the auth-state flag
+    // and clear any token left over from a pre-Phase-2b session. `token` is intentionally unused.
     this.publishAuthenticationState(true)
-    localStorage.setItem(this.FASTEN_JWT_LOCALSTORAGE_KEY, token)
+    localStorage.removeItem(this.FASTEN_JWT_LOCALSTORAGE_KEY)
   }
 
   private publishAuthenticationState(authenticated){

--- a/frontend/src/app/services/event-bus.service.ts
+++ b/frontend/src/app/services/event-bus.service.ts
@@ -89,9 +89,9 @@ export class EventBusService {
     this.eventBus = new Observable(observer => {
       fetchEventSource(eventStreamUrl, {
         method: 'GET',
-        headers: {
-          'Authorization': `Bearer ${this.authService.GetAuthToken()}`
-        },
+        // Phase 2b (#118): authenticate the SSE stream with the HttpOnly session cookie
+        // (same-origin) instead of a Bearer header — JS no longer holds a token.
+        credentials: 'include',
         onmessage(ev) {
           observer.next(JSON.parse(ev.data));
         },


### PR DESCRIPTION
**The cutover that delivers the XSS-theft protection** (#103 / H2): the session JWT is no longer held in JS, so an XSS can't exfiltrate it. Builds on Phase 1 (#112, backend dual-accept) + Phase 2a (#119, `/me` identity).

## Changes
- `IsAuthenticated()` → probes `GET /me` (200 = authed, 401 = not); no local token to inspect.
- `GetAuthToken()` → returns `null` (the HttpOnly cookie carries the session).
- `setAuthToken()` → stops writing `localStorage`; clears any legacy token; just flips the auth-state flag.
- `auth-interceptor` → attaches `Bearer` only if a token exists (it won't) → cookie authenticates; never sends `Bearer null` (which would defeat the backend cookie fallback).
- `event-bus` SSE → `credentials: 'include'` instead of a `Bearer` header.
- Removed the now-unused `jose` import.

## ⚠️ DO NOT MERGE until browser-validated
CI can't exercise the cookie/session flow (Karma mocks HTTP). Validate locally with `make serve-backend` + `make serve-frontend`:
1. **Login** → reaches dashboard; **no token in `localStorage`** (DevTools → Application → Local Storage).
2. **Refresh** the page → stays logged in (re-hydrates via `/me`).
3. **Header** shows your user; **admin** routes gated correctly.
4. **SSE** — trigger a sync, watch job progress stream in.
5. **Logout** → fully signed out; refresh does **not** restore the session (cookie cleared).
6. **Token expiry** (1h) → next action redirects to signin.

## Notes / known follow-ups
- `IsAuthenticated()` now does a `/me` round-trip per protected navigation (correct but chatty) — a caching optimization is a possible follow-up.
- On a 401, the interceptor forces `Logout()` + redirect to signin (expected for not-authed; verify no redirect loop on the signin page — it's unguarded, so it shouldn't).
- The IdP/hello.coop login has no backend `/auth/callback` route in this fork; when it's built, it must also set the session cookie.

Closes #118. Refs #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)