### PR TITLE
perf(ingest): compile the goja FHIRPath programs once, not per resource (#151)

### DIFF
--- a/backend/pkg/models/database/fhir_account.go
+++ b/backend/pkg/models/database/fhir_account.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -91,31 +89,7 @@ func (s *FhirAccount) PopulateAndExtractSearchParameters(resourceRaw json.RawMes
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_adverse_event.go
+++ b/backend/pkg/models/database/fhir_adverse_event.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -111,31 +109,7 @@ func (s *FhirAdverseEvent) PopulateAndExtractSearchParameters(resourceRaw json.R
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_allergy_intolerance.go
+++ b/backend/pkg/models/database/fhir_allergy_intolerance.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -202,31 +200,7 @@ func (s *FhirAllergyIntolerance) PopulateAndExtractSearchParameters(resourceRaw 
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_appointment.go
+++ b/backend/pkg/models/database/fhir_appointment.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -127,31 +125,7 @@ func (s *FhirAppointment) PopulateAndExtractSearchParameters(resourceRaw json.Ra
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_binary.go
+++ b/backend/pkg/models/database/fhir_binary.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -63,31 +61,7 @@ func (s *FhirBinary) PopulateAndExtractSearchParameters(resourceRaw json.RawMess
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_care_plan.go
+++ b/backend/pkg/models/database/fhir_care_plan.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -196,31 +194,7 @@ func (s *FhirCarePlan) PopulateAndExtractSearchParameters(resourceRaw json.RawMe
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_care_team.go
+++ b/backend/pkg/models/database/fhir_care_team.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -144,31 +142,7 @@ func (s *FhirCareTeam) PopulateAndExtractSearchParameters(resourceRaw json.RawMe
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_claim.go
+++ b/backend/pkg/models/database/fhir_claim.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -127,31 +125,7 @@ func (s *FhirClaim) PopulateAndExtractSearchParameters(resourceRaw json.RawMessa
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_claim_response.go
+++ b/backend/pkg/models/database/fhir_claim_response.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -103,31 +101,7 @@ func (s *FhirClaimResponse) PopulateAndExtractSearchParameters(resourceRaw json.
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_clinical_impression.go
+++ b/backend/pkg/models/database/fhir_clinical_impression.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -131,31 +129,7 @@ func (s *FhirClinicalImpression) PopulateAndExtractSearchParameters(resourceRaw 
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_composition.go
+++ b/backend/pkg/models/database/fhir_composition.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -208,31 +206,7 @@ func (s *FhirComposition) PopulateAndExtractSearchParameters(resourceRaw json.Ra
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_condition.go
+++ b/backend/pkg/models/database/fhir_condition.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -193,31 +191,7 @@ func (s *FhirCondition) PopulateAndExtractSearchParameters(resourceRaw json.RawM
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_consent.go
+++ b/backend/pkg/models/database/fhir_consent.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -172,31 +170,7 @@ func (s *FhirConsent) PopulateAndExtractSearchParameters(resourceRaw json.RawMes
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_coverage.go
+++ b/backend/pkg/models/database/fhir_coverage.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -103,31 +101,7 @@ func (s *FhirCoverage) PopulateAndExtractSearchParameters(resourceRaw json.RawMe
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_coverage_eligibility_request.go
+++ b/backend/pkg/models/database/fhir_coverage_eligibility_request.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -87,31 +85,7 @@ func (s *FhirCoverageEligibilityRequest) PopulateAndExtractSearchParameters(reso
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_coverage_eligibility_response.go
+++ b/backend/pkg/models/database/fhir_coverage_eligibility_response.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -95,31 +93,7 @@ func (s *FhirCoverageEligibilityResponse) PopulateAndExtractSearchParameters(res
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_device.go
+++ b/backend/pkg/models/database/fhir_device.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -107,31 +105,7 @@ func (s *FhirDevice) PopulateAndExtractSearchParameters(resourceRaw json.RawMess
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_device_request.go
+++ b/backend/pkg/models/database/fhir_device_request.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -196,31 +194,7 @@ func (s *FhirDeviceRequest) PopulateAndExtractSearchParameters(resourceRaw json.
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_diagnostic_report.go
+++ b/backend/pkg/models/database/fhir_diagnostic_report.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -208,31 +206,7 @@ func (s *FhirDiagnosticReport) PopulateAndExtractSearchParameters(resourceRaw js
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_document_manifest.go
+++ b/backend/pkg/models/database/fhir_document_manifest.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -153,31 +151,7 @@ func (s *FhirDocumentManifest) PopulateAndExtractSearchParameters(resourceRaw js
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_document_reference.go
+++ b/backend/pkg/models/database/fhir_document_reference.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -208,31 +206,7 @@ func (s *FhirDocumentReference) PopulateAndExtractSearchParameters(resourceRaw j
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_encounter.go
+++ b/backend/pkg/models/database/fhir_encounter.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -213,31 +211,7 @@ func (s *FhirEncounter) PopulateAndExtractSearchParameters(resourceRaw json.RawM
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_endpoint.go
+++ b/backend/pkg/models/database/fhir_endpoint.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -87,31 +85,7 @@ func (s *FhirEndpoint) PopulateAndExtractSearchParameters(resourceRaw json.RawMe
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_enrollment_request.go
+++ b/backend/pkg/models/database/fhir_enrollment_request.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -75,31 +73,7 @@ func (s *FhirEnrollmentRequest) PopulateAndExtractSearchParameters(resourceRaw j
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_enrollment_response.go
+++ b/backend/pkg/models/database/fhir_enrollment_response.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -75,31 +73,7 @@ func (s *FhirEnrollmentResponse) PopulateAndExtractSearchParameters(resourceRaw 
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_explanation_of_benefit.go
+++ b/backend/pkg/models/database/fhir_explanation_of_benefit.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -127,31 +125,7 @@ func (s *FhirExplanationOfBenefit) PopulateAndExtractSearchParameters(resourceRa
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_family_member_history.go
+++ b/backend/pkg/models/database/fhir_family_member_history.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -165,31 +163,7 @@ func (s *FhirFamilyMemberHistory) PopulateAndExtractSearchParameters(resourceRaw
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_goal.go
+++ b/backend/pkg/models/database/fhir_goal.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -124,31 +122,7 @@ func (s *FhirGoal) PopulateAndExtractSearchParameters(resourceRaw json.RawMessag
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_imaging_study.go
+++ b/backend/pkg/models/database/fhir_imaging_study.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -160,31 +158,7 @@ func (s *FhirImagingStudy) PopulateAndExtractSearchParameters(resourceRaw json.R
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_immunization.go
+++ b/backend/pkg/models/database/fhir_immunization.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -180,31 +178,7 @@ func (s *FhirImmunization) PopulateAndExtractSearchParameters(resourceRaw json.R
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_insurance_plan.go
+++ b/backend/pkg/models/database/fhir_insurance_plan.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -119,31 +117,7 @@ func (s *FhirInsurancePlan) PopulateAndExtractSearchParameters(resourceRaw json.
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_location.go
+++ b/backend/pkg/models/database/fhir_location.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -119,31 +117,7 @@ func (s *FhirLocation) PopulateAndExtractSearchParameters(resourceRaw json.RawMe
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_media.go
+++ b/backend/pkg/models/database/fhir_media.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -111,31 +109,7 @@ func (s *FhirMedia) PopulateAndExtractSearchParameters(resourceRaw json.RawMessa
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_medication.go
+++ b/backend/pkg/models/database/fhir_medication.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -124,31 +122,7 @@ func (s *FhirMedication) PopulateAndExtractSearchParameters(resourceRaw json.Raw
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_medication_administration.go
+++ b/backend/pkg/models/database/fhir_medication_administration.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -175,31 +173,7 @@ func (s *FhirMedicationAdministration) PopulateAndExtractSearchParameters(resour
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_medication_dispense.go
+++ b/backend/pkg/models/database/fhir_medication_dispense.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -187,31 +185,7 @@ func (s *FhirMedicationDispense) PopulateAndExtractSearchParameters(resourceRaw 
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_medication_request.go
+++ b/backend/pkg/models/database/fhir_medication_request.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -203,31 +201,7 @@ func (s *FhirMedicationRequest) PopulateAndExtractSearchParameters(resourceRaw j
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_medication_statement.go
+++ b/backend/pkg/models/database/fhir_medication_statement.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -171,31 +169,7 @@ func (s *FhirMedicationStatement) PopulateAndExtractSearchParameters(resourceRaw
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_nutrition_order.go
+++ b/backend/pkg/models/database/fhir_nutrition_order.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -155,31 +153,7 @@ func (s *FhirNutritionOrder) PopulateAndExtractSearchParameters(resourceRaw json
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_observation.go
+++ b/backend/pkg/models/database/fhir_observation.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -272,31 +270,7 @@ func (s *FhirObservation) PopulateAndExtractSearchParameters(resourceRaw json.Ra
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_organization.go
+++ b/backend/pkg/models/database/fhir_organization.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -115,31 +113,7 @@ func (s *FhirOrganization) PopulateAndExtractSearchParameters(resourceRaw json.R
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_organization_affiliation.go
+++ b/backend/pkg/models/database/fhir_organization_affiliation.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -119,31 +117,7 @@ func (s *FhirOrganizationAffiliation) PopulateAndExtractSearchParameters(resourc
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_patient.go
+++ b/backend/pkg/models/database/fhir_patient.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -247,31 +245,7 @@ func (s *FhirPatient) PopulateAndExtractSearchParameters(resourceRaw json.RawMes
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_person.go
+++ b/backend/pkg/models/database/fhir_person.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -221,31 +219,7 @@ func (s *FhirPerson) PopulateAndExtractSearchParameters(resourceRaw json.RawMess
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_practitioner.go
+++ b/backend/pkg/models/database/fhir_practitioner.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -221,31 +219,7 @@ func (s *FhirPractitioner) PopulateAndExtractSearchParameters(resourceRaw json.R
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_practitioner_role.go
+++ b/backend/pkg/models/database/fhir_practitioner_role.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -139,31 +137,7 @@ func (s *FhirPractitionerRole) PopulateAndExtractSearchParameters(resourceRaw js
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_procedure.go
+++ b/backend/pkg/models/database/fhir_procedure.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -208,31 +206,7 @@ func (s *FhirProcedure) PopulateAndExtractSearchParameters(resourceRaw json.RawM
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_provenance.go
+++ b/backend/pkg/models/database/fhir_provenance.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -99,31 +97,7 @@ func (s *FhirProvenance) PopulateAndExtractSearchParameters(resourceRaw json.Raw
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_questionnaire.go
+++ b/backend/pkg/models/database/fhir_questionnaire.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -131,31 +129,7 @@ func (s *FhirQuestionnaire) PopulateAndExtractSearchParameters(resourceRaw json.
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_questionnaire_response.go
+++ b/backend/pkg/models/database/fhir_questionnaire_response.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -103,31 +101,7 @@ func (s *FhirQuestionnaireResponse) PopulateAndExtractSearchParameters(resourceR
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_related_person.go
+++ b/backend/pkg/models/database/fhir_related_person.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -213,31 +211,7 @@ func (s *FhirRelatedPerson) PopulateAndExtractSearchParameters(resourceRaw json.
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_schedule.go
+++ b/backend/pkg/models/database/fhir_schedule.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -91,31 +89,7 @@ func (s *FhirSchedule) PopulateAndExtractSearchParameters(resourceRaw json.RawMe
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_service_request.go
+++ b/backend/pkg/models/database/fhir_service_request.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -208,31 +206,7 @@ func (s *FhirServiceRequest) PopulateAndExtractSearchParameters(resourceRaw json
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_slot.go
+++ b/backend/pkg/models/database/fhir_slot.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -95,31 +93,7 @@ func (s *FhirSlot) PopulateAndExtractSearchParameters(resourceRaw json.RawMessag
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_specimen.go
+++ b/backend/pkg/models/database/fhir_specimen.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -107,31 +105,7 @@ func (s *FhirSpecimen) PopulateAndExtractSearchParameters(resourceRaw json.RawMe
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/fhir_vision_prescription.go
+++ b/backend/pkg/models/database/fhir_vision_prescription.go
@@ -5,8 +5,6 @@ package database
 
 import (
 	"encoding/json"
-	"fmt"
-	goja "github.com/dop251/goja"
 	models "github.com/fastenhealth/fasten-onprem/backend/pkg/models"
 	datatypes "gorm.io/datatypes"
 	"time"
@@ -131,31 +129,7 @@ func (s *FhirVisionPrescription) PopulateAndExtractSearchParameters(resourceRaw 
 	if err != nil {
 		return err
 	}
-	if len(fhirPathJs) == 0 {
-		return fmt.Errorf("fhirPathJs script is empty")
-	}
-	vm := goja.New()
-	// setup the global window object
-	vm.Set("window", vm.NewObject())
-	// set the global FHIR Resource object
-	vm.Set("fhirResource", resourceRawMap)
-	// compile the fhirpath library
-	fhirPathJsProgram, err := goja.Compile("fhirpath.min.js", fhirPathJs, true)
-	if err != nil {
-		return err
-	}
-	// compile the searchParametersExtractor library
-	searchParametersExtractorJsProgram, err := goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
-	if err != nil {
-		return err
-	}
-	// add the fhirpath library in the goja vm
-	_, err = vm.RunProgram(fhirPathJsProgram)
-	if err != nil {
-		return err
-	}
-	// add the searchParametersExtractor library in the goja vm
-	_, err = vm.RunProgram(searchParametersExtractorJsProgram)
+	vm, err := newSearchParameterExtractorVM(resourceRawMap)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/models/database/generate.go
+++ b/backend/pkg/models/database/generate.go
@@ -279,39 +279,10 @@ func main() {
 				g.Return(jen.Err())
 			})
 
-			//check length of fhirPathJs script (may not have been embedded correctly)
-			g.If(jen.Len(jen.Id("fhirPathJs")).Op("==").Lit(0)).BlockFunc(func(f *jen.Group) {
-				f.Return(jen.Qual("fmt", "Errorf").Call(jen.Lit("fhirPathJs script is empty")))
-			})
-
-			//initialize goja vm
-			g.Id("vm").Op(":=").Qual("github.com/dop251/goja", "New").Call()
-			g.Comment("setup the global window object")
-			g.Id("vm").Dot("Set").Call(jen.Lit("window"), jen.Id("vm").Dot("NewObject").Call())
-
-			g.Comment("set the global FHIR Resource object")
-			g.Id("vm").Dot("Set").Call(jen.Lit("fhirResource"), jen.Id("resourceRawMap"))
-
-			g.Comment("compile the fhirpath library")
-			g.List(jen.Id("fhirPathJsProgram"), jen.Id("err")).Op(":=").Qual("github.com/dop251/goja", "Compile").Call(jen.Lit("fhirpath.min.js"), jen.Id("fhirPathJs"), jen.True())
-			g.If(jen.Err().Op("!=").Nil()).BlockFunc(func(e *jen.Group) {
-				e.Return(jen.Err())
-			})
-
-			g.Comment("compile the searchParametersExtractor library")
-			g.List(jen.Id("searchParametersExtractorJsProgram"), jen.Id("err")).Op(":=").Qual("github.com/dop251/goja", "Compile").Call(jen.Lit("searchParameterExtractor.js"), jen.Id("searchParameterExtractorJs"), jen.True())
-			g.If(jen.Err().Op("!=").Nil()).BlockFunc(func(e *jen.Group) {
-				e.Return(jen.Err())
-			})
-
-			g.Comment("add the fhirpath library in the goja vm")
-			g.List(jen.Id("_"), jen.Id("err")).Op("=").Id("vm").Dot("RunProgram").Call(jen.Id("fhirPathJsProgram"))
-			g.If(jen.Err().Op("!=").Nil()).BlockFunc(func(e *jen.Group) {
-				e.Return(jen.Err())
-			})
-
-			g.Comment("add the searchParametersExtractor library in the goja vm")
-			g.List(jen.Id("_"), jen.Id("err")).Op("=").Id("vm").Dot("RunProgram").Call(jen.Id("searchParametersExtractorJsProgram"))
+			//initialize a goja vm with the (compile-once, cached) fhirpath + searchParameterExtractor
+			//libraries loaded and the resource bound as `fhirResource`. See goja_extractor.go (#151):
+			//the 602KB fhirpath.min.js is compiled once package-wide instead of per resource.
+			g.List(jen.Id("vm"), jen.Id("err")).Op(":=").Id("newSearchParameterExtractorVM").Call(jen.Id("resourceRawMap"))
 			g.If(jen.Err().Op("!=").Nil()).BlockFunc(func(e *jen.Group) {
 				e.Return(jen.Err())
 			})

--- a/backend/pkg/models/database/goja_extractor.go
+++ b/backend/pkg/models/database/goja_extractor.go
@@ -1,0 +1,65 @@
+package database
+
+import (
+	"fmt"
+	"sync"
+
+	goja "github.com/dop251/goja"
+)
+
+// The fhirpath.min.js library is ~602KB. Compiling it (and searchParameterExtractor.js) is the
+// expensive part of search-parameter extraction, and it used to run once *per resource* inside every
+// generated PopulateAndExtractSearchParameters — so importing an N-resource bundle compiled the
+// library N times. We compile both programs exactly once, package-wide, and reuse the immutable
+// *goja.Program for every resource. See #151.
+//
+// We still create a fresh goja.Runtime per call: goja.Runtime is not safe for concurrent use and the
+// extractor binds per-resource globals (`window`, `fhirResource`). Reusing/pooling VMs is a possible
+// further optimization but risks state leaking between resources, so it is intentionally not done here.
+var (
+	extractorProgramsOnce sync.Once
+	fhirPathProgram       *goja.Program
+	searchParamProgram    *goja.Program
+	extractorProgramsErr  error
+)
+
+func compiledExtractorPrograms() (*goja.Program, *goja.Program, error) {
+	extractorProgramsOnce.Do(func() {
+		if len(fhirPathJs) == 0 {
+			extractorProgramsErr = fmt.Errorf("fhirPathJs script is empty")
+			return
+		}
+		fhirPathProgram, extractorProgramsErr = goja.Compile("fhirpath.min.js", fhirPathJs, true)
+		if extractorProgramsErr != nil {
+			return
+		}
+		searchParamProgram, extractorProgramsErr = goja.Compile("searchParameterExtractor.js", searchParameterExtractorJs, true)
+	})
+	return fhirPathProgram, searchParamProgram, extractorProgramsErr
+}
+
+// newSearchParameterExtractorVM returns a goja runtime with the fhirpath + searchParameterExtractor
+// libraries loaded (from the cached compiled programs) and the given resource bound as the global
+// `fhirResource`, ready to run extractTokenSearchParameters(...) etc.
+func newSearchParameterExtractorVM(resourceRawMap map[string]interface{}) (*goja.Runtime, error) {
+	fhirPathProg, searchParamProg, err := compiledExtractorPrograms()
+	if err != nil {
+		return nil, err
+	}
+
+	vm := goja.New()
+	// setup the global window object
+	vm.Set("window", vm.NewObject())
+	// set the global FHIR Resource object
+	vm.Set("fhirResource", resourceRawMap)
+
+	// load the fhirpath library
+	if _, err := vm.RunProgram(fhirPathProg); err != nil {
+		return nil, err
+	}
+	// load the searchParametersExtractor library
+	if _, err := vm.RunProgram(searchParamProg); err != nil {
+		return nil, err
+	}
+	return vm, nil
+}


### PR DESCRIPTION
Fixes #151.

## Problem
Every `PopulateAndExtractSearchParameters` call — i.e. **every resource imported** — did `goja.New()` and **re-compiled the 602KB `fhirpath.min.js`** (+ `searchParameterExtractor.js`). Importing an N-resource bundle compiled the library N times. This slowed real bundle imports and was the bulk of the backend-test goja time.

## Fix
- New hand-written `goja_extractor.go`: compiles both JS programs **once** (package-level `sync.Once`) and reuses the immutable `*goja.Program`. Exposes `newSearchParameterExtractorVM(resourceRawMap)`.
- `generate.go` now emits a single `vm, err := newSearchParameterExtractorVM(resourceRawMap)` call instead of the inline per-resource compile — regenerated the 56 `fhir_*.go` files (`go run generate.go`).
- A fresh `goja.Runtime` is still created per call (goja runtimes aren't concurrency-safe and bind per-resource `fhirResource`/`window` globals). **VM pooling** would save more (~33% vs ~13%) but risks state leaking between resources, so it's intentionally **not** done here — possible follow-up.

## Measured
- ~17ms/resource saved (the compile cost — matches a micro-benchmark).
- Graph-import test (198 resources): **32.1s → 28.7s**.
- `backend/pkg/database` package: **146s → 137s**.
- A real ~500-resource bundle import saves **~8s**.
- Bonus: removes ~30 lines of setup from each of the 56 generated files.

## Safety
- `*goja.Program` is immutable → safe to share across goroutines/calls.
- `ExtractSearchParameters` tests (`backend/pkg/models/database`) pass — output unchanged.
- `go vet` + `go build ./backend/...` clean.
- Generated files only — `generate.go` is the source of truth; never hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)