### PR TITLE
fix(import): derive sort_title/sort_date for Appointment incl. non-US-Core shape (#171)

### DIFF
--- a/backend/pkg/models/database/fhir_appointment.go
+++ b/backend/pkg/models/database/fhir_appointment.go
@@ -261,6 +261,21 @@ func (s *FhirAppointment) PopulateAndExtractSearchParameters(resourceRaw json.Ra
 	if err == nil && textResult.String() != "undefined" {
 		s.Text = []byte(textResult.String())
 	}
+	// set sort_title from best available human-readable display text (Fasten-specific, not a FHIR search parameter)
+	sortTitleResult, err := vm.RunString("(function(){var r=fhirResource;function cc(x){if(!x)return undefined;if(x.text)return x.text;if(x.coding&&x.coding[0]){return x.coding[0].display||x.coding[0].code;}return undefined;}var t=cc(r.appointmentType);if(t)return t;if(r.serviceType&&r.serviceType[0]){var s=cc(r.serviceType[0]);if(s)return s;}if(r.description)return r.description;if(r.reasonCode&&r.reasonCode[0]){var rc=cc(r.reasonCode[0]);if(rc)return rc;}if(r.participant){for(var i=0;i<r.participant.length;i++){var p=r.participant[i];if(p.actor&&p.actor.display&&p.actor.reference&&p.actor.reference.indexOf('Practitioner')===0)return 'Appointment with '+p.actor.display;}}return 'Appointment';})()")
+	if err == nil && sortTitleResult.String() != "undefined" && sortTitleResult.String() != "null" {
+		sortTitle := sortTitleResult.String()
+		s.SetSortTitle(&sortTitle)
+	}
+	// set sort_date from best available date field (Fasten-specific, not a FHIR search parameter)
+	sortDateResult, err := vm.RunString("(function(){var r=fhirResource;if(r.start)return r.start;if(r.created)return r.created;return undefined;})()")
+	if err == nil && sortDateResult.String() != "undefined" && sortDateResult.String() != "null" {
+		if t, err := time.Parse(time.RFC3339, sortDateResult.String()); err == nil {
+			s.SetSortDate(&t)
+		} else if t, err = time.Parse("2006-01-02", sortDateResult.String()); err == nil {
+			s.SetSortDate(&t)
+		}
+	}
 	return nil
 }
 

--- a/backend/pkg/models/database/fhir_appointment_test.go
+++ b/backend/pkg/models/database/fhir_appointment_test.go
@@ -1,0 +1,43 @@
+package database
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Non-US-Core (#171): a FollowMyHealth Appointment has no appointmentType/serviceType/description and
+// no start — only participants + created. It should still get a sensible sort_title (from the
+// practitioner participant) and sort_date (from created), so it doesn't render blank/undated.
+func TestFhirAppointment_FollowMyHealth_SortTitleAndDate(t *testing.T) {
+	t.Parallel()
+	bytes, err := os.ReadFile("../../../../frontend/src/lib/fixtures/r4/resources/appointment/example-followmyhealth.json")
+	require.NoError(t, err)
+
+	model := FhirAppointment{}
+	err = model.PopulateAndExtractSearchParameters(bytes)
+	require.NoError(t, err)
+
+	require.NotNil(t, model.SortTitle, "FMH appointment should have a derived sort_title, not blank")
+	require.Equal(t, "Appointment with Dr. Jane Smith", *model.SortTitle)
+
+	require.NotNil(t, model.SortDate, "FMH appointment should fall back to created for sort_date")
+	require.Equal(t, time.Date(2025, time.August, 22, 0, 0, 0, 0, time.UTC), *model.SortDate)
+}
+
+// Standard FHIR appointment: sort_title from appointmentType, sort_date from start.
+func TestFhirAppointment_Standard_SortTitleAndDate(t *testing.T) {
+	t.Parallel()
+	bytes, err := os.ReadFile("../../../../frontend/src/lib/fixtures/r4/resources/appointment/example1.json")
+	require.NoError(t, err)
+
+	model := FhirAppointment{}
+	err = model.PopulateAndExtractSearchParameters(bytes)
+	require.NoError(t, err)
+
+	require.NotNil(t, model.SortTitle, "standard appointment should derive a sort_title")
+	require.NotEmpty(t, *model.SortTitle)
+	require.NotNil(t, model.SortDate, "standard appointment should derive a sort_date from start")
+}

--- a/backend/pkg/models/database/generate.go
+++ b/backend/pkg/models/database/generate.go
@@ -646,6 +646,23 @@ var resourceSortConfig = map[string]resourceSortConfigEntry{
 		SortTitleJS: `(function(){var r=fhirResource;if(r.description)return r.description;var c=r.type;if(c){if(c.text)return c.text;if(c.coding&&c.coding[0]&&c.coding[0].display)return c.coding[0].display;}return undefined;})()`,
 		SortDateJS:  `(function(){var r=fhirResource;if(r.date)return r.date;return undefined;})()`,
 	},
+	"Appointment": {
+		// appointmentType/serviceType/reasonCode are standard; Veradigm/FollowMyHealth often omit all of
+		// them (the appointment is identified only by its participants), so fall back to a non-patient
+		// participant's display, then a generic label — so it never renders blank/untitled (#171).
+		SortTitleJS: `(function(){` +
+			`var r=fhirResource;` +
+			`function cc(x){if(!x)return undefined;if(x.text)return x.text;if(x.coding&&x.coding[0]){return x.coding[0].display||x.coding[0].code;}return undefined;}` +
+			`var t=cc(r.appointmentType);if(t)return t;` +
+			`if(r.serviceType&&r.serviceType[0]){var s=cc(r.serviceType[0]);if(s)return s;}` +
+			`if(r.description)return r.description;` +
+			`if(r.reasonCode&&r.reasonCode[0]){var rc=cc(r.reasonCode[0]);if(rc)return rc;}` +
+			`if(r.participant){for(var i=0;i<r.participant.length;i++){var p=r.participant[i];if(p.actor&&p.actor.display&&p.actor.reference&&p.actor.reference.indexOf('Practitioner')===0)return 'Appointment with '+p.actor.display;}}` +
+			`return 'Appointment';` +
+			`})()`,
+		// start is standard; FollowMyHealth omits it on cancelled appointments — fall back to created.
+		SortDateJS: `(function(){var r=fhirResource;if(r.start)return r.start;if(r.created)return r.created;return undefined;})()`,
+	},
 }
 
 // TODO: should we do this, or allow all resources instead of just USCore?

--- a/frontend/src/lib/fixtures/r4/resources/appointment/example-followmyhealth.json
+++ b/frontend/src/lib/fixtures/r4/resources/appointment/example-followmyhealth.json
@@ -1,0 +1,40 @@
+{
+  "resourceType": "Appointment",
+  "id": "example-followmyhealth",
+  "meta": {
+    "extension": [
+      {
+        "url": "https://fhir.followmyhealth.com/api/FirstCreatedExtension?_format=application/json",
+        "valueInstant": "2025-08-22T13:31:34.775+00:00"
+      }
+    ],
+    "lastUpdated": "2026-02-24T14:34:58.26+00:00"
+  },
+  "identifier": [
+    {
+      "use": "official",
+      "system": "https://fhir.followmyhealth.com/id/global",
+      "value": "example-followmyhealth",
+      "assigner": {
+        "display": "FollowMyHealth"
+      }
+    }
+  ],
+  "status": "cancelled",
+  "created": "2025-08-22",
+  "participant": [
+    {
+      "actor": {
+        "reference": "Patient/example"
+      },
+      "status": "declined"
+    },
+    {
+      "actor": {
+        "reference": "Practitioner/example",
+        "display": "Dr. Jane Smith"
+      },
+      "status": "declined"
+    }
+  ]
+}


### PR DESCRIPTION
Part of #171 — and it turned out the real backend non-US-Core problem isn't search-param extraction (that's standard-FHIRPath / conformance-agnostic) but **`sort_title`/`sort_date` derivation**.

## Real-data finding
A **FollowMyHealth Appointment** (cancelled, identified only by participants + `created` — no `appointmentType`/`serviceType`/`description`/`start`) imported with **`sort_title: null`, `sort_date: null`** → it shows **blank and undated** in timeline/list views. Root cause: **`Appointment` was missing from the generator's `resourceSortConfig` entirely**, so *every* appointment (US-Core or not) got null sort fields.

## Fix
Added an `Appointment` entry to `resourceSortConfig` (`generate.go`) and regenerated `fhir_appointment.go`:
- **sort_title:** `appointmentType` → `serviceType` → `description` → `reasonCode` → **"Appointment with &lt;practitioner participant display&gt;"** → `"Appointment"` (never blank).
- **sort_date:** `start` → `created` (FMH cancelled appointments lack `start`).

## Tests
- **Synthetic** FMH-shaped fixture (no PHI — `Dr. Jane Smith`, `example` ids): `sort_title` = "Appointment with Dr. Jane Smith", `sort_date` from `created`.
- Standard fixture: `appointmentType` title + `start` date.
- Both green; `go vet` clean.

## On #171 scope
This fixes the concrete failure the real data exposed. The original "search-param extraction" framing is largely moot — extraction is standard FHIRPath and conformance-agnostic (a class-only Encounter still indexes by `class`); the one shape-gap (text-only token codes) is unsearchable until a token `:text` modifier exists (`gorm_repository_query.go:598` TODO). `Refs #171` — other resources lacking a `sortConfig` can get the same treatment as the data warrants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)