### PR TITLE
feat(us-core): add Provenance display model + card (#162)

### DIFF
--- a/docs/us-core/README.md
+++ b/docs/us-core/README.md
@@ -14,9 +14,9 @@ How YourPHR relates to the [FHIR **US Core** Implementation Guide](https://hl7.o
 
 ## Role and target
 
-- **Actor:** YourPHR is a US Core **Requestor / Client** — it imports FHIR bundles and fetches data via the SMART relay, then displays it. It is **not** a Responder/Server (it doesn't serve a FHIR API). So only the *Requestor* actor applies.
+- **Actor:** YourPHR is a US Core **Requestor / Client** — it imports FHIR bundles and fetches data via the SMART relay, then displays it. It is **not** a Responder/Server (it doesn't serve a FHIR API). So only the _Requestor_ actor applies.
 - **Target version:** **US Core 9.0.0 (STU 9)** (published 2026-05-31), FHIR R4 — the latest published release.
-- **Client conformance bar:** be able to **process and display the Must-Support data elements** of US Core profiles. (We don't need to *produce* conformant resources.)
+- **Client conformance bar:** be able to **process and display the Must-Support data elements** of US Core profiles. (We don't need to _produce_ conformant resources.)
 
 ## Support matrix (current)
 
@@ -55,7 +55,7 @@ Backend coverage is broad — ~56 generated FHIR R4 resource models with search-
 
 ## Roadmap
 
-Tracked in epic [#136](https://github.com/jwilleke/yourphr/issues/136): pick the target version (done — 9.0.0), audit + complete Must-Support display per profile (prioritizing the Cures-Act USCDI core: problems, medications, allergies, labs+vitals, clinical notes), add the missing resources, then verify with Inferno. Complement: [#54](https://github.com/jwilleke/yourphr/issues/54) handles *non*-US-Core (non-conformant) data display.
+Tracked in epic [#136](https://github.com/jwilleke/yourphr/issues/136): pick the target version (done — 9.0.0), audit + complete Must-Support display per profile (prioritizing the Cures-Act USCDI core: problems, medications, allergies, labs+vitals, clinical notes), add the missing resources, then verify with Inferno. Complement: [#54](https://github.com/jwilleke/yourphr/issues/54) handles _non_-US-Core (non-conformant) data display.
 
 ## Per-profile dashboards
 

--- a/docs/us-core/README.md
+++ b/docs/us-core/README.md
@@ -2,7 +2,7 @@
 
 > **Status (2026-06-08):** The six Cures-Act USCDI **core** profiles are now audited for **Must-Support _display_** vs US Core 9.0.0 — Patient ([#142](https://github.com/jwilleke/yourphr/issues/142)), AllergyIntolerance ([#145](https://github.com/jwilleke/yourphr/issues/145)), Condition ([#143](https://github.com/jwilleke/yourphr/issues/143)), MedicationRequest ([#144](https://github.com/jwilleke/yourphr/issues/144)), DocumentReference ([#147](https://github.com/jwilleke/yourphr/issues/147)), and Observation (labs + vital signs incl. multi-component blood pressure, [#146](https://github.com/jwilleke/yourphr/issues/146)).
 >
-> **All other resource types still render as generic FHIR R4**; Provenance and QuestionnaireResponse have no display model yet, and ~24 Observation sub-profiles classify but render generically.
+> **Most other resource types still render as generic FHIR R4**; QuestionnaireResponse has no display model yet, and ~24 Observation sub-profiles classify but render generically. (Provenance now has a display model, [#162](https://github.com/jwilleke/yourphr/issues/162).)
 >
 > This is **display progress, not a conformance claim**: nothing has been verified against the ONC **Inferno** US Core test kit, so YourPHR is **not yet verified-conformant** to any US Core version. The rest is tracked in epic [#136](https://github.com/jwilleke/yourphr/issues/136).
 >
@@ -40,7 +40,7 @@ How YourPHR relates to the [FHIR **US Core** Implementation Guide](https://hl7.o
 | Care providers / orgs | Practitioner, PractitionerRole, Organization, Location | Practitioner, PractitionerRole, Organization, Location | ✅ | partial (practitionerrole ext) |
 | Related person | RelatedPerson | RelatedPerson | ✅ | generic |
 | Coverage / specimen / service request | Coverage, Specimen, ServiceRequest | Coverage, Specimen, ServiceRequest | ✅ | generic |
-| **Provenance** | US Core Provenance | Provenance | ❌ **none** | ❌ required by US Core; missing |
+| Provenance | US Core Provenance | Provenance | ✅ | ✅ display model added (#162): MS target[] / recorded / agent[] (type, who, onBehalfOf) — author/transmitter; resolves agent + target references |
 | **Questionnaire responses** | QuestionnaireResponse | QuestionnaireResponse | ❌ **none** | ❌ (lforms renders questionnaires, but no QR display model) |
 
 Backend coverage is broad — ~56 generated FHIR R4 resource models with search-parameter extraction handle storage/indexing for essentially all of these. A code→display **glossary** renders coded values (LOINC / SNOMED / RxNorm).
@@ -49,7 +49,7 @@ Backend coverage is broad — ~56 generated FHIR R4 resource models with search-
 
 1. **No profile-level Must-Support audit** — we render generic FHIR R4, not per US Core 9.0.0 profile.
 2. **Observation isn't split** into US Core's ~15 sub-profiles (vitals, labs, smoking, sexual orientation, occupation, screening, …).
-3. **Missing resources:** Provenance (US-Core-required) and QuestionnaireResponse have no display models.
+3. **Missing resources:** QuestionnaireResponse has no display model ([#160](https://github.com/jwilleke/yourphr/issues/160)). (Provenance done — [#162](https://github.com/jwilleke/yourphr/issues/162).)
 4. **Extensions beyond Patient** aren't handled.
 5. **No conformance verification** — nothing checked against US Core 9.0.0 examples or the ONC **Inferno** test kit.
 

--- a/frontend/src/app/components/fhir-card/fhir-card/fhir-card.component.ts
+++ b/frontend/src/app/components/fhir-card/fhir-card/fhir-card.component.ts
@@ -23,6 +23,7 @@ import {MedicationComponent} from '../resources/medication/medication.component'
 import {MedicationRequestComponent} from '../resources/medication-request/medication-request.component';
 import {FastenDisplayModel} from '../../../../lib/models/fasten/fasten-display-model';
 import {ProcedureComponent} from '../resources/procedure/procedure.component';
+import {ProvenanceComponent} from '../resources/provenance/provenance.component';
 import {DiagnosticReportComponent} from '../resources/diagnostic-report/diagnostic-report.component';
 import {PractitionerComponent} from '../resources/practitioner/practitioner.component';
 import {DocumentReferenceComponent} from '../resources/document-reference/document-reference.component';
@@ -174,6 +175,9 @@ export class FhirCardComponent implements OnInit, OnChanges {
       }
       case "Procedure": {
         return ProcedureComponent;
+      }
+      case "Provenance": {
+        return ProvenanceComponent;
       }
       case "Practitioner": {
         return PractitionerComponent;

--- a/frontend/src/app/components/fhir-card/resources/provenance/provenance.component.html
+++ b/frontend/src/app/components/fhir-card/resources/provenance/provenance.component.html
@@ -1,0 +1,14 @@
+<div class="card card-fhir-resource">
+  <div class="card-header" (click)="isCollapsed = ! isCollapsed">
+    <div>
+      <h6 class="card-title">{{displayModel?.sort_title || 'Provenance'}}</h6>
+    </div>
+  </div>
+  <div #collapse="ngbCollapse" [(ngbCollapse)]="isCollapsed" class="card-body">
+    <p class="az-content-text mg-b-20">Provenance — who or what was responsible for creating or transmitting this record, and when. The audit trail for the data's origin.</p>
+    <fhir-ui-table [displayModel]="displayModel" [tableData]="tableData"></fhir-ui-table>
+  </div>
+  <div *ngIf="showDetails" class="card-footer">
+    <a class="float-right" [routerLink]="['/explore', displayModel?.source_id, 'resource', displayModel?.source_resource_id]">details</a>
+  </div>
+</div>

--- a/frontend/src/app/components/fhir-card/resources/provenance/provenance.component.spec.ts
+++ b/frontend/src/app/components/fhir-card/resources/provenance/provenance.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProvenanceComponent } from './provenance.component';
+import {RouterTestingModule} from '@angular/router/testing';
+
+describe('ProvenanceComponent', () => {
+  let component: ProvenanceComponent;
+  let fixture: ComponentFixture<ProvenanceComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ RouterTestingModule, ProvenanceComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ProvenanceComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/components/fhir-card/resources/provenance/provenance.component.ts
+++ b/frontend/src/app/components/fhir-card/resources/provenance/provenance.component.ts
@@ -1,0 +1,75 @@
+import {ChangeDetectorRef, Component, Input, OnInit} from '@angular/core';
+import {NgbCollapseModule} from '@ng-bootstrap/ng-bootstrap';
+import {CommonModule} from '@angular/common';
+import {TableComponent} from '../../common/table/table.component';
+import {Router, RouterModule} from '@angular/router';
+import {FhirCardComponentInterface} from '../../fhir-card/fhir-card-component-interface';
+import {TableRowItem, TableRowItemDataType} from '../../common/table/table-row-item';
+import {ProvenanceModel} from '../../../../../lib/models/resources/provenance-model';
+
+@Component({
+    imports: [NgbCollapseModule, CommonModule, TableComponent, RouterModule],
+    selector: 'fhir-provenance',
+    templateUrl: './provenance.component.html',
+    styleUrls: ['./provenance.component.scss']
+})
+export class ProvenanceComponent implements OnInit, FhirCardComponentInterface {
+  @Input() displayModel: ProvenanceModel
+  @Input() showDetails = true
+  @Input() isCollapsed = false
+
+  tableData: TableRowItem[] = []
+
+  constructor(public changeRef: ChangeDetectorRef, public router: Router) { }
+
+  ngOnInit(): void {
+    if (!this.displayModel) { return }
+
+    this.tableData.push({
+      label: 'Recorded',
+      data: this.displayModel?.recorded,
+      enabled: !!this.displayModel?.recorded,
+    })
+
+    if (this.displayModel?.activity) {
+      this.tableData.push({
+        label: 'Activity',
+        data: this.displayModel?.activity,
+        data_type: TableRowItemDataType.CodableConcept,
+        enabled: !!this.displayModel?.activity?.coding?.length,
+      })
+    }
+
+    // agent[] — who was involved (author / transmitter / …) and on whose behalf.
+    for (const agent of (this.displayModel?.agents || [])) {
+      this.tableData.push({
+        label: agent.type ? `Agent — ${agent.type}` : 'Agent',
+        data: agent.who,
+        data_type: TableRowItemDataType.Reference,
+        enabled: !!agent.who,
+      })
+      if (agent.on_behalf_of) {
+        this.tableData.push({
+          label: 'On behalf of',
+          data: agent.on_behalf_of,
+          data_type: TableRowItemDataType.Reference,
+          enabled: !!agent.on_behalf_of,
+        })
+      }
+    }
+
+    // target[] — the resource(s) this provenance is about.
+    for (const target of (this.displayModel?.targets || [])) {
+      this.tableData.push({
+        label: 'Target',
+        data: target,
+        data_type: TableRowItemDataType.Reference,
+        enabled: !!target,
+      })
+    }
+  }
+
+  markForCheck(){
+    this.changeRef.markForCheck()
+  }
+}

--- a/frontend/src/lib/fixtures/r4/resources/provenance/example1.json
+++ b/frontend/src/lib/fixtures/r4/resources/provenance/example1.json
@@ -1,0 +1,60 @@
+{
+  "resourceType": "Provenance",
+  "id": "example",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance"
+    ]
+  },
+  "target": [
+    {
+      "reference": "DocumentReference/episode-summary"
+    }
+  ],
+  "recorded": "2016-05-26T12:46:25Z",
+  "agent": [
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code": "author",
+            "display": "Author"
+          }
+        ]
+      },
+      "who": {
+        "reference": "Practitioner/practitioner-1",
+        "display": "Dr. Adam Everyman"
+      },
+      "onBehalfOf": {
+        "reference": "Organization/org-1",
+        "display": "Good Health Clinic"
+      }
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+            "code": "transmitter",
+            "display": "Transmitter"
+          }
+        ]
+      },
+      "who": {
+        "reference": "Organization/org-1",
+        "display": "Good Health Clinic"
+      }
+    }
+  ],
+  "activity": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-DataOperation",
+        "code": "CREATE",
+        "display": "create"
+      }
+    ]
+  }
+}

--- a/frontend/src/lib/models/factory.ts
+++ b/frontend/src/lib/models/factory.ts
@@ -20,6 +20,7 @@ import {PatientModel} from './resources/patient-model';
 import {PractitionerModel} from './resources/practitioner-model';
 import {PractitionerRoleModel} from './resources/practitioner-role-model';
 import {ProcedureModel} from './resources/procedure-model';
+import {ProvenanceModel} from './resources/provenance-model';
 import {RelatedPersonModel} from './resources/related-person-model';
 import {ResearchStudyModel} from './resources/research-study-model';
 import {FastenOptions} from './fasten/fasten-options';
@@ -162,6 +163,9 @@ export function fhirModelFactory(
       break
     case ResourceType.Procedure:
       resourceModel = new ProcedureModel(fhirResourceWrapper.resource_raw, fhirVersion, fastenOptions)
+      break
+    case ResourceType.Provenance:
+      resourceModel = new ProvenanceModel(fhirResourceWrapper.resource_raw, fhirVersion, fastenOptions)
       break
     // case ResourceType.Questionnaire:
     //   resourceModel = new QuestionnaireModel(fhirResourceWrapper.resource_raw, fhirVersion, fastenOptions)

--- a/frontend/src/lib/models/resources/provenance-model.spec.ts
+++ b/frontend/src/lib/models/resources/provenance-model.spec.ts
@@ -1,0 +1,30 @@
+import { ProvenanceModel } from './provenance-model';
+import * as example1Fixture from '../../fixtures/r4/resources/provenance/example1.json';
+
+describe('ProvenanceModel', () => {
+  it('should create an instance', () => {
+    expect(new ProvenanceModel({})).toBeTruthy();
+  });
+
+  it('parses target, recorded, agents and activity from r4 example1', () => {
+    const m = new ProvenanceModel(example1Fixture);
+    expect(m.recorded).toBe('2016-05-26T12:46:25Z');
+    expect(m.targets).toEqual([{ reference: 'DocumentReference/episode-summary' }]);
+    expect(m.agents.length).toBe(2);
+    expect(m.agents[0].type).toBe('Author');
+    expect(m.agents[0].who).toEqual({ reference: 'Practitioner/practitioner-1', display: 'Dr. Adam Everyman' });
+    expect(m.agents[0].on_behalf_of).toEqual({ reference: 'Organization/org-1', display: 'Good Health Clinic' });
+    expect(m.agents[1].type).toBe('Transmitter');
+    expect(m.agents[1].who).toEqual({ reference: 'Organization/org-1', display: 'Good Health Clinic' });
+    expect(m.agents[1].on_behalf_of).toBeUndefined();
+    expect(m.activity?.coding?.[0]?.display).toBe('create');
+  });
+
+  it('defaults to empty arrays / undefined for a bare resource', () => {
+    const m = new ProvenanceModel({});
+    expect(m.targets).toEqual([]);
+    expect(m.agents).toEqual([]);
+    expect(m.recorded).toBeUndefined();
+    expect(m.activity).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/models/resources/provenance-model.ts
+++ b/frontend/src/lib/models/resources/provenance-model.ts
@@ -1,0 +1,38 @@
+import * as _ from "lodash";
+import {fhirVersions, ResourceType} from '../constants';
+import {ReferenceModel} from '../datatypes/reference-model';
+import {CodableConceptModel} from '../datatypes/codable-concept-model';
+import {FastenDisplayModel} from '../fasten/fasten-display-model';
+import {FastenOptions} from '../fasten/fasten-options';
+
+// A single Provenance.agent — who was involved, how, and on whose behalf.
+export interface ProvenanceAgent {
+  type: string | undefined           // agent.type display (e.g. Author / Transmitter)
+  who: ReferenceModel | undefined    // agent.who — Practitioner/Organization/Patient/PractitionerRole/RelatedPerson/Device (1..1)
+  on_behalf_of: ReferenceModel | undefined   // agent.onBehalfOf — Organization
+}
+
+// US Core 9.0.0 Provenance (#162). Provenance is US-Core-required: the audit trail of who/what
+// created a record and when. Must-Support: target[] (1..*), recorded (1..1), agent[] (1..*) with
+// agent.type / agent.who / agent.onBehalfOf. occurred[x] and activity are not MS (activity shown
+// when present). https://hl7.org/fhir/us/core/StructureDefinition-us-core-provenance.html
+export class ProvenanceModel extends FastenDisplayModel {
+  targets: ReferenceModel[] = []
+  recorded: string | undefined
+  agents: ProvenanceAgent[] = []
+  activity: CodableConceptModel | undefined
+
+  constructor(fhirResource: any, fhirVersion?: fhirVersions, fastenOptions?: FastenOptions) {
+    super(fastenOptions)
+    this.source_resource_type = ResourceType.Provenance
+
+    this.targets = _.get(fhirResource, 'target', []);
+    this.recorded = _.get(fhirResource, 'recorded');
+    this.agents = _.get(fhirResource, 'agent', []).map((agent: any): ProvenanceAgent => ({
+      type: _.get(agent, 'type.coding.0.display') || _.get(agent, 'type.coding.0.code') || _.get(agent, 'type.text'),
+      who: _.get(agent, 'who'),
+      on_behalf_of: _.get(agent, 'onBehalfOf'),
+    }));
+    this.activity = _.get(fhirResource, 'activity') ? new CodableConceptModel(_.get(fhirResource, 'activity')) : undefined;
+  }
+}


### PR DESCRIPTION
Fixes #162 — Provenance is **US-Core-required** but had **no display model** (it fell through to the generic fallback). Closes one of the two missing-resource gaps in epic #136.

## Verified MS set (vs live 9.0.0 StructureDefinition)
- `target[]` (Reference, **1..\***) — what the provenance is about
- `recorded` (instant, **1..1**)
- `agent[]` (**1..\***): `agent.type`, `agent.who` (1..1 → Practitioner/Organization/Patient/PractitionerRole/RelatedPerson/Device), `agent.onBehalfOf` (Organization); author/transmitter slices
- `occurred[x]` / `activity` are **not** MS (activity rendered when present)

## What landed
- **`ProvenanceModel`** — parses targets, recorded, agents (type/who/onBehalfOf), activity.
- **`ProvenanceComponent`** (fhir-card) — renders Recorded, Activity, an **Agent row per agent** (labelled by type, e.g. "Agent — Author") with its **On behalf of**, and a **Target row per target**; resolves agent + target references via the existing Reference renderer.
- **Wired in:** `factory.ts` (resource → model) + the fhir-card `typeLookup` (type → card component).
- Synthetic US Core Provenance **fixture**; **model spec 3/3 + component spec green**; **sandbox build clean**.
- README matrix: Provenance `❌ none` → `✅`; status + gaps lines updated (only QuestionnaireResponse #160 remains of the two missing resources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)