### PR TITLE
feat(us-core): complete Patient Must-Support display — tribal-affiliation + interpreter-needed (#142)

### DIFF
--- a/docs/us-core/README.md
+++ b/docs/us-core/README.md
@@ -20,7 +20,7 @@ How YourPHR relates to the [FHIR **US Core** Implementation Guide](https://hl7.o
 
 | USCDI data class | US Core profile(s) | Resource(s) | Display model | US Core handling |
 |---|---|---|---|---|
-| Patient demographics | US Core Patient | Patient | ✅ | ✅ race / ethnicity / birthsex extensions |
+| Patient demographics | US Core Patient | Patient | ✅ | ✅ audited vs 9.0.0 (#142): core MS + all extension slices — race / ethnicity / birthsex / **sex (individual-sex)** / **tribal-affiliation** / **interpreter-needed** (no gender-identity slice in 9.0.0) |
 | Problems / health concerns | Condition (Problems), Condition (Encounter Dx) | Condition | ✅ | generic (Must-Support not audited) |
 | Allergies | AllergyIntolerance | AllergyIntolerance | ✅ | generic |
 | Medications | MedicationRequest, Medication, MedicationDispense | MedicationRequest, Medication, MedicationDispense | ✅ | generic |

--- a/frontend/src/app/components/fhir-card/resources/patient/patient.component.html
+++ b/frontend/src/app/components/fhir-card/resources/patient/patient.component.html
@@ -16,6 +16,8 @@
           <li><strong>Marital Status:</strong> {{ displayModel.marital_status }}</li>
           <li><strong>Race:</strong> {{ displayModel.race }}</li>
           <li><strong>Ethnicity:</strong> {{ displayModel.ethnicity }}</li>
+          <li *ngIf="displayModel.tribal_affiliation"><strong>Tribal Affiliation:</strong> {{ displayModel.tribal_affiliation }}<span *ngIf="displayModel.tribal_enrolled !== undefined"> ({{ displayModel.tribal_enrolled ? 'enrolled' : 'not enrolled' }})</span></li>
+          <li *ngIf="displayModel.interpreter_needed"><strong>Interpreter Needed:</strong> {{ displayModel.interpreter_needed }}</li>
         </ul>
       </div>
 

--- a/frontend/src/lib/models/resources/patient-model.spec.ts
+++ b/frontend/src/lib/models/resources/patient-model.spec.ts
@@ -32,6 +32,21 @@ describe('PatientModel', () => {
           extension: [{ url: 'text', valueString: 'Not Hispanic or Latino' }]
         },
         {
+          url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-individual-sex',
+          valueCoding: { system: 'http://snomed.info/sct', code: '248153007', display: 'Male' }
+        },
+        {
+          url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-tribal-affiliation',
+          extension: [
+            { url: 'tribalAffiliation', valueCodeableConcept: { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/v3-TribalEntityUS', code: 'CHICKASAW', display: 'Chickasaw' }] } },
+            { url: 'isEnrolled', valueBoolean: true }
+          ]
+        },
+        {
+          url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-interpreter-needed',
+          valueCoding: { system: 'http://terminology.hl7.org/CodeSystem/v2-0136', code: 'Y', display: 'Yes' }
+        },
+        {
           url: 'http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName',
           valueString: 'Smith'
         },
@@ -109,6 +124,27 @@ describe('PatientModel', () => {
 
   it('should return the correct ethnicity', () => {
     expect(patientModel.ethnicity).toBe('Not Hispanic or Latino');
+  });
+
+  it('should return the US Core 9.0.0 individual sex (Coding display)', () => {
+    expect(patientModel.individual_sex).toBe('Male');
+  });
+
+  it('should return the tribal affiliation and enrollment', () => {
+    expect(patientModel.tribal_affiliation).toBe('Chickasaw');
+    expect(patientModel.tribal_enrolled).toBe(true);
+  });
+
+  it('should return whether an interpreter is needed', () => {
+    expect(patientModel.interpreter_needed).toBe('Yes');
+  });
+
+  it('should leave US Core extension fields undefined when the extensions are absent', () => {
+    const bare = new PatientModel({ id: 'x', name: [{ given: ['A'], family: 'B' }] });
+    expect(bare.individual_sex).toBeUndefined();
+    expect(bare.tribal_affiliation).toBeUndefined();
+    expect(bare.tribal_enrolled).toBeUndefined();
+    expect(bare.interpreter_needed).toBeUndefined();
   });
 
   it('should return the correct mother\'s maiden name', () => {

--- a/frontend/src/lib/models/resources/patient-model.ts
+++ b/frontend/src/lib/models/resources/patient-model.ts
@@ -26,6 +26,9 @@ export class PatientModel extends FastenDisplayModel {
   marital_status: string|undefined
   race: string|undefined
   ethnicity: string|undefined
+  tribal_affiliation: string|undefined
+  tribal_enrolled: boolean|undefined
+  interpreter_needed: string|undefined
   mothers_maiden_name: string|undefined
   birth_place: string|undefined
   multiple_birth: boolean|undefined
@@ -59,6 +62,9 @@ export class PatientModel extends FastenDisplayModel {
     this.marital_status = _.get(fhirResource, 'maritalStatus.text');
     this.race = this.getRace(fhirResource);
     this.ethnicity = this.getEthnicity(fhirResource);
+    this.tribal_affiliation = this.getTribalAffiliation(fhirResource);
+    this.tribal_enrolled = this.getTribalEnrolled(fhirResource);
+    this.interpreter_needed = this.getInterpreterNeeded(fhirResource);
     this.mothers_maiden_name = this.getMothersMaidenName(fhirResource);
     this.birth_place = this.getBirthPlace(fhirResource);
     this.multiple_birth = _.get(fhirResource, 'multipleBirthBoolean', false);
@@ -112,6 +118,32 @@ export class PatientModel extends FastenDisplayModel {
       ext.url === "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
     );
     return extension?.extension?.find((ext: any) => ext.url === "text")?.valueString;
+  }
+
+  // US Core 9.0.0 Tribal Affiliation — complex extension: tribalAffiliation (CodeableConcept, 1..1)
+  // + isEnrolled (boolean, 0..1). Returns the affiliated tribe's display text. (#142)
+  getTribalAffiliation(fhirResource: any) {
+    const extension = fhirResource.extension?.find((ext: any) =>
+      ext.url === "http://hl7.org/fhir/us/core/StructureDefinition/us-core-tribal-affiliation"
+    );
+    const affiliation = extension?.extension?.find((ext: any) => ext.url === "tribalAffiliation")?.valueCodeableConcept;
+    return affiliation?.text || affiliation?.coding?.[0]?.display || affiliation?.coding?.[0]?.code;
+  }
+
+  // Companion to getTribalAffiliation: whether the individual is enrolled in the tribe (0..1). (#142)
+  getTribalEnrolled(fhirResource: any) {
+    const extension = fhirResource.extension?.find((ext: any) =>
+      ext.url === "http://hl7.org/fhir/us/core/StructureDefinition/us-core-tribal-affiliation"
+    );
+    return extension?.extension?.find((ext: any) => ext.url === "isEnrolled")?.valueBoolean;
+  }
+
+  // US Core 9.0.0 Interpreter Needed — simple extension, value[x] is a Coding (Yes/No/Unknown). (#142)
+  getInterpreterNeeded(fhirResource: any) {
+    const extension = fhirResource.extension?.find((ext: any) =>
+      ext.url === "http://hl7.org/fhir/us/core/StructureDefinition/us-core-interpreter-needed"
+    );
+    return extension?.valueCoding?.display || extension?.valueCoding?.code;
   }
 
   getMothersMaidenName(fhirResource: any) {


### PR DESCRIPTION
Fixes #142 — completes the US Core 9.0.0 Patient profile audit (epic #136).

## What
Added the two remaining `Patient.extension` slices (verified against the live 9.0.0 StructureDefinitions via the IG):

- **us-core-tribal-affiliation** (complex): `tribalAffiliation` (CodeableConcept, 1..1) + `isEnrolled` (boolean, 0..1) → `getTribalAffiliation` / `getTribalEnrolled`. Renders `Tribal Affiliation: <tribe> (enrolled/not enrolled)`.
- **us-core-interpreter-needed** (simple, `valueCoding` Yes/No/Unknown) → `getInterpreterNeeded`. Renders `Interpreter Needed: <value>`.

Both display rows are `*ngIf`-guarded so missing data renders nothing.

## Verified against 9.0.0
- `us-core-individual-sex` ("Sex") value shape = `valueCoding` (already shipped in a3e29c7b) — confirmed.
- The 9.0.0 Patient profile has **no gender-identity extension slice**, so the issue's "genderIdentity likely missing" doesn't apply to this version — nothing to add.
- With this, **all** Patient.extension slices the profile defines are parsed + displayed: race / ethnicity / birthsex / sex / tribal-affiliation / interpreter-needed. Core MS elements (identifier, name, telecom, gender, birthDate, address, communication.language) were already covered.

## Tests
- `patient-model.spec`: added coverage for `individual_sex`, `tribal_affiliation` + enrollment, `interpreter_needed`, and the extensions-absent path → **20/20 green**.
- `patient.component.spec` green.
- Updated the support matrix in `docs/us-core/README.md`.

First profile fully through the per-profile pattern for #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)