### PR TITLE
chore(frontend): align angular.json default outputPath with the actual build path (../dist)

### DIFF
--- a/config.e2e.yaml
+++ b/config.e2e.yaml
@@ -11,6 +11,8 @@ web:
       enabled: false
   src:
     frontend:
+      # repo-root ./dist = the Angular build output. `yarn run build` (and the Dockerfile/CI) all
+      # emit here via `--output-path=../dist`; angular.json's default outputPath matches (../dist).
       path: ./dist
 database:
   type: sqlite

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -18,7 +18,7 @@
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
             "sourceMap": true,
-            "outputPath": "dist/fastenhealth",
+            "outputPath": "../dist",
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",


### PR DESCRIPTION
While bringing up the E2E app locally I flagged an apparent build/serve path inconsistency. On investigation it's **not** a functional bug — just **misleading dead config**.

## Finding
- The Angular build target's default `outputPath` was `dist/fastenhealth`.
- But **every** build path overrides it with `--output-path=../dist`: the `build` + `dist` npm scripts, the Dockerfile, and cloud-deploy.
- `config.e2e.yaml` serves repo-root `./dist` (`base.StaticFS("/web", http.Dir(frontend.path))`, backend cwd = repo root) — which **is** `../dist` from `frontend/`. So build output and serve path already match; `make test-e2e` works in CI for this reason.
- `dist/fastenhealth` is referenced nowhere — pure dead default.

## Change
- angular.json: default `outputPath` `dist/fastenhealth` → `../dist` (matches every caller + the e2e serve path; a bare `ng build` now lands where everything expects).
- config.e2e.yaml: one-line comment documenting that `./dist` is the build output.

## Safety
No behavioural change — existing builds already pass `--output-path=../dist`. Verified a **bare** `ng build --configuration sandbox` (exercising the new default) outputs to repo-root/dist with nothing in the old path. CI's **E2E (Playwright)** job serves from this dist path, so it validates the wiring end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)