### PR TITLE
feat(resource-detail): add "Copy to Clipboard" button to debug-mode raw JSON (#167)

### DIFF
--- a/frontend/src/app/pages/resource-detail/resource-detail.component.html
+++ b/frontend/src/app/pages/resource-detail/resource-detail.component.html
@@ -21,6 +21,9 @@
         </div>
 
         <ng-container *ngIf="resource && debugMode">
+          <button type="button" class="btn btn-sm btn-outline-indigo mg-b-10" (click)="copyResourceRaw()">
+            <i class="fas fa-copy mg-r-5"></i>{{ copied ? 'Copied!' : 'Copy to Clipboard' }}
+          </button>
           <pre><code  [highlight]="resource.resource_raw | json"></code></pre>
         </ng-container>
       </ng-container>

--- a/frontend/src/app/pages/resource-detail/resource-detail.component.ts
+++ b/frontend/src/app/pages/resource-detail/resource-detail.component.ts
@@ -5,6 +5,7 @@ import {ResourceFhir} from '../../models/fasten/resource_fhir';
 import {fhirModelFactory} from '../../../lib/models/factory';
 import {ResourceType} from '../../../lib/models/constants';
 import {FastenDisplayModel} from '../../../lib/models/fasten/fasten-display-model';
+import {Clipboard} from '@angular/cdk/clipboard';
 
 @Component({
     selector: 'app-resource-detail',
@@ -15,6 +16,7 @@ import {FastenDisplayModel} from '../../../lib/models/fasten/fasten-display-mode
 export class ResourceDetailComponent implements OnInit {
   loading = false
   debugMode = false;
+  copied = false;
 
 
   sourceId = ""
@@ -22,7 +24,18 @@ export class ResourceDetailComponent implements OnInit {
   resource: ResourceFhir = null
   displayModel: FastenDisplayModel = null
 
-  constructor(private fastenApi: FastenApiService, private router: Router, private route: ActivatedRoute) {
+  constructor(private fastenApi: FastenApiService, private router: Router, private route: ActivatedRoute, private clipboard: Clipboard) {
+  }
+
+  // #167: copy the raw FHIR resource JSON (shown in debug mode) to the clipboard.
+  copyResourceRaw(): void {
+    if (!this.resource?.resource_raw) { return }
+    const raw = this.resource.resource_raw as any
+    const text = typeof raw === 'string' ? raw : JSON.stringify(raw, null, 2)
+    if (this.clipboard.copy(text)) {
+      this.copied = true
+      setTimeout(() => { this.copied = false }, 2000)
+    }
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
Fixes #167.

On the resource detail page (`/web/explore/:source/resource/:id`), when **Enable Debug mode** is on, the raw FHIR JSON is shown. This adds a **Copy to Clipboard** button so it can be grabbed in one click instead of manual select-all — handy for sharing/inspecting a resource (e.g. diagnosing non-US-Core display issues, like the FollowMyHealth Appointment that drove #171/#172).

## Change
- `Copy to Clipboard` button rendered in the debug block; flips to **"Copied!"** for 2s on success.
- Copies `resource_raw` as pretty JSON (or as-is if already a string).
- Uses the `@angular/cdk` `Clipboard` service (root-provided → no module change; has a fallback for non-secure contexts).

## Verification
- `resource-detail.component.spec` green; `yarn build --configuration sandbox` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)