### PR TITLE
feat(sort): sort_title/sort_date for MedicationDispense + MedicationStatement (#176)

### DIFF
--- a/backend/pkg/models/database/fhir_medication_dispense.go
+++ b/backend/pkg/models/database/fhir_medication_dispense.go
@@ -319,6 +319,21 @@ func (s *FhirMedicationDispense) PopulateAndExtractSearchParameters(resourceRaw 
 			s.Whenprepared = &t
 		}
 	}
+	// set sort_title from best available human-readable display text (Fasten-specific, not a FHIR search parameter)
+	sortTitleResult, err := vm.RunString("(function(){var r=fhirResource;function cc(x){if(!x)return undefined;if(x.text)return x.text;if(x.coding&&x.coding[0]){return x.coding[0].display||x.coding[0].code;}return undefined;}var t=cc(r.medicationCodeableConcept);if(t)return t;if(r.medicationReference){if(r.medicationReference.display)return r.medicationReference.display;var ref=r.medicationReference.reference;if(ref&&ref.charAt(0)==='#'&&r.contained){var id=ref.substring(1);for(var i=0;i<r.contained.length;i++){var co=r.contained[i];if(co.id===id&&co.code){var n=cc(co.code);if(n)return n;}}}}return undefined;})()")
+	if err == nil && sortTitleResult.String() != "undefined" && sortTitleResult.String() != "null" {
+		sortTitle := sortTitleResult.String()
+		s.SetSortTitle(&sortTitle)
+	}
+	// set sort_date from best available date field (Fasten-specific, not a FHIR search parameter)
+	sortDateResult, err := vm.RunString("(function(){var r=fhirResource;if(r.whenHandedOver)return r.whenHandedOver;if(r.whenPrepared)return r.whenPrepared;return undefined;})()")
+	if err == nil && sortDateResult.String() != "undefined" && sortDateResult.String() != "null" {
+		if t, err := time.Parse(time.RFC3339, sortDateResult.String()); err == nil {
+			s.SetSortDate(&t)
+		} else if t, err = time.Parse("2006-01-02", sortDateResult.String()); err == nil {
+			s.SetSortDate(&t)
+		}
+	}
 	return nil
 }
 

