### PR TITLE
feat(us-core): complete AllergyIntolerance Must-Support display — clinicalStatus + reactions (#145)

### DIFF
--- a/docs/us-core/README.md
+++ b/docs/us-core/README.md
@@ -22,7 +22,7 @@ How YourPHR relates to the [FHIR **US Core** Implementation Guide](https://hl7.o
 |---|---|---|---|---|
 | Patient demographics | US Core Patient | Patient | ✅ | ✅ audited vs 9.0.0 (#142): core MS + all extension slices — race / ethnicity / birthsex / **sex (individual-sex)** / **tribal-affiliation** / **interpreter-needed** (no gender-identity slice in 9.0.0) |
 | Problems / health concerns | Condition (Problems), Condition (Encounter Dx) | Condition | ✅ | generic (Must-Support not audited) |
-| Allergies | AllergyIntolerance | AllergyIntolerance | ✅ | generic |
+| Allergies | AllergyIntolerance | AllergyIntolerance | ✅ | ✅ audited vs 9.0.0 (#145): MS code / clinicalStatus / verificationStatus / patient + reaction.manifestation; plus criticality & reaction.severity |
 | Medications | MedicationRequest, Medication, MedicationDispense | MedicationRequest, Medication, MedicationDispense | ✅ | generic |
 | Lab results | Observation (Lab Result), DiagnosticReport (Lab) | Observation, DiagnosticReport | ✅ | ⚠️ generic — Observation **not split** by sub-profile |
 | Vital signs | Vital Signs + the per-vital profiles (BP, height, weight, temp, HR, RR, SpO₂, …) | Observation | ✅ | ⚠️ generic — no per-vital handling; `component` TODO |

--- a/frontend/src/app/components/fhir-card/resources/allergy-intolerance/allergy-intolerance.component.ts
+++ b/frontend/src/app/components/fhir-card/resources/allergy-intolerance/allergy-intolerance.component.ts
@@ -32,6 +32,25 @@ export class AllergyIntoleranceComponent implements OnInit, FhirCardComponentInt
         enabled: !!this.displayModel?.code,
       },
       {
+        label: 'Clinical Status',
+        data: this.displayModel?.clinical_status,
+        enabled: !!this.displayModel?.clinical_status,
+      },
+      {
+        label: 'Criticality',
+        data: this.displayModel?.criticality,
+        enabled: !!this.displayModel?.criticality,
+      },
+      {
+        label: 'Reactions',
+        // manifestation(s) + optional severity per reaction, e.g. "Anaphylactic reaction (severe); Urticaria"
+        data: (this.displayModel?.reactions || [])
+          .map(r => r.manifestation.join(', ') + (r.severity ? ` (${r.severity})` : ''))
+          .filter(s => s.length > 0)
+          .join('; '),
+        enabled: !!this.displayModel?.reactions?.length,
+      },
+      {
         label: 'Type',
         data: this.displayModel?.type,
         enabled: !!this.displayModel?.type,

--- a/frontend/src/lib/models/resources/allergy-intolerance-model.spec.ts
+++ b/frontend/src/lib/models/resources/allergy-intolerance-model.spec.ts
@@ -20,6 +20,12 @@ describe('AllergyIntoleranceModel', () => {
       const expected = new AllergyIntoleranceModel({})
       expected.title = 'Cashew nuts'
       expected.status = 'Confirmed'
+      expected.clinical_status = 'Active'
+      expected.criticality = 'high'
+      expected.reactions = [
+        { manifestation: ['Anaphylactic reaction'], severity: 'severe', description: 'Challenge Protocol. Severe reaction to subcutaneous cashew extract. Epinephrine administered' },
+        { manifestation: ['Urticaria'], severity: 'moderate', description: undefined },
+      ]
       expected.recorded_date = '2014-10-09T14:58:00+11:00'
       expected.substance_coding = [
         {
@@ -42,6 +48,11 @@ describe('AllergyIntoleranceModel', () => {
       const expected = new AllergyIntoleranceModel({})
       expected.title = 'Penicillin G'
       expected.status = 'Unconfirmed'
+      expected.clinical_status = 'Active'
+      expected.criticality = 'high'
+      expected.reactions = [
+        { manifestation: ['Hives'], severity: undefined, description: undefined },
+      ]
       expected.recorded_date = '2010-03-01'
       expected.substance_coding = []
       // expected.asserter = { reference: 'Patient/example' }
@@ -58,6 +69,7 @@ describe('AllergyIntoleranceModel', () => {
       const expected = new AllergyIntoleranceModel({})
       expected.title = 'No Known Allergy (situation)'
       expected.status = 'Confirmed'
+      expected.clinical_status = 'Active'
       expected.recorded_date = '2015-08-06T15:37:31-06:00'
       expected.substance_coding = []
       // expected.asserter = { reference: 'Patient/example' }

--- a/frontend/src/lib/models/resources/allergy-intolerance-model.ts
+++ b/frontend/src/lib/models/resources/allergy-intolerance-model.ts
@@ -11,9 +11,15 @@ export class AllergyIntoleranceModel extends FastenDisplayModel {
 
   title: string | undefined
   status: string | undefined
+  // initialized (not just declared) so they're consistent own-properties across all FHIR versions,
+  // since they're only populated in r4DTO (US Core is R4).
+  clinical_status: string | undefined = undefined
+  criticality: string | undefined = undefined
   recorded_date: string | undefined
   substance_coding: CodingModel[] | undefined
-  // reaction: string | undefined
+  // US Core 9.0.0 Must-Support: reaction (BackboneElement) with manifestation (CodeableConcept, 1..*);
+  // severity (mild|moderate|severe) and description are additional, not MS. (#145)
+  reactions: { manifestation: string[]; severity?: string; description?: string }[] = []
   asserter: ReferenceModel | undefined
   note: { text: string }[] | undefined
   type: string | undefined
@@ -67,11 +73,25 @@ export class AllergyIntoleranceModel extends FastenDisplayModel {
   r4DTO(fhirResource: any) {
     this.title = _.get(fhirResource, 'code.coding.0.display') || _.get(fhirResource, 'code.text')
     this.status = _.get(fhirResource, 'verificationStatus.coding[0].display');
+    // US Core 9.0.0 Must-Support: clinicalStatus (active|inactive|resolved). (#145)
+    this.clinical_status = _.get(fhirResource, 'clinicalStatus.coding[0].display')
+      || _.get(fhirResource, 'clinicalStatus.coding[0].code')
+      || _.get(fhirResource, 'clinicalStatus.text');
+    this.criticality = _.get(fhirResource, 'criticality');
     this.recorded_date = _.get(fhirResource, 'recordedDate');
     const substanceCoding = _.get(fhirResource, 'reaction', []).filter((item: any) =>
       _.get(item, 'substance.coding'),
     );
     this.substance_coding = _.get(substanceCoding, '0.substance.coding', []);
+
+    // US Core 9.0.0 Must-Support: reaction.manifestation (CodeableConcept, 1..*); plus severity/description.
+    this.reactions = _.get(fhirResource, 'reaction', []).map((reaction: any) => ({
+      manifestation: _.get(reaction, 'manifestation', [])
+        .map((m: any) => _.get(m, 'coding[0].display') || _.get(m, 'text'))
+        .filter(Boolean),
+      severity: _.get(reaction, 'severity'),
+      description: _.get(reaction, 'description'),
+    }));
 
     this.note = _.get(fhirResource, 'note');
   };


### PR DESCRIPTION
Fixes #145 — AllergyIntolerance through the US Core 9.0.0 per-profile pattern (epic #136).

## Verified MS set (vs live 9.0.0 StructureDefinition)
Must-Support: `code`, `clinicalStatus`, `verificationStatus`, `patient`, `reaction`, `reaction.manifestation` (CodeableConcept, 1..*). `reaction.severity` and `criticality` are **not** MS but clinically useful, so included. `manifestation` stays CodeableConcept in 9.0.0 (not CodeableReference).

## Gaps filled (R4)
- **clinicalStatus** → `clinical_status` (active|inactive|resolved) — was missing.
- **reaction[]** → `reactions[]` = `{ manifestation: string[]; severity?; description? }` — was missing.
- **criticality** (low|high|unable-to-assess) — added alongside.
- `verificationStatus` (→`status`), `code`, `patient` were already covered.

## Display
The card's `fhir-ui-table` gains **Clinical Status**, **Criticality**, and a **Reactions** row rendered as `"<manifestation(s)> (severity); …"` (revives the long-stubbed manifestation row). All guarded by `enabled`.

## Tests / safety
- Parsing lives in `r4DTO` (US Core is R4); new fields are initialized so they're consistent own-properties across DSTU2/STU3/R4 (avoids `toEqual` drift).
- Updated the r4 example expecteds; **8/8 model specs + component spec green**.
- Updated the `docs/us-core/README.md` matrix.

Second profile through the pattern (after Patient #142).

🤖 Generated with [Claude Code](https://claude.com/claude-code)