### PR TITLE
feat(us-core): complete Condition Must-Support display — verificationStatus, category, subject (#143)

### DIFF
--- a/docs/us-core/README.md
+++ b/docs/us-core/README.md
@@ -21,7 +21,7 @@ How YourPHR relates to the [FHIR **US Core** Implementation Guide](https://hl7.o
 | USCDI data class | US Core profile(s) | Resource(s) | Display model | US Core handling |
 |---|---|---|---|---|
 | Patient demographics | US Core Patient | Patient | ✅ | ✅ audited vs 9.0.0 (#142): core MS + all extension slices — race / ethnicity / birthsex / **sex (individual-sex)** / **tribal-affiliation** / **interpreter-needed** (no gender-identity slice in 9.0.0) |
-| Problems / health concerns | Condition (Problems), Condition (Encounter Dx) | Condition | ✅ | generic (Must-Support not audited) |
+| Problems / health concerns | Condition (Problems), Condition (Encounter Dx) | Condition | ✅ | ✅ audited vs 9.0.0 (#143): MS clinicalStatus / verificationStatus / **category (problem-list-item vs health-concern)** / code / subject / onset / abatement / recordedDate |
 | Allergies | AllergyIntolerance | AllergyIntolerance | ✅ | ✅ audited vs 9.0.0 (#145): MS code / clinicalStatus / verificationStatus / patient + reaction.manifestation; plus criticality & reaction.severity |
 | Medications | MedicationRequest, Medication, MedicationDispense | MedicationRequest, Medication, MedicationDispense | ✅ | generic |
 | Lab results | Observation (Lab Result), DiagnosticReport (Lab) | Observation, DiagnosticReport | ✅ | ⚠️ generic — Observation **not split** by sub-profile |

--- a/frontend/src/app/components/report-medical-history-condition/report-medical-history-condition.component.html
+++ b/frontend/src/app/components/report-medical-history-condition/report-medical-history-condition.component.html
@@ -17,6 +17,15 @@
 <!--      {{conditionDisplayModel | json}}-->
       <div class="col-6 mb-2">
 
+        <!-- US Core 9.0.0 Must-Support: category (problem-list-item vs health-concern), clinical & verification status (#143) -->
+        <div *ngIf="conditionDisplayModel?.categories?.length || conditionDisplayModel?.clinical_status || conditionDisplayModel?.verification_status" class="row pl-3 mb-2">
+          <div class="col-12">
+            <span class="badge badge-light mg-r-5" *ngFor="let category of conditionDisplayModel?.categories">{{ category }}</span>
+            <span class="badge badge-secondary mg-r-5" *ngIf="conditionDisplayModel?.clinical_status">{{ conditionDisplayModel.clinical_status | titlecase }}</span>
+            <span class="badge badge-info" *ngIf="conditionDisplayModel?.verification_status">{{ conditionDisplayModel.verification_status | titlecase }}</span>
+          </div>
+        </div>
+
         <div *ngIf="involvedInCare.length > 0" class="row  pl-3">
           <div class="col-12 mt-3 mb-2 tx-indigo">
             <p>Involved in Care</p>

--- a/frontend/src/lib/models/resources/condition-model.spec.ts
+++ b/frontend/src/lib/models/resources/condition-model.spec.ts
@@ -34,6 +34,9 @@ describe('ConditionModel', () => {
         "text": "Left Ear"
       })]
       expected.clinical_status = 'active'
+      expected.verification_status = 'confirmed'
+      expected.categories = ['Encounter Diagnosis']
+      expected.subject = { reference: 'Patient/example' }
       // expected.dateRecorded: string | undefined
       expected.onset_datetime = '2012-05-24'
       expected.code = { coding: [{ system: 'http://snomed.info/sct', code: '39065001', display: 'Burn of ear' } ], text: 'Burnt Ear' }
@@ -49,6 +52,9 @@ describe('ConditionModel', () => {
       expected.has_body_site = false
       // expected.bodySite
       expected.clinical_status = 'active'
+      expected.verification_status = 'confirmed'
+      expected.categories = ['Problem List Item']
+      expected.subject = { reference: 'Patient/example' }
       // expected.dateRecorded: string | undefined
       // expected.onsetDateTime = '2012-05-24'
       //@ts-ignore
@@ -66,6 +72,9 @@ describe('ConditionModel', () => {
       expected.has_body_site = true
       expected.body_site = [new CodableConceptModel({ text: '', coding: [ Object({ system: 'http://snomed.info/sct', code: '38266002', display: 'Entire body as a whole' }) ] })]
       expected.clinical_status = 'resolved'
+      expected.verification_status = 'confirmed'
+      expected.categories = ['Problem']
+      expected.subject = { reference: 'Patient/f201', display: 'Roel' }
       expected.date_recorded = '2013-04-04'
       expected.onset_datetime =  '2013-04-02'
       expected.code ={ coding: [{ system: 'http://snomed.info/sct', code: '386661006', display: 'Fever' }] }

--- a/frontend/src/lib/models/resources/condition-model.ts
+++ b/frontend/src/lib/models/resources/condition-model.ts
@@ -17,6 +17,10 @@ export class ConditionModel extends FastenDisplayModel {
   has_body_site: boolean | undefined
   body_site: CodableConceptModel[] | undefined
   clinical_status: string | undefined
+  // US Core 9.0.0 Must-Support (Condition Problems & Health Concerns, #143):
+  verification_status: string | undefined
+  categories: string[] = []        // problem-list-item vs health-concern distinction
+  subject: ReferenceModel | undefined
   date_recorded: string | undefined
   onset_datetime: string | undefined
   abatement_datetime: string | undefined
@@ -65,6 +69,13 @@ export class ConditionModel extends FastenDisplayModel {
 
   r4DTO(fhirResource:any){
     this.clinical_status = _.get(fhirResource, 'clinicalStatus.coding.0.code');
+    this.verification_status = _.get(fhirResource, 'verificationStatus.coding.0.display')
+      || _.get(fhirResource, 'verificationStatus.coding.0.code');
+    // category[] distinguishes problem-list-item vs health-concern (US Core required slice)
+    this.categories = _.get(fhirResource, 'category', [])
+      .map((c:any) => _.get(c, 'coding.0.display') || _.get(c, 'text') || _.get(c, 'coding.0.code'))
+      .filter(Boolean);
+    this.subject = _.get(fhirResource, 'subject');
     this.date_recorded = _.get(fhirResource, 'recordedDate');
     this.note = _.get(fhirResource, 'note.0.text');
   };


### PR DESCRIPTION
Fixes #143 — Condition (Problems & Health Concerns) through the US Core 9.0.0 per-profile pattern (epic #136). Third profile after Patient (#142) and AllergyIntolerance (#145).

## Verified MS set (vs live 9.0.0 StructureDefinition)
clinicalStatus, verificationStatus, **category**, code, subject, onset[x], abatement[x], recordedDate — all Must-Support. Category required codes: `problem-list-item` vs `health-concern`.

## Gaps filled (R4)
- **verification_status** (confirmed|unconfirmed|refuted|…) — was missing.
- **categories[]** — the problem-list-item vs health-concern distinction central to this profile — was missing.
- **subject** (Reference to Patient) — was missing.
- clinicalStatus, code, onset, abatement, recordedDate, severity, bodySite already covered.

## Display
The medical-history Condition card gains a badge line: **category** (e.g. "Problem List Item"), **clinical status**, **verification status**.

## Tests
- Parsing in `r4DTO` (US Core is R4); spec is R4-only, so updated the 3 r4 expecteds.
- **4/4 model specs + the display-component spec green.** Doc matrix row updated (alongside #145's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)