### PR TITLE
feat(us-core): complete MedicationRequest Must-Support display — subject, encounter, reported, category, dosage (#144)

### DIFF
--- a/docs/us-core/README.md
+++ b/docs/us-core/README.md
@@ -23,7 +23,7 @@ How YourPHR relates to the [FHIR **US Core** Implementation Guide](https://hl7.o
 | Patient demographics | US Core Patient | Patient | ✅ | ✅ audited vs 9.0.0 (#142): core MS + all extension slices — race / ethnicity / birthsex / **sex (individual-sex)** / **tribal-affiliation** / **interpreter-needed** (no gender-identity slice in 9.0.0) |
 | Problems / health concerns | Condition (Problems), Condition (Encounter Dx) | Condition | ✅ | ✅ audited vs 9.0.0 (#143): MS clinicalStatus / verificationStatus / **category (problem-list-item vs health-concern)** / code / subject / onset / abatement / recordedDate |
 | Allergies | AllergyIntolerance | AllergyIntolerance | ✅ | ✅ audited vs 9.0.0 (#145): MS code / clinicalStatus / verificationStatus / patient + reaction.manifestation; plus criticality & reaction.severity |
-| Medications | MedicationRequest, Medication, MedicationDispense | MedicationRequest, Medication, MedicationDispense | ✅ | generic |
+| Medications | MedicationRequest, Medication, MedicationDispense | MedicationRequest, Medication, MedicationDispense | ✅ | ✅ MedicationRequest audited vs 9.0.0 (#144): MS status / intent / medication[x] (CodeableConcept + Reference) / subject / encounter / reported[x] / authoredOn / requester / dosageInstruction.text / category |
 | Lab results | Observation (Lab Result), DiagnosticReport (Lab) | Observation, DiagnosticReport | ✅ | ⚠️ generic — Observation **not split** by sub-profile |
 | Vital signs | Vital Signs + the per-vital profiles (BP, height, weight, temp, HR, RR, SpO₂, …) | Observation | ✅ | ⚠️ generic — no per-vital handling; `component` TODO |
 | Smoking status | Smoking Status Observation | Observation | ✅ | ⚠️ generic — not differentiated |

--- a/frontend/src/app/components/fhir-card/resources/medication-request/medication-request.component.ts
+++ b/frontend/src/app/components/fhir-card/resources/medication-request/medication-request.component.ts
@@ -41,6 +41,36 @@ export class MedicationRequestComponent implements OnInit, FhirCardComponentInte
         enabled: !!this.displayModel?.medication_codeable_concept,
       },
       {
+        // medication[x] as a Reference to a (US Core) Medication resource
+        label: 'Medication',
+        data: this.displayModel?.medication_reference,
+        data_type: TableRowItemDataType.Reference,
+        enabled: !this.displayModel?.medication_codeable_concept && !!this.displayModel?.medication_reference,
+      },
+      {
+        label: 'Status',
+        data: this.displayModel?.status,
+        enabled: !!this.displayModel?.status,
+      },
+      {
+        label: 'Patient',
+        data: this.displayModel?.subject,
+        data_type: TableRowItemDataType.Reference,
+        enabled: !!this.displayModel?.subject,
+      },
+      {
+        label: 'Encounter',
+        data: this.displayModel?.encounter,
+        data_type: TableRowItemDataType.Reference,
+        enabled: !!this.displayModel?.encounter,
+      },
+      {
+        label: 'Reported by',
+        data: this.displayModel?.reported_reference,
+        data_type: TableRowItemDataType.Reference,
+        enabled: !!this.displayModel?.reported_reference,
+      },
+      {
         label: 'Requester',
         data: this.displayModel?.requester,
         data_type: TableRowItemDataType.Reference,
@@ -62,16 +92,16 @@ export class MedicationRequestComponent implements OnInit, FhirCardComponentInte
         data_type: TableRowItemDataType.Coding,
         enabled: !!this.displayModel?.reason_code,
       },
-      // {
-      //   label: 'Dosage',
-      //     testId: 'hasDosageInstruction',
-      //   data:
-      //   hasDosageInstruction &&
-      //   dosageInstruction.map((item, i) => (
-      //     <p key={`dosage-instruction-item-${i}`}>{item.text}</p>
-      // )),
-      //   status: hasDosageInstruction,
-      // },
+      {
+        label: 'Dosage',
+        data: this.displayModel?.dosage_instruction_text,
+        enabled: !!this.displayModel?.dosage_instruction_text,
+      },
+      {
+        label: 'Category',
+        data: (this.displayModel?.categories || []).join(', '),
+        enabled: !!this.displayModel?.categories?.length,
+      },
     ];
   }
   markForCheck(){

--- a/frontend/src/lib/models/resources/medication-request-model.spec.ts
+++ b/frontend/src/lib/models/resources/medication-request-model.spec.ts
@@ -1,7 +1,50 @@
 import { MedicationRequestModel } from './medication-request-model';
+import * as example1Fixture from '../../fixtures/r4/resources/medicationRequest/example1.json';
 
 describe('MedicationRequestModel', () => {
   it('should create an instance', () => {
     expect(new MedicationRequestModel({})).toBeTruthy();
+  });
+
+  describe('US Core 9.0.0 Must-Support (#144)', () => {
+    it('should parse subject, encounter, authoredOn, intent, status from r4 example1', () => {
+      const model = new MedicationRequestModel(example1Fixture);
+      expect(model.subject).toEqual({ reference: 'Patient/pat1', display: 'Donald Duck' });
+      expect(model.encounter).toEqual({ reference: 'Encounter/f001', display: 'encounter that leads to this prescription' });
+      expect(model.status).toBe('active');
+      expect(model.intent).toBe('order');
+      expect(model.created).toBe('2015-03-01');
+      expect(model.dosage_instruction_text).toBe('Take one tablet daily as directed');
+    });
+
+    it('should resolve a medication Reference', () => {
+      const model = new MedicationRequestModel(example1Fixture);
+      expect(model.medication_reference).toBeTruthy();
+    });
+
+    it('should parse reported[x] and category when present', () => {
+      const model = new MedicationRequestModel({
+        resourceType: 'MedicationRequest',
+        status: 'active',
+        intent: 'order',
+        reportedBoolean: true,
+        category: [
+          { coding: [{ system: 'http://terminology.hl7.org/CodeSystem/medicationrequest-category', code: 'community', display: 'Community' }] },
+        ],
+        medicationCodeableConcept: { text: 'Aspirin 81 MG' },
+        subject: { reference: 'Patient/pat1' },
+      });
+      expect(model.reported_boolean).toBe(true);
+      expect(model.categories).toEqual(['Community']);
+    });
+
+    it('should default categories to [] and leave optional MS fields undefined when absent', () => {
+      const model = new MedicationRequestModel({ resourceType: 'MedicationRequest', status: 'active', intent: 'order' });
+      expect(model.categories).toEqual([]);
+      expect(model.subject).toBeUndefined();
+      expect(model.encounter).toBeUndefined();
+      expect(model.reported_boolean).toBeUndefined();
+      expect(model.reported_reference).toBeUndefined();
+    });
   });
 });

--- a/frontend/src/lib/models/resources/medication-request-model.ts
+++ b/frontend/src/lib/models/resources/medication-request-model.ts
@@ -18,6 +18,13 @@ export class MedicationRequestModel extends FastenDisplayModel {
   created: string|undefined
   intent: string|undefined
   status: string|undefined
+  // US Core 9.0.0 Must-Support (#144):
+  subject: ReferenceModel|undefined          // Reference(Patient) — mandatory
+  encounter: ReferenceModel|undefined
+  reported_boolean: boolean|undefined        // reported[x]: was this reported rather than primary?
+  reported_reference: ReferenceModel|undefined
+  categories: string[] = []                  // category:us-core (e.g. community, discharge)
+  dosage_instruction_text: string|undefined  // dosageInstruction.text (MS)
 
   constructor(fhirResource: any, fhirVersion?: fhirVersions, fastenOptions?: FastenOptions) {
     super(fastenOptions)
@@ -34,10 +41,20 @@ export class MedicationRequestModel extends FastenDisplayModel {
     this.dosage_instruction = _.get(fhirResource, 'dosageInstruction');
     this.has_dosage_instruction =
       Array.isArray(this.dosage_instruction) && this.dosage_instruction.length > 0;
+    this.dosage_instruction_text = _.get(fhirResource, 'dosageInstruction.0.text');
     this.requester =
       _.get(fhirResource, 'requester.agent') || _.get(fhirResource, 'requester');
     this.created = _.get(fhirResource, 'authoredOn');
     this.intent = _.get(fhirResource, 'intent');
+
+    // US Core Must-Support elements (#144)
+    this.subject = _.get(fhirResource, 'subject');
+    this.encounter = _.get(fhirResource, 'encounter');
+    this.reported_boolean = _.get(fhirResource, 'reportedBoolean');
+    this.reported_reference = _.get(fhirResource, 'reportedReference');
+    this.categories = _.get(fhirResource, 'category', [])
+      .map((c: any) => _.get(c, 'coding.0.display') || _.get(c, 'text') || _.get(c, 'coding.0.code'))
+      .filter(Boolean);
 
     this.display = _.get(fhirResource, 'medicationCodeableConcept.text') || _.get(fhirResource, 'medicationCodeableConcept.0.display') || _.get(fhirResource, 'dosageInstruction.0.text') || 'unknown'
   }


### PR DESCRIPTION
Fixes #144 — MedicationRequest through the US Core 9.0.0 per-profile pattern (epic #136). Fourth profile (after #142 Patient, #145 AllergyIntolerance, #143 Condition).

## Verified MS set (vs live 9.0.0 StructureDefinition)
Mandatory: `status`, `intent`, `medication[x]`, `subject`. MS: `category:us-core`, `reported[x]`, `encounter`, `authoredOn`, `requester`, `dosageInstruction` (+ `.text`).

## Gaps filled
- **subject** (Reference Patient, mandatory) — was missing.
- **encounter** (Reference) — was missing.
- **reported[x]** (`reportedBoolean` / `reportedReference`) — was missing.
- **categories[]** (`category:us-core`, e.g. community / discharge) — was missing.
- **dosage_instruction_text** (`dosageInstruction.text`) — extracted for display.
- `status`, `intent`, `medication[x]` (CodeableConcept + Reference), `requester`, `authoredOn` already covered.

## Display
Card adds **Status, Patient, Encounter, Reported by, Dosage, Category** rows, and a **Medication** row that renders `medicationReference` when the med is a Reference (resolving Reference vs CodeableConcept — the issue's "resolving medication Reference").

## Tests
- Model spec expanded from a stub to cover subject/encounter/status/intent/authoredOn/dosage, medication-Reference resolution, `reported[x]` + category, and the absent-fields path — **5/5 green**; component spec green.
- Rebased onto post-#143 main; resolved the `docs/us-core/README.md` row (all four audited profiles now ✅).

🤖 Generated with [Claude Code](https://claude.com/claude-code)