--- a/backend/pkg/models/database/fhir_medication_sort_test.go
+++ b/backend/pkg/models/database/fhir_medication_sort_test.go
@@ -1,0 +1,78 @@
+package database
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// #176: MedicationDispense and MedicationStatement previously had no resourceSortConfig entry, so
+// they rendered blank/undated. These tests cover both a non-US-Core (FollowMyHealth) shape — where
+// the medication carries only coding[0].display under a local code system — and the standard shape
+// where the medication is a contained reference.
+
+func TestFhirMedicationDispense_FollowMyHealth_SortTitleAndDate(t *testing.T) {
+	t.Parallel()
+	bytes, err := os.ReadFile("../../../../frontend/src/lib/fixtures/r4/resources/medicationDispense/example-followmyhealth.json")
+	require.NoError(t, err)
+
+	model := FhirMedicationDispense{}
+	err = model.PopulateAndExtractSearchParameters(bytes)
+	require.NoError(t, err)
+
+	require.NotNil(t, model.SortTitle, "FMH dispense should derive sort_title from coding[0].display")
+	require.Equal(t, "Lisinopril 40 MG Oral Tablet", *model.SortTitle)
+
+	require.NotNil(t, model.SortDate, "FMH dispense should derive sort_date from whenHandedOver")
+	require.Equal(t, time.Date(2026, time.January, 15, 0, 0, 0, 0, time.UTC), *model.SortDate)
+}
+
+func TestFhirMedicationDispense_Contained_SortTitle(t *testing.T) {
+	t.Parallel()
+	bytes, err := os.ReadFile("../../../../frontend/src/lib/fixtures/r4/resources/medicationDispense/example1.json")
+	require.NoError(t, err)
+
+	model := FhirMedicationDispense{}
+	err = model.PopulateAndExtractSearchParameters(bytes)
+	require.NoError(t, err)
+
+	// example1 has no medicationCodeableConcept — the name lives in a contained Medication
+	// referenced by "#medexample015"; the sort_title must resolve through it.
+	require.NotNil(t, model.SortTitle, "dispense should resolve sort_title from the contained Medication")
+	require.Equal(t, "Capecitabine 500mg oral tablet (Xeloda)", *model.SortTitle)
+}
+
+func TestFhirMedicationStatement_FollowMyHealth_SortTitleAndDate(t *testing.T) {
+	t.Parallel()
+	bytes, err := os.ReadFile("../../../../frontend/src/lib/fixtures/r4/resources/medicationStatement/example-followmyhealth.json")
+	require.NoError(t, err)
+
+	model := FhirMedicationStatement{}
+	err = model.PopulateAndExtractSearchParameters(bytes)
+	require.NoError(t, err)
+
+	require.NotNil(t, model.SortTitle, "FMH statement should derive sort_title from coding[0].display")
+	require.Equal(t, "Omeprazole 20 MG Oral Tablet Delayed Release", *model.SortTitle)
+
+	require.NotNil(t, model.SortDate, "FMH statement should fall back to effectivePeriod.start for sort_date")
+	require.Equal(t, time.Date(2025, time.November, 1, 0, 0, 0, 0, time.UTC), *model.SortDate)
+}
+
+func TestFhirMedicationStatement_Standard_SortTitleAndDate(t *testing.T) {
+	t.Parallel()
+	bytes, err := os.ReadFile("../../../../frontend/src/lib/fixtures/r4/resources/medicationStatement/example1.json")
+	require.NoError(t, err)
+
+	model := FhirMedicationStatement{}
+	err = model.PopulateAndExtractSearchParameters(bytes)
+	require.NoError(t, err)
+
+	// Name lives in a contained Medication referenced by "#med0309".
+	require.NotNil(t, model.SortTitle, "statement should resolve sort_title from the contained Medication")
+	require.Equal(t, "Tylenol PM", *model.SortTitle)
+
+	require.NotNil(t, model.SortDate, "statement should derive sort_date from effectiveDateTime")
+	require.Equal(t, time.Date(2015, time.January, 23, 0, 0, 0, 0, time.UTC), *model.SortDate)
+}

--- a/backend/pkg/models/database/fhir_medication_statement.go
+++ b/backend/pkg/models/database/fhir_medication_statement.go
@@ -280,6 +280,21 @@ func (s *FhirMedicationStatement) PopulateAndExtractSearchParameters(resourceRaw
 	if err == nil && textResult.String() != "undefined" {
 		s.Text = []byte(textResult.String())
 	}
+	// set sort_title from best available human-readable display text (Fasten-specific, not a FHIR search parameter)
+	sortTitleResult, err := vm.RunString("(function(){var r=fhirResource;function cc(x){if(!x)return undefined;if(x.text)return x.text;if(x.coding&&x.coding[0]){return x.coding[0].display||x.coding[0].code;}return undefined;}var t=cc(r.medicationCodeableConcept);if(t)return t;if(r.medicationReference){if(r.medicationReference.display)return r.medicationReference.display;var ref=r.medicationReference.reference;if(ref&&ref.charAt(0)==='#'&&r.contained){var id=ref.substring(1);for(var i=0;i<r.contained.length;i++){var co=r.contained[i];if(co.id===id&&co.code){var n=cc(co.code);if(n)return n;}}}}return undefined;})()")
+	if err == nil && sortTitleResult.String() != "undefined" && sortTitleResult.String() != "null" {
+		sortTitle := sortTitleResult.String()
+		s.SetSortTitle(&sortTitle)
+	}
+	// set sort_date from best available date field (Fasten-specific, not a FHIR search parameter)
+	sortDateResult, err := vm.RunString("(function(){var r=fhirResource;if(r.effectiveDateTime)return r.effectiveDateTime;if(r.effectivePeriod&&r.effectivePeriod.start)return r.effectivePeriod.start;if(r.dateAsserted)return r.dateAsserted;return undefined;})()")
+	if err == nil && sortDateResult.String() != "undefined" && sortDateResult.String() != "null" {
+		if t, err := time.Parse(time.RFC3339, sortDateResult.String()); err == nil {
+			s.SetSortDate(&t)
+		} else if t, err = time.Parse("2006-01-02", sortDateResult.String()); err == nil {
+			s.SetSortDate(&t)
+		}
+	}
 	return nil
 }
 

