### PR TITLE
feat(ui): app-wide "Data Not Provided" missing-data component (#178)

### DIFF
--- a/frontend/src/app/components/missing-data/missing-data.component.html
+++ b/frontend/src/app/components/missing-data/missing-data.component.html
@@ -1,0 +1,5 @@
+<span class="missing-data text-muted fst-italic"
+      [ngbTooltip]="explanation"
+      [attr.aria-label]="explanation"
+      role="note"
+      tabindex="0">{{ label }}</span>

--- a/frontend/src/app/components/missing-data/missing-data.component.scss
+++ b/frontend/src/app/components/missing-data/missing-data.component.scss
@@ -1,0 +1,7 @@
+.missing-data {
+  cursor: help;
+  // dotted underline signals there's an explanation on hover/focus
+  text-decoration: underline dotted;
+  text-underline-offset: 2px;
+  font-size: 0.875em;
+}

--- a/frontend/src/app/components/missing-data/missing-data.component.spec.ts
+++ b/frontend/src/app/components/missing-data/missing-data.component.spec.ts
@@ -1,0 +1,38 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {MissingDataComponent} from './missing-data.component';
+
+describe('MissingDataComponent', () => {
+  let component: MissingDataComponent;
+  let fixture: ComponentFixture<MissingDataComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MissingDataComponent]
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(MissingDataComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('renders the default "Data Not Provided" label', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.textContent?.trim()).toBe('Data Not Provided');
+  });
+
+  it('explains that the data was absent from the source record (no guessing)', () => {
+    expect(component.explanation).toContain('was not included in the record imported from your provider');
+    expect(component.explanation).toContain('never fills in or guesses');
+  });
+
+  it('tailors the explanation to a named field', () => {
+    component.field = 'Purpose';
+    expect(component.explanation).toContain('"Purpose" was not included');
+  });
+});

--- a/frontend/src/app/components/missing-data/missing-data.component.ts
+++ b/frontend/src/app/components/missing-data/missing-data.component.ts
@@ -1,0 +1,27 @@
+import {Component, Input} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {NgbTooltipModule} from '@ng-bootstrap/ng-bootstrap';
+
+// App-wide "Data Not Provided" marker (#178). The visible expression of the no-guessing principle:
+// when an *expected* field is absent from the imported record, render this instead of a blank cell,
+// so the patient knows the data was not in the source — not that YourPHR failed or that the value
+// is zero/none. Use it for prominent fields only; silently omit truly-minor optional fields.
+@Component({
+  standalone: true,
+  imports: [CommonModule, NgbTooltipModule],
+  selector: 'app-missing-data',
+  templateUrl: './missing-data.component.html',
+  styleUrls: ['./missing-data.component.scss']
+})
+export class MissingDataComponent {
+  // The visible text. Defaults to the standard marker; override only if a context needs different wording.
+  @Input() label = 'Data Not Provided';
+  // Optional field name, used to tailor the explanation (e.g. field="Purpose").
+  @Input() field?: string;
+
+  get explanation(): string {
+    const subject = this.field ? `"${this.field}"` : 'This information';
+    return `${subject} was not included in the record imported from your provider. ` +
+      `YourPHR shows only what the source supplied — it never fills in or guesses missing values.`;
+  }
+}

--- a/frontend/src/app/components/missing-data/missing-data.stories.ts
+++ b/frontend/src/app/components/missing-data/missing-data.stories.ts
@@ -1,0 +1,23 @@
+import type {Meta, StoryObj} from '@storybook/angular';
+import {MissingDataComponent} from './missing-data.component';
+
+const meta: Meta<MissingDataComponent> = {
+  title: 'Components/MissingData',
+  component: MissingDataComponent,
+  tags: ['autodocs'],
+  argTypes: {
+    label: {control: 'text'},
+    field: {control: 'text'},
+  },
+};
+
+export default meta;
+type Story = StoryObj<MissingDataComponent>;
+
+export const Default: Story = {};
+
+export const ForAField: Story = {
+  args: {
+    field: 'Purpose',
+  },
+};


### PR DESCRIPTION
Part of #174. Fixes #178.

## What

A shared, standalone `<app-missing-data>` component — the visible expression of the **no-guessing** principle. When an *expected* field is absent from the imported record, render this instead of a blank cell so the patient knows the data **wasn't in the source** (not that YourPHR failed, and not a real zero/none).

- Muted, dotted-underline **"Data Not Provided"** text.
- `ngbTooltip` explanation: _"This information was not included in the record imported from your provider. YourPHR shows only what the source supplied — it never fills in or guesses missing values."_
- Optional `field` input tailors it (e.g. `field="Purpose"` → `"Purpose" was not included…`).
- `role="note"`, `aria-label`, `tabindex="0"` for keyboard/screen-reader access.

App-wide by design (Conditions/Observations/etc. next); medications "Purpose" (#179) is the first consumer.

## Design note (deviation from the issue)

The issue mentioned "+ glossary term". I **did not** route this through the glossary service — that API is **code-based** (`getGlossarySearchByCode(code, codeSystem)`) for clinical codes, so a free-text explanation doesn't fit it. The explanation lives in the tooltip instead. A docs/help link can be added later if wanted. (Flagging so the deviation is explicit.)

## Tests

`missing-data.component.spec.ts` — creates, renders the default label, and verifies the explanation (incl. field-tailored). 4/4 green, 100% coverage. Storybook story added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)