### PR TITLE
fix(allergy): non-US-Core status display + shared resolveStatus util (#54)

### DIFF
--- a/frontend/src/lib/models/datatypes/resolve-status.spec.ts
+++ b/frontend/src/lib/models/datatypes/resolve-status.spec.ts
@@ -1,0 +1,33 @@
+import { resolveStatus } from './resolve-status';
+
+describe('resolveStatus (#54 non-US-Core)', () => {
+  it('returns undefined for null/undefined', () => {
+    expect(resolveStatus(undefined)).toBeUndefined();
+    expect(resolveStatus(null)).toBeUndefined();
+  });
+
+  it('returns a plain string as-is (loose non-US-Core exporters)', () => {
+    expect(resolveStatus('active')).toBe('active');
+  });
+
+  it('code-first by default (preserves US Core codes)', () => {
+    expect(resolveStatus({ coding: [{ code: 'active', display: 'Active' }] })).toBe('active');
+  });
+
+  it('display-first when preferDisplay=true', () => {
+    expect(resolveStatus({ coding: [{ code: 'active', display: 'Active' }] }, true)).toBe('Active');
+  });
+
+  it('falls back to coding display when no code (code-first)', () => {
+    expect(resolveStatus({ coding: [{ display: 'Active' }] })).toBe('Active');
+  });
+
+  it('falls back to text when there is no coding', () => {
+    expect(resolveStatus({ text: 'Active' })).toBe('Active');
+    expect(resolveStatus({ text: 'Active' }, true)).toBe('Active');
+  });
+
+  it('returns undefined for an empty concept', () => {
+    expect(resolveStatus({})).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/models/datatypes/resolve-status.ts
+++ b/frontend/src/lib/models/datatypes/resolve-status.ts
@@ -1,0 +1,19 @@
+import * as _ from "lodash";
+
+// Resolve a status-like element to a display string regardless of conformance (#54).
+//
+// US Core sends these as a CodeableConcept ({coding:[{code,display}]}), but loose / non-US-Core
+// exporters (e.g. Veradigm/FollowMyHealth) commonly send a text-only concept ({text}) or even a
+// plain string code ("active"). This resolves all three shapes so the value always displays — a
+// viewer displays the patient's data, it does not validate conformance.
+//
+// preferDisplay=false (default) -> code-first (preserves US Core codes like 'active');
+// preferDisplay=true            -> display-first (human-readable label).
+export function resolveStatus(value: any, preferDisplay = false): string | undefined {
+  if (value == null) { return undefined }
+  if (typeof value === 'string') { return value }
+  const code = _.get(value, 'coding.0.code');
+  const display = _.get(value, 'coding.0.display');
+  const text = _.get(value, 'text');
+  return preferDisplay ? (display || code || text) : (code || display || text);
+}

--- a/frontend/src/lib/models/resources/allergy-intolerance-model.spec.ts
+++ b/frontend/src/lib/models/resources/allergy-intolerance-model.spec.ts
@@ -170,4 +170,44 @@ describe('AllergyIntoleranceModel', () => {
 
   })
 
+  // Non-US-Core hardening (#54): status (verificationStatus) + clinical_status should display whether
+  // they arrive as a US Core CodeableConcept, a text-only concept, or a loose plain-string code.
+  describe('non-US-Core status shapes (#54)', () => {
+    it('resolves a US Core CodeableConcept (display-first)', () => {
+      const m = new AllergyIntoleranceModel({
+        code: { text: 'Penicillin' },
+        verificationStatus: { coding: [{ code: 'confirmed', display: 'Confirmed' }] },
+        clinicalStatus: { coding: [{ code: 'active', display: 'Active' }] },
+      });
+      expect(m.status).toBe('Confirmed');
+      expect(m.clinical_status).toBe('Active');
+    });
+
+    it('resolves a text-only concept (no coding)', () => {
+      const m = new AllergyIntoleranceModel({
+        code: { text: 'Penicillin' },
+        verificationStatus: { text: 'Confirmed' },
+        clinicalStatus: { text: 'Active' },
+      });
+      expect(m.status).toBe('Confirmed');
+      expect(m.clinical_status).toBe('Active');
+    });
+
+    it('resolves a loose plain-string code (Veradigm/FollowMyHealth-style)', () => {
+      const m = new AllergyIntoleranceModel({
+        code: { text: 'Penicillin' },
+        verificationStatus: 'confirmed',
+        clinicalStatus: 'active',
+      });
+      expect(m.status).toBe('confirmed');
+      expect(m.clinical_status).toBe('active');
+    });
+
+    it('leaves status undefined when absent (no crash)', () => {
+      const m = new AllergyIntoleranceModel({ code: { text: 'Penicillin' } });
+      expect(m.status).toBeUndefined();
+      expect(m.clinical_status).toBeUndefined();
+    });
+  });
+
 });

--- a/frontend/src/lib/models/resources/allergy-intolerance-model.ts
+++ b/frontend/src/lib/models/resources/allergy-intolerance-model.ts
@@ -5,6 +5,7 @@ import {ReferenceModel} from '../datatypes/reference-model';
 import {FastenDisplayModel} from '../fasten/fasten-display-model';
 import {FastenOptions} from '../fasten/fasten-options';
 import {CodableConceptModel} from '../datatypes/codable-concept-model';
+import {resolveStatus} from '../datatypes/resolve-status';
 
 export class AllergyIntoleranceModel extends FastenDisplayModel {
   code: CodableConceptModel | undefined
@@ -72,11 +73,12 @@ export class AllergyIntoleranceModel extends FastenDisplayModel {
 
   r4DTO(fhirResource: any) {
     this.title = _.get(fhirResource, 'code.coding.0.display') || _.get(fhirResource, 'code.text')
-    this.status = _.get(fhirResource, 'verificationStatus.coding[0].display');
+    // Non-US-Core hardening (#54): verificationStatus / clinicalStatus may be a US Core
+    // CodeableConcept, a text-only concept, or a loose plain-string code — resolve all (display-first
+    // for human-readable labels) so the status always displays.
+    this.status = resolveStatus(_.get(fhirResource, 'verificationStatus'), true);
     // US Core 9.0.0 Must-Support: clinicalStatus (active|inactive|resolved). (#145)
-    this.clinical_status = _.get(fhirResource, 'clinicalStatus.coding[0].display')
-      || _.get(fhirResource, 'clinicalStatus.coding[0].code')
-      || _.get(fhirResource, 'clinicalStatus.text');
+    this.clinical_status = resolveStatus(_.get(fhirResource, 'clinicalStatus'), true);
     this.criticality = _.get(fhirResource, 'criticality');
     this.recorded_date = _.get(fhirResource, 'recordedDate');
     const substanceCoding = _.get(fhirResource, 'reaction', []).filter((item: any) =>

--- a/frontend/src/lib/models/resources/condition-model.ts
+++ b/frontend/src/lib/models/resources/condition-model.ts
@@ -4,6 +4,7 @@ import {CodableConceptModel, hasValue} from '../datatypes/codable-concept-model'
 import {ReferenceModel} from '../datatypes/reference-model';
 import {FastenDisplayModel} from '../fasten/fasten-display-model';
 import {FastenOptions} from '../fasten/fasten-options';
+import {resolveStatus} from '../datatypes/resolve-status';
 
 export class ConditionModel extends FastenDisplayModel {
   code: CodableConceptModel | undefined
@@ -71,8 +72,8 @@ export class ConditionModel extends FastenDisplayModel {
     // Non-US-Core hardening (#54): clinical/verification status may arrive as a US Core
     // CodeableConcept, a text-only concept (no coding), or a loose plain-string code (Veradigm/FMH).
     // Resolve all shapes so the status always displays. clinical_status stays code-first (e.g. 'active').
-    this.clinical_status = ConditionModel.resolveStatus(_.get(fhirResource, 'clinicalStatus'));
-    this.verification_status = ConditionModel.resolveStatus(_.get(fhirResource, 'verificationStatus'), true);
+    this.clinical_status = resolveStatus(_.get(fhirResource, 'clinicalStatus'));
+    this.verification_status = resolveStatus(_.get(fhirResource, 'verificationStatus'), true);
     // category[] distinguishes problem-list-item vs health-concern (US Core required slice)
     this.categories = _.get(fhirResource, 'category', [])
       .map((c:any) => _.get(c, 'coding.0.display') || _.get(c, 'text') || _.get(c, 'coding.0.code'))
@@ -104,18 +105,5 @@ export class ConditionModel extends FastenDisplayModel {
         throw Error('Unrecognized the fhir version property type.');
     }
   };
-
-  // Resolve a status-like element to a display string regardless of conformance (#54): a US Core
-  // CodeableConcept ({coding:[{code,display}]}), a text-only concept ({text}), or a loose plain-string
-  // code ("active") as some non-US-Core exporters (Veradigm/FollowMyHealth) emit. Code-first by
-  // default (preserves US Core codes like 'active'); preferDisplay flips to display-first.
-  static resolveStatus(value: any, preferDisplay = false): string | undefined {
-    if (value == null) { return undefined }
-    if (typeof value === 'string') { return value }
-    const code = _.get(value, 'coding.0.code');
-    const display = _.get(value, 'coding.0.display');
-    const text = _.get(value, 'text');
-    return preferDisplay ? (display || code || text) : (code || display || text);
-  }
 
 }


### PR DESCRIPTION
Continues #54 (non-US-Core display) — the robustness pass over the other commonly-imported resources, following the Condition slice (#168). Same principle: **display the patient's data regardless of conformance.**

## Audit result
Checked `status` across the common resources: on **MedicationRequest / Observation / DiagnosticReport / Procedure** it's a plain FHIR `code` (already a string) → no CodeableConcept-shape risk. The **one** other resource with the Condition-style problem is **AllergyIntolerance**, whose `status` (verificationStatus) read only `coding[0].display` and went **blank** on text-only / plain-string exports.

## Change
- **New shared `resolveStatus()` util** (`datatypes/resolve-status.ts`): resolves a US Core CodeableConcept, a text-only concept, or a loose plain-string code; code-first by default, display-first via flag.
- **AllergyIntolerance:** `status` + `clinical_status` now routed through it (display-first). Conformant data unchanged — the #145 example `toEqual` specs still pass.
- **Condition:** refactored its inline static into the shared util (**DRY**); behaviour preserved (#143/#54 specs still pass).

## Tests
+11 (allergy non-US-Core shapes: CodeableConcept / text-only / plain-string / absent; plus a focused spec for the shared util). **27/27 green** across the touched specs. No UI conformance-flagging; no logging (the frontend has no logging system — raw `console.*` only — so display is the deliverable).

`Refs #54` — the backend search-param-extraction half of #54 remains separate/deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)