--- a/backend/pkg/models/database/generate.go
+++ b/backend/pkg/models/database/generate.go
@@ -594,6 +594,23 @@ type resourceSortConfigEntry struct {
 	SortDateJS  string // JS expression returning an ISO date string or undefined
 }
 
+// medicationSortTitleJS resolves a human-readable medication name for the resources whose
+// medication is given as `medication[x]` (MedicationDispense, MedicationStatement). It tries, in
+// order: medicationCodeableConcept (text → coding display → coding code), medicationReference.display,
+// then a contained Medication referenced by "#id" (its code text → coding display → coding code).
+// Returns undefined when none is present (no guessing).
+const medicationSortTitleJS = `(function(){` +
+	`var r=fhirResource;` +
+	`function cc(x){if(!x)return undefined;if(x.text)return x.text;if(x.coding&&x.coding[0]){return x.coding[0].display||x.coding[0].code;}return undefined;}` +
+	`var t=cc(r.medicationCodeableConcept);if(t)return t;` +
+	`if(r.medicationReference){` +
+	`if(r.medicationReference.display)return r.medicationReference.display;` +
+	`var ref=r.medicationReference.reference;` +
+	`if(ref&&ref.charAt(0)==='#'&&r.contained){var id=ref.substring(1);for(var i=0;i<r.contained.length;i++){var co=r.contained[i];if(co.id===id&&co.code){var n=cc(co.code);if(n)return n;}}}` +
+	`}` +
+	`return undefined;` +
+	`})()`
+
 var resourceSortConfig = map[string]resourceSortConfigEntry{
 	"Encounter": {
 		// Standard FHIR: type[0].text or type[0].coding[0].display.
@@ -633,6 +650,22 @@ var resourceSortConfig = map[string]resourceSortConfigEntry{
 	"MedicationRequest": {
 		SortTitleJS: `(function(){var m=fhirResource.medicationCodeableConcept;if(m){if(m.text)return m.text;if(m.coding&&m.coding[0]&&m.coding[0].display)return m.coding[0].display;}return undefined;})()`,
 		SortDateJS:  `(function(){var r=fhirResource;if(r.authoredOn)return r.authoredOn;return undefined;})()`,
+	},
+	"MedicationDispense": {
+		// medicationCodeableConcept is standard; FollowMyHealth supplies only coding[0].display
+		// (with a local/proprietary system) and no .text. The medication may instead be a reference
+		// to a contained Medication (no .display on the reference) — resolve that too (#176).
+		SortTitleJS: medicationSortTitleJS,
+		// whenHandedOver is the dispense event date; fall back to whenPrepared.
+		SortDateJS: `(function(){var r=fhirResource;if(r.whenHandedOver)return r.whenHandedOver;if(r.whenPrepared)return r.whenPrepared;return undefined;})()`,
+	},
+	"MedicationStatement": {
+		// Same medication-name resolution as dispense (CodeableConcept / reference / contained).
+		// MedicationStatement is not a US Core profile but FollowMyHealth emits it for self-reported
+		// meds (OTC, supplements) — so it must still get a sort_title/sort_date, not render blank (#176).
+		SortTitleJS: medicationSortTitleJS,
+		// effective[x] is the period the med is/was taken; fall back to dateAsserted.
+		SortDateJS: `(function(){var r=fhirResource;if(r.effectiveDateTime)return r.effectiveDateTime;if(r.effectivePeriod&&r.effectivePeriod.start)return r.effectivePeriod.start;if(r.dateAsserted)return r.dateAsserted;return undefined;})()`,
 	},
 	"Immunization": {
 		SortTitleJS: `(function(){var c=fhirResource.vaccineCode;if(!c)return undefined;if(c.text)return c.text;if(c.coding&&c.coding[0]&&c.coding[0].display)return c.coding[0].display;return undefined;})()`,

--- a/frontend/src/lib/fixtures/r4/resources/medicationDispense/example-followmyhealth.json
+++ b/frontend/src/lib/fixtures/r4/resources/medicationDispense/example-followmyhealth.json
@@ -1,0 +1,35 @@
+{
+  "resourceType": "MedicationDispense",
+  "id": "example-followmyhealth",
+  "meta": {
+    "lastUpdated": "2026-02-24T14:34:58.26+00:00"
+  },
+  "identifier": [
+    {
+      "use": "official",
+      "system": "https://fhir.followmyhealth.com/id/global",
+      "value": "example-followmyhealth",
+      "assigner": {
+        "display": "FollowMyHealth"
+      }
+    }
+  ],
+  "status": "completed",
+  "medicationCodeableConcept": {
+    "coding": [
+      {
+        "system": "https://fhir.followmyhealth.com/id/translation",
+        "code": "b7e3c1a0-0000-4000-8000-000000000176",
+        "display": "Lisinopril 40 MG Oral Tablet"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/example"
+  },
+  "whenHandedOver": "2026-01-15",
+  "quantity": {
+    "value": 90,
+    "unit": "tablet"
+  }
+}

--- a/frontend/src/lib/fixtures/r4/resources/medicationStatement/example-followmyhealth.json
+++ b/frontend/src/lib/fixtures/r4/resources/medicationStatement/example-followmyhealth.json
@@ -1,0 +1,42 @@
+{
+  "resourceType": "MedicationStatement",
+  "id": "example-followmyhealth",
+  "meta": {
+    "lastUpdated": "2026-02-24T14:34:58.26+00:00"
+  },
+  "identifier": [
+    {
+      "use": "official",
+      "system": "https://fhir.followmyhealth.com/id/global",
+      "value": "example-followmyhealth",
+      "assigner": {
+        "display": "FollowMyHealth"
+      }
+    }
+  ],
+  "status": "active",
+  "medicationCodeableConcept": {
+    "coding": [
+      {
+        "system": "https://fhir.followmyhealth.com/id/translation",
+        "code": "7c2e9d40-0000-4000-8000-000000000176",
+        "display": "Omeprazole 20 MG Oral Tablet Delayed Release"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/example"
+  },
+  "effectivePeriod": {
+    "start": "2025-11-01"
+  },
+  "dateAsserted": "2026-02-20",
+  "informationSource": {
+    "reference": "Patient/example",
+    "display": "Self-reported"
+  },
+  "note": [
+    { "text": "Comments -" },
+    { "text": "ProviderName -" }
+  ]
+}


### PR DESCRIPTION
Part of #174. Fixes #176.

## What

MedicationDispense and MedicationStatement had no `resourceSortConfig` entry, so they rendered blank/undated in list/timeline views. This adds both, using a shared `medicationSortTitleJS` helper.

- **sort_title** resolves the medication name from, in order: `medicationCodeableConcept` (text → coding display → coding code), `medicationReference.display`, then a **contained** Medication referenced by `#id` (its `code`). Returns undefined otherwise — no guessing.
- **sort_date**: Dispense → `whenHandedOver` | `whenPrepared`; Statement → `effectiveDateTime` | `effectivePeriod.start` | `dateAsserted`.
- Regenerated `fhir_medication_dispense.go` + `fhir_medication_statement.go` via the jennifer generator.

## Non-US-Core

Adds synthetic **FollowMyHealth-shaped** fixtures (medication carried as `coding[0].display` under a local code system `https://fhir.followmyhealth.com/id/translation`, no `.text`) — the detect-don't-require path.

## Tests

`fhir_medication_sort_test.go` — 4 cases: FMH dispense + statement (local-code display, date fallbacks) and the standard **contained-reference** path for both. All green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)