### PR TITLE
fix(condition): display clinical/verification status from non-US-Core shapes (#54)

### DIFF
--- a/frontend/src/lib/models/resources/condition-model.spec.ts
+++ b/frontend/src/lib/models/resources/condition-model.spec.ts
@@ -84,4 +84,44 @@ describe('ConditionModel', () => {
 
   })
 
+  // Non-US-Core hardening (#54): the same data should display whether clinicalStatus/verificationStatus
+  // arrive as a US Core CodeableConcept, a text-only concept, or a loose plain-string code.
+  describe('non-US-Core status shapes (#54)', () => {
+    it('resolves a US Core CodeableConcept (code-first for clinical, display-first for verification)', () => {
+      const m = new ConditionModel({
+        code: { text: 'Asthma' },
+        clinicalStatus: { coding: [{ code: 'active', display: 'Active' }] },
+        verificationStatus: { coding: [{ code: 'confirmed', display: 'Confirmed' }] },
+      });
+      expect(m.clinical_status).toBe('active');
+      expect(m.verification_status).toBe('Confirmed');
+    });
+
+    it('resolves a text-only concept (no coding)', () => {
+      const m = new ConditionModel({
+        code: { text: 'Asthma' },
+        clinicalStatus: { text: 'Active' },
+        verificationStatus: { text: 'Confirmed' },
+      });
+      expect(m.clinical_status).toBe('Active');
+      expect(m.verification_status).toBe('Confirmed');
+    });
+
+    it('resolves a loose plain-string code (Veradigm/FollowMyHealth-style)', () => {
+      const m = new ConditionModel({
+        code: { text: 'Asthma' },
+        clinicalStatus: 'active',
+        verificationStatus: 'confirmed',
+      });
+      expect(m.clinical_status).toBe('active');
+      expect(m.verification_status).toBe('confirmed');
+    });
+
+    it('leaves status undefined when absent (no crash)', () => {
+      const m = new ConditionModel({ code: { text: 'Asthma' } });
+      expect(m.clinical_status).toBeUndefined();
+      expect(m.verification_status).toBeUndefined();
+    });
+  });
+
 });

--- a/frontend/src/lib/models/resources/condition-model.ts
+++ b/frontend/src/lib/models/resources/condition-model.ts
@@ -68,9 +68,11 @@ export class ConditionModel extends FastenDisplayModel {
   };
 
   r4DTO(fhirResource:any){
-    this.clinical_status = _.get(fhirResource, 'clinicalStatus.coding.0.code');
-    this.verification_status = _.get(fhirResource, 'verificationStatus.coding.0.display')
-      || _.get(fhirResource, 'verificationStatus.coding.0.code');
+    // Non-US-Core hardening (#54): clinical/verification status may arrive as a US Core
+    // CodeableConcept, a text-only concept (no coding), or a loose plain-string code (Veradigm/FMH).
+    // Resolve all shapes so the status always displays. clinical_status stays code-first (e.g. 'active').
+    this.clinical_status = ConditionModel.resolveStatus(_.get(fhirResource, 'clinicalStatus'));
+    this.verification_status = ConditionModel.resolveStatus(_.get(fhirResource, 'verificationStatus'), true);
     // category[] distinguishes problem-list-item vs health-concern (US Core required slice)
     this.categories = _.get(fhirResource, 'category', [])
       .map((c:any) => _.get(c, 'coding.0.display') || _.get(c, 'text') || _.get(c, 'coding.0.code'))
@@ -102,5 +104,18 @@ export class ConditionModel extends FastenDisplayModel {
         throw Error('Unrecognized the fhir version property type.');
     }
   };
+
+  // Resolve a status-like element to a display string regardless of conformance (#54): a US Core
+  // CodeableConcept ({coding:[{code,display}]}), a text-only concept ({text}), or a loose plain-string
+  // code ("active") as some non-US-Core exporters (Veradigm/FollowMyHealth) emit. Code-first by
+  // default (preserves US Core codes like 'active'); preferDisplay flips to display-first.
+  static resolveStatus(value: any, preferDisplay = false): string | undefined {
+    if (value == null) { return undefined }
+    if (typeof value === 'string') { return value }
+    const code = _.get(value, 'coding.0.code');
+    const display = _.get(value, 'coding.0.display');
+    const text = _.get(value, 'text');
+    return preferDisplay ? (display || code || text) : (code || display || text);
+  }
 
 }


### PR DESCRIPTION
Part of #54 (non-US-Core display). Aligned with the project stance we settled on: **accurately display the patient's data regardless of conformance — a viewer displays, it doesn't validate.**

## Gap
`Condition.clinicalStatus` / `verificationStatus` were read as only `coding.0.code` / `coding.0.display`. Loose exporters (Veradigm/FollowMyHealth) often send these as a **text-only CodeableConcept** (no `coding`) or even a **plain string** (`"active"`) — in which case the status rendered **blank** despite the data being present.

## Fix
`ConditionModel.resolveStatus()` resolves all three shapes:
- US Core CodeableConcept (`coding.0.code`/`display`)
- text-only concept (`text`)
- loose plain-string code

`clinicalStatus` stays **code-first** (preserves US Core codes like `active`); `verificationStatus` is **display-first**. Purely additive — conformant data is unchanged (the #143 example `toEqual` specs still pass). **No UI conformance-flagging** — just accurate display.

## Tests
+4 cases (CodeableConcept / text-only / plain-string / absent-no-crash). **8/8 green.**

## Scope notes
- **Encounter** non-US-Core fallbacks (`class.code`, type-from-location synthesis) are **already implemented + tested** — no change needed there.
- **Backend search-param extraction** for non-US-Core data (the other half of #54) is a separate, deferred backend concern — not touched here.
- Hence `Refs #54`, not `Fixes` — this is the Condition display slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)