### PR TITLE
feat(us-core): Observation profile registry + classification + multi-component BP (#146)

### DIFF
--- a/docs/us-core/README.md
+++ b/docs/us-core/README.md
@@ -24,9 +24,9 @@ How YourPHR relates to the [FHIR **US Core** Implementation Guide](https://hl7.o
 | Problems / health concerns | Condition (Problems), Condition (Encounter Dx) | Condition | ✅ | ✅ audited vs 9.0.0 (#143): MS clinicalStatus / verificationStatus / **category (problem-list-item vs health-concern)** / code / subject / onset / abatement / recordedDate |
 | Allergies | AllergyIntolerance | AllergyIntolerance | ✅ | ✅ audited vs 9.0.0 (#145): MS code / clinicalStatus / verificationStatus / patient + reaction.manifestation; plus criticality & reaction.severity |
 | Medications | MedicationRequest, Medication, MedicationDispense | MedicationRequest, Medication, MedicationDispense | ✅ | ✅ MedicationRequest audited vs 9.0.0 (#144): MS status / intent / medication[x] (CodeableConcept + Reference) / subject / encounter / reported[x] / authoredOn / requester / dosageInstruction.text / category |
-| Lab results | Observation (Lab Result), DiagnosticReport (Lab) | Observation, DiagnosticReport | ✅ | ⚠️ generic — Observation **not split** by sub-profile |
-| Vital signs | Vital Signs + the per-vital profiles (BP, height, weight, temp, HR, RR, SpO₂, …) | Observation | ✅ | ⚠️ generic — no per-vital handling; `component` TODO |
-| Smoking status | Smoking Status Observation | Observation | ✅ | ⚠️ generic — not differentiated |
+| Lab results | Observation (Lab Result), DiagnosticReport (Lab) | Observation, DiagnosticReport | ✅ | ✅ Observation classified by `meta.profile` + category/LOINC fallback (#146); registry covers all ~28 Observation sub-profiles. Labs: value + reference range |
+| Vital signs | Vital Signs + the per-vital profiles (BP, height, weight, temp, HR, RR, SpO₂, …) | Observation | ✅ | ✅ classified (#146); **multi-component BP** (systolic/diastolic) now rendered + `value[x]` extended. Per-vital dashboard widgets deferred |
+| Smoking status | Smoking Status Observation | Observation | ✅ | ⚠️ classified as social-history (#146); generic value render — dedicated view deferred |
 | Immunizations | Immunization | Immunization | ✅ | generic |
 | Procedures | Procedure | Procedure | ✅ | generic |
 | Clinical notes | DocumentReference, DiagnosticReport (Note) | DocumentReference, DiagnosticReport | ✅ | ✅ DocumentReference audited vs 9.0.0 (#147): MS status / type / category / subject / date / author / content.attachment (contentType, data/url — rendered & downloadable) / content.format / context |

--- a/frontend/src/app/components/fhir-card/resources/observation/observation.component.ts
+++ b/frontend/src/app/components/fhir-card/resources/observation/observation.component.ts
@@ -67,6 +67,23 @@ export class ObservationComponent implements OnInit {
         enabled: !!this.displayModel?.reference_range.hasValue(),
       }
     )
+
+    // Multi-component observations (e.g. Blood Pressure: systolic / diastolic) — US Core MS (#146).
+    for (const component of (this.displayModel?.components || [])) {
+      this.tableData.push({
+        label: component.label,
+        data: component.value_model?.display(),
+        enabled: !!component.value_model,
+      })
+    }
+
+    // Surface the declared US Core profile — only when the resource actually claims one via
+    // meta.profile (we don't present an inferred classification as if it were declared).
+    this.tableData.push({
+      label: 'US Core Profile',
+      data: this.displayModel?.us_core_profile?.profile?.display,
+      enabled: !this.displayModel?.us_core_profile?.inferred && !!this.displayModel?.us_core_profile?.profile,
+    })
   }
 
   markForCheck(){

--- a/frontend/src/lib/fixtures/r4/resources/observation/blood-pressure.json
+++ b/frontend/src/lib/fixtures/r4/resources/observation/blood-pressure.json
@@ -1,0 +1,71 @@
+{
+  "resourceType": "Observation",
+  "id": "blood-pressure",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"
+    ]
+  },
+  "status": "final",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+          "code": "vital-signs",
+          "display": "Vital Signs"
+        }
+      ]
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "85354-9",
+        "display": "Blood pressure panel with all children optional"
+      }
+    ],
+    "text": "Blood pressure systolic & diastolic"
+  },
+  "subject": {
+    "reference": "Patient/example"
+  },
+  "effectiveDateTime": "2012-09-17",
+  "component": [
+    {
+      "code": {
+        "coding": [
+          {
+            "system": "http://loinc.org",
+            "code": "8480-6",
+            "display": "Systolic blood pressure"
+          }
+        ]
+      },
+      "valueQuantity": {
+        "value": 107,
+        "unit": "mmHg",
+        "system": "http://unitsofmeasure.org",
+        "code": "mm[Hg]"
+      }
+    },
+    {
+      "code": {
+        "coding": [
+          {
+            "system": "http://loinc.org",
+            "code": "8462-4",
+            "display": "Diastolic blood pressure"
+          }
+        ]
+      },
+      "valueQuantity": {
+        "value": 60,
+        "unit": "mmHg",
+        "system": "http://unitsofmeasure.org",
+        "code": "mm[Hg]"
+      }
+    }
+  ]
+}

--- a/frontend/src/lib/models/resources/observation-model.spec.ts
+++ b/frontend/src/lib/models/resources/observation-model.spec.ts
@@ -8,6 +8,7 @@ import { BooleanModel } from '../datatypes/boolean-model';
 import { ObservationValueCodeableConceptModel } from '../datatypes/observation-value-codeable-concept-model';
 import { ReferenceRangeModel } from '../datatypes/reference-range-model';
 import { DataAbsentReasonModel } from '../datatypes/data-absent-reason-model';
+import * as bloodPressureFixture from '../../fixtures/r4/resources/observation/blood-pressure.json';
 
 describe('ObservationModel', () => {
   it('should create an instance', () => {
@@ -57,6 +58,65 @@ describe('ObservationModel', () => {
       const observation = new ObservationModel(observationR4Factory.dataAbsent().build(), fhirVersions.R4);
 
       expect(observation.value_model).toBeInstanceOf(DataAbsentReasonModel);
+    });
+
+    it('is a StringModel for valueDateTime', () => {
+      const observation = new ObservationModel({ valueDateTime: '2020-01-02' }, fhirVersions.R4);
+      expect(observation.value_model).toBeInstanceOf(StringModel);
+      expect(observation.value_model.display()).toBe('2020-01-02');
+    });
+  });
+
+  // US Core 9.0.0 profile classification + components (#146)
+  describe('US Core profile classification', () => {
+    it('classifies a Blood Pressure observation via meta.profile (not inferred)', () => {
+      const obs = new ObservationModel(bloodPressureFixture, fhirVersions.R4);
+      expect(obs.meta_profiles).toContain('http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure');
+      expect(obs.us_core_profile.kind).toBe('blood-pressure');
+      expect(obs.us_core_profile.inferred).toBe(false);
+      expect(obs.us_core_profile.profile?.display).toBe('Blood Pressure');
+    });
+
+    it('parses the systolic + diastolic components with their values', () => {
+      const obs = new ObservationModel(bloodPressureFixture, fhirVersions.R4);
+      expect(obs.components.length).toBe(2);
+      expect(obs.components[0].label).toBe('Systolic blood pressure');
+      expect(obs.components[0].value_model).toBeInstanceOf(QuantityModel);
+      expect(obs.components[0].value_model!.display()).toBe('107 mmHg');
+      expect(obs.components[1].label).toBe('Diastolic blood pressure');
+      expect(obs.components[1].value_model!.display()).toBe('60 mmHg');
+    });
+
+    it('infers laboratory from category when meta.profile is absent (non-US-Core fallback)', () => {
+      const obs = new ObservationModel({
+        status: 'final',
+        category: [{ coding: [{ system: 'http://terminology.hl7.org/CodeSystem/observation-category', code: 'laboratory' }] }],
+        code: { coding: [{ system: 'http://loinc.org', code: '718-7', display: 'Hemoglobin' }] },
+        valueQuantity: { value: 13.2, unit: 'g/dL' },
+      }, fhirVersions.R4);
+      expect(obs.us_core_profile.kind).toBe('laboratory');
+      expect(obs.us_core_profile.inferred).toBe(true);
+      expect(obs.us_core_profile.profile).toBeUndefined();
+    });
+
+    it('infers blood-pressure from component codes when meta.profile is absent', () => {
+      const obs = new ObservationModel({
+        status: 'final',
+        category: [{ coding: [{ code: 'vital-signs' }] }],
+        component: [
+          { code: { coding: [{ system: 'http://loinc.org', code: '8480-6' }] }, valueQuantity: { value: 120, unit: 'mmHg' } },
+          { code: { coding: [{ system: 'http://loinc.org', code: '8462-4' }] }, valueQuantity: { value: 80, unit: 'mmHg' } },
+        ],
+      }, fhirVersions.R4);
+      expect(obs.us_core_profile.kind).toBe('blood-pressure');
+      expect(obs.us_core_profile.inferred).toBe(true);
+    });
+
+    it('defaults to "other" with empty components for a bare observation', () => {
+      const obs = new ObservationModel({}, fhirVersions.R4);
+      expect(obs.us_core_profile.kind).toBe('other');
+      expect(obs.components).toEqual([]);
+      expect(obs.meta_profiles).toEqual([]);
     });
   });
 });

--- a/frontend/src/lib/models/resources/observation-model.ts
+++ b/frontend/src/lib/models/resources/observation-model.ts
@@ -11,6 +11,14 @@ import { BooleanModel } from '../datatypes/boolean-model';
 import { ObservationValueCodeableConceptModel } from '../datatypes/observation-value-codeable-concept-model';
 import { ReferenceRangeModel } from '../datatypes/reference-range-model';
 import { DataAbsentReasonModel } from '../datatypes/data-absent-reason-model';
+import { classifyObservationProfile, ObservationClassification } from './observation-profile-registry';
+
+// A single component of a multi-component Observation (e.g. Blood Pressure systolic/diastolic).
+export interface ObservationComponent {
+  label: string
+  code: CodableConceptModel | undefined
+  value_model: ObservationValue | undefined
+}
 
 // should have either range or value
 export interface ValueObject {
@@ -37,6 +45,12 @@ export class ObservationModel extends FastenDisplayModel {
 
   value_model: ObservationValue
 
+  // US Core 9.0.0 (#146): the claimed conformance profiles + the resolved classification (meta.profile
+  // when present, else inferred from category + LOINC code), and any value-bearing components.
+  meta_profiles: string[]
+  us_core_profile: ObservationClassification
+  components: ObservationComponent[] = []
+
   constructor(fhirResource: any, fhirVersion?: fhirVersions, fastenOptions?: FastenOptions) {
     super(fastenOptions)
     this.fhirResource = fhirResource
@@ -49,13 +63,37 @@ export class ObservationModel extends FastenDisplayModel {
     this.subject = _.get(fhirResource, 'subject');
     this.reference_range = new ReferenceRangeModel(_.get(this.fhirResource, 'referenceRange.0'))
 
-    // TODO: there are more value types that can be set: valueRange, valueRatio, valueSampledData, valueTime, valueDateTime, valuePeriod
-    // TODO: It is possible for values to be set in the Component element instead of any value component from above. Figure out what to do for that
-    if (_.get(fhirResource, 'valueQuantity')) { this.value_model = new QuantityModel(fhirResource['valueQuantity']) }
-    if (_.get(fhirResource, 'valueString')) { this.value_model = new StringModel(fhirResource['valueString']) }
-    if (_.get(fhirResource, 'valueInteger')) { this.value_model = new IntegerModel(fhirResource['valueInteger']) }
-    if (_.get(fhirResource, 'valueBoolean')) { this.value_model = new BooleanModel(fhirResource['valueBoolean']) }
-    if (_.get(fhirResource, 'valueCodeableConcept')) { this.value_model = new ObservationValueCodeableConceptModel(fhirResource['valueCodeableConcept']) }
-    if (_.get(fhirResource, 'dataAbsentReason')) { this.value_model = new DataAbsentReasonModel(fhirResource['dataAbsentReason']) }
+    this.meta_profiles = _.get(fhirResource, 'meta.profile', []) || [];
+    this.us_core_profile = classifyObservationProfile(fhirResource);
+
+    const value = ObservationModel.buildValue(fhirResource)
+    if (value) { this.value_model = value }
+
+    // Multi-component observations (e.g. Blood Pressure: systolic + diastolic). Each component carries
+    // its own code + value[x] — US Core Must-Support for the component-bearing vital-signs profiles.
+    this.components = _.get(fhirResource, 'component', []).map((component: any): ObservationComponent => ({
+      label: _.get(component, 'code.coding.0.display') || _.get(component, 'code.text') || _.get(component, 'code.coding.0.code') || 'Component',
+      code: new CodableConceptModel(_.get(component, 'code')),
+      value_model: ObservationModel.buildValue(component),
+    }))
+  }
+
+  // Builds the ObservationValue for a value[x] carrier (the Observation itself or a component).
+  // Returns the first value[x] present; undefined if none.
+  static buildValue(source: any): ObservationValue | undefined {
+    if (_.get(source, 'valueQuantity')) { return new QuantityModel(source['valueQuantity']) }
+    if (_.get(source, 'valueString')) { return new StringModel(source['valueString']) }
+    if (_.get(source, 'valueInteger')) { return new IntegerModel(source['valueInteger']) }
+    if (_.get(source, 'valueBoolean')) { return new BooleanModel(source['valueBoolean']) }
+    if (_.get(source, 'valueCodeableConcept')) { return new ObservationValueCodeableConceptModel(source['valueCodeableConcept']) }
+    // value[x] types without a dedicated model render as their string form (#146).
+    if (_.get(source, 'valueDateTime')) { return new StringModel(source['valueDateTime']) }
+    if (_.get(source, 'valuePeriod')) {
+      return new StringModel([_.get(source, 'valuePeriod.start'), _.get(source, 'valuePeriod.end')].filter(Boolean).join(' – '))
+    }
+    if (_.get(source, 'valueTime')) { return new StringModel(source['valueTime']) }
+    if (_.get(source, 'dataAbsentReason')) { return new DataAbsentReasonModel(source['dataAbsentReason']) }
+    // TODO (#146 follow-up): valueRange, valueRatio, valueSampledData need dedicated value models.
+    return undefined
   }
 }

--- a/frontend/src/lib/models/resources/observation-profile-registry.ts
+++ b/frontend/src/lib/models/resources/observation-profile-registry.ts
@@ -1,0 +1,110 @@
+import _ from "lodash";
+
+// US Core 9.0.0 Observation profiles — the full family from
+// https://www.hl7.org/fhir/us/core/#us-core-profiles (each profile is a SHALL-contract identified by
+// its canonical URL, which is what appears in Observation.meta.profile).
+//
+// We classify an Observation by its claimed meta.profile; when meta.profile is absent — common in
+// imported / non-US-Core exports (e.g. Veradigm/FollowMyHealth) — we fall back to category + LOINC
+// code. This registry is the single source of truth: it lists every Observation profile so adding
+// richer handling later is an additive change. #146 renders the first slice richly (Laboratory,
+// Vital Signs, Blood Pressure); the rest classify and degrade gracefully to the generic value view.
+
+const US_CORE = 'http://hl7.org/fhir/us/core/StructureDefinition/';
+
+// Rendering-meaningful grouping of the profiles (NOT a US Core concept — our display routing).
+export type ObservationProfileKind =
+  | 'laboratory'
+  | 'vital-signs'
+  | 'blood-pressure'      // component-bearing (systolic + diastolic)
+  | 'social-history'
+  | 'preference'
+  | 'pregnancy'
+  | 'advance-directive'
+  | 'other';
+
+export interface ObservationProfileEntry {
+  canonical: string;
+  display: string;
+  kind: ObservationProfileKind;
+  hasComponents?: boolean;
+}
+
+function entry(id: string, display: string, kind: ObservationProfileKind, hasComponents = false): [string, ObservationProfileEntry] {
+  const canonical = US_CORE + id;
+  return [canonical, { canonical, display, kind, hasComponents }];
+}
+
+// Keyed by canonical URL (the meta.profile value).
+export const US_CORE_OBSERVATION_PROFILES: Record<string, ObservationProfileEntry> = Object.fromEntries([
+  // Lab / results
+  entry('us-core-observation-lab', 'Laboratory Result', 'laboratory'),
+  entry('us-core-observation-clinical-result', 'Clinical Result', 'laboratory'),
+  entry('us-core-simple-observation', 'Simple Observation', 'other'),
+  entry('us-core-observation-screening-assessment', 'Screening / Assessment', 'other'),
+  // Vital signs (parent + subtypes)
+  entry('us-core-vital-signs', 'Vital Signs', 'vital-signs'),
+  entry('us-core-blood-pressure', 'Blood Pressure', 'blood-pressure', true),
+  entry('us-core-average-blood-pressure', 'Average Blood Pressure', 'blood-pressure', true),
+  entry('us-core-bmi', 'BMI', 'vital-signs'),
+  entry('us-core-body-height', 'Body Height', 'vital-signs'),
+  entry('us-core-body-weight', 'Body Weight', 'vital-signs'),
+  entry('us-core-body-temperature', 'Body Temperature', 'vital-signs'),
+  entry('us-core-head-circumference', 'Head Circumference', 'vital-signs'),
+  entry('us-core-heart-rate', 'Heart Rate', 'vital-signs'),
+  entry('us-core-pulse-oximetry', 'Pulse Oximetry', 'vital-signs'),
+  entry('us-core-respiratory-rate', 'Respiratory Rate', 'vital-signs'),
+  entry('pediatric-bmi-for-age', 'Pediatric BMI for Age', 'vital-signs'),
+  entry('pediatric-weight-for-height', 'Pediatric Weight for Height', 'vital-signs'),
+  entry('head-occipital-frontal-circumference-percentile', 'Pediatric Head Circumference Percentile', 'vital-signs'),
+  // Social / behavioral
+  entry('us-core-smokingstatus', 'Smoking Status', 'social-history'),
+  entry('us-core-observation-occupation', 'Occupation', 'social-history'),
+  entry('us-core-observation-sexual-orientation', 'Sexual Orientation', 'social-history'),
+  // Preferences / intent
+  entry('us-core-care-experience-preference', 'Care Experience Preference', 'preference'),
+  entry('us-core-treatment-intervention-preference', 'Treatment Intervention Preference', 'preference'),
+  entry('us-core-observation-pregnancyintent', 'Pregnancy Intent', 'pregnancy'),
+  entry('us-core-observation-pregnancystatus', 'Pregnancy Status', 'pregnancy'),
+  // Advance directives
+  entry('us-core-observation-adi-documentation', 'Advance Directive Documentation', 'advance-directive'),
+]);
+
+// LOINC codes used to recognise a blood-pressure observation when meta.profile is absent.
+const BP_PANEL_CODES = ['85354-9', '55284-4'];     // BP panel codes
+const BP_SYSTOLIC = '8480-6';
+const BP_DIASTOLIC = '8462-4';
+
+export interface ObservationClassification {
+  profile?: ObservationProfileEntry;   // matched registry entry (only when meta.profile is known)
+  kind: ObservationProfileKind;        // resolved kind (from registry or inferred)
+  canonical?: string;                  // the matched meta.profile URL
+  inferred: boolean;                   // true => resolved via category/code fallback, not meta.profile
+}
+
+// Classify by meta.profile (primary), else infer from category + LOINC code (fallback for data that
+// doesn't declare conformance — the common case for imported non-US-Core exports).
+export function classifyObservationProfile(fhirResource: any): ObservationClassification {
+  const metaProfiles: string[] = _.get(fhirResource, 'meta.profile', []) || [];
+  for (const url of metaProfiles) {
+    const matched = US_CORE_OBSERVATION_PROFILES[url];
+    if (matched) {
+      return { profile: matched, kind: matched.kind, canonical: url, inferred: false };
+    }
+  }
+
+  // Fallback inference
+  const categoryCodes: string[] = (_.get(fhirResource, 'category', []) as any[])
+    .flatMap((c) => _.get(c, 'coding', []).map((cd: any) => cd.code));
+  const codes: string[] = _.get(fhirResource, 'code.coding', []).map((c: any) => c.code);
+  const componentCodes: string[] = (_.get(fhirResource, 'component', []) as any[])
+    .flatMap((comp) => _.get(comp, 'code.coding', []).map((c: any) => c.code));
+
+  const looksLikeBP = codes.some((c) => BP_PANEL_CODES.includes(c))
+    || (componentCodes.includes(BP_SYSTOLIC) && componentCodes.includes(BP_DIASTOLIC));
+  if (looksLikeBP) return { kind: 'blood-pressure', inferred: true };
+  if (categoryCodes.includes('laboratory')) return { kind: 'laboratory', inferred: true };
+  if (categoryCodes.includes('vital-signs')) return { kind: 'vital-signs', inferred: true };
+  if (categoryCodes.includes('social-history')) return { kind: 'social-history', inferred: true };
+  return { kind: 'other', inferred: true };
+}


### PR DESCRIPTION
First slice of Observation sub-profiles (epic #136). US Core defines **~28 Observation profiles**, each a SHALL-contract identified by its canonical URL (`meta.profile`). Built **registry-first** so this scales instead of hardcoding branches.

## What landed
- **`observation-profile-registry.ts`** — the full US Core 9.0.0 Observation family keyed by canonical URL (lab/clinical-result/simple/screening; vital-signs + every per-vital subtype incl. (average) blood-pressure, BMI, height, weight, temp, HR, RR, SpO₂, pediatric; smoking/occupation/sexual-orientation; care/treatment preference; pregnancy; ADI). Single source of truth — new profiles are one-line additions.
- **`classifyObservationProfile()`** — resolves by `meta.profile` (primary), **falls back to category + LOINC code** when `meta.profile` is absent (the common non-US-Core / Veradigm-FMH reality). **Display-only** per the agreed stance: we classify + render, we do **not** flag SHALL violations (a viewer displays; it doesn't validate).
- **`ObservationModel`** — parses `meta.profile`, exposes `us_core_profile`, and fixes the long-standing **`component` TODO**: `components[]` (code + value) so **multi-component Blood Pressure (systolic/diastolic)** renders. Extracted `buildValue()` + extended `value[x]` (valueDateTime/valuePeriod/valueTime).
- **Card** renders each component as its own row, and surfaces the declared profile *only when actually claimed via `meta.profile`* (never an inferred guess).
- Synthetic **BP fixture**; **model spec 15/15, component spec 3/3** green.

## Scope
**Lab + Vital Signs + BP handled richly; the other ~24 classify and degrade gracefully** to the generic value view. Per-profile **dashboard widgets** stay deferred to #136's end-state.

## On closing #146
The issue's acceptance — *"labs vs vitals rendered with their Must-Support elements incl. multi-component (BP); vs 9.0.0 examples"* — **is met** here. I used `Refs` (not `Fixes`) so you can decide: close #146 on merge (and let the remaining ~24 sub-profiles + dashboard widgets live under #136 / new issues), or keep it open as the umbrella for the full split. Your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)