### PR TITLE
feat(medications): reconciled Current Medications endpoint (#175)

### DIFF
--- a/backend/pkg/medication/fhir.go
+++ b/backend/pkg/medication/fhir.go
@@ -1,0 +1,289 @@
+package medication
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Minimal FHIR R4 shapes — only the fields reconciliation needs, unioned across the four medication
+// resource types. JSON unmarshalling ignores absent fields, so one struct serves all types.
+
+type fhirCoding struct {
+	System  string `json:"system"`
+	Code    string `json:"code"`
+	Display string `json:"display"`
+}
+
+type fhirCodeableConcept struct {
+	Text   string       `json:"text"`
+	Coding []fhirCoding `json:"coding"`
+}
+
+type fhirReference struct {
+	Reference string `json:"reference"`
+	Display   string `json:"display"`
+}
+
+type fhirQuantity struct {
+	Value float64 `json:"value"`
+	Unit  string  `json:"unit"`
+}
+
+type fhirPeriod struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+}
+
+type fhirDoseAndRate struct {
+	DoseQuantity *fhirQuantity `json:"doseQuantity"`
+	DoseRange    *struct {
+		Low  *fhirQuantity `json:"low"`
+		High *fhirQuantity `json:"high"`
+	} `json:"doseRange"`
+}
+
+type fhirTimingRepeat struct {
+	Frequency  int     `json:"frequency"`
+	Period     float64 `json:"period"`
+	PeriodUnit string  `json:"periodUnit"`
+}
+
+type fhirDosage struct {
+	Text   string `json:"text"`
+	Timing *struct {
+		Repeat *fhirTimingRepeat `json:"repeat"`
+	} `json:"timing"`
+	AsNeededBoolean         *bool                `json:"asNeededBoolean"`
+	AsNeededCodeableConcept *fhirCodeableConcept `json:"asNeededCodeableConcept"`
+	DoseAndRate             []fhirDoseAndRate    `json:"doseAndRate"`
+}
+
+type fhirContained struct {
+	ResourceType string               `json:"resourceType"`
+	ID           string               `json:"id"`
+	Code         *fhirCodeableConcept `json:"code"`
+}
+
+type rawMedicationResource struct {
+	ResourceType string `json:"resourceType"`
+	ID           string `json:"id"`
+	Status       string `json:"status"`
+
+	MedicationCodeableConcept *fhirCodeableConcept `json:"medicationCodeableConcept"`
+	MedicationReference       *fhirReference       `json:"medicationReference"`
+	Contained                 []fhirContained      `json:"contained"`
+
+	AuthoredOn        string      `json:"authoredOn"`
+	WhenHandedOver    string      `json:"whenHandedOver"`
+	WhenPrepared      string      `json:"whenPrepared"`
+	EffectiveDateTime string      `json:"effectiveDateTime"`
+	EffectivePeriod   *fhirPeriod `json:"effectivePeriod"`
+	DateAsserted      string      `json:"dateAsserted"`
+
+	DosageInstruction []fhirDosage `json:"dosageInstruction"` // MedicationRequest / MedicationDispense
+	Dosage            []fhirDosage `json:"dosage"`            // MedicationStatement
+
+	Requester         *fhirReference `json:"requester"`
+	InformationSource *fhirReference `json:"informationSource"`
+
+	ReasonCode []fhirCodeableConcept `json:"reasonCode"`
+
+	// set from the DB row (authoritative), not the JSON
+	sourceResourceType string
+	sourceResourceID   string
+}
+
+func (r *rawMedicationResource) resolvedType() string {
+	if r.sourceResourceType != "" {
+		return r.sourceResourceType
+	}
+	return r.ResourceType
+}
+
+// medication resolves the display name, the original codings (for passthrough), and the RxNorm code
+// if present. Resolution order mirrors the sort_title generator: medicationCodeableConcept →
+// medicationReference.display → a contained Medication referenced by "#id".
+func (r *rawMedicationResource) medication() (name string, codings []fhirCoding, rxCode string) {
+	cc := r.MedicationCodeableConcept
+	if cc == nil && r.MedicationReference != nil {
+		if ref := r.MedicationReference.Reference; strings.HasPrefix(ref, "#") {
+			id := strings.TrimPrefix(ref, "#")
+			for i := range r.Contained {
+				if r.Contained[i].ID == id && r.Contained[i].Code != nil {
+					cc = r.Contained[i].Code
+					break
+				}
+			}
+		}
+	}
+
+	if cc != nil {
+		codings = cc.Coding
+		for _, c := range cc.Coding {
+			if c.System == rxNormSystem && c.Code != "" {
+				rxCode = c.Code
+			}
+		}
+		if cc.Text != "" {
+			name = cc.Text
+		} else {
+			for _, c := range cc.Coding {
+				if c.Display != "" {
+					name = c.Display
+					break
+				}
+			}
+			if name == "" {
+				for _, c := range cc.Coding {
+					if c.Code != "" {
+						name = c.Code
+						break
+					}
+				}
+			}
+		}
+	}
+	if name == "" && r.MedicationReference != nil && r.MedicationReference.Display != "" {
+		name = r.MedicationReference.Display
+	}
+	return name, codings, rxCode
+}
+
+// classifyState maps the explicit status (and an explicit past end date) to a state. excluded is
+// true for entered-in-error. MedicationDispense carries no medication-state signal (its status
+// describes the dispense act), so it returns ("", false).
+func (r *rawMedicationResource) classifyState(now time.Time) (state string, excluded bool) {
+	status := strings.ToLower(strings.TrimSpace(r.Status))
+	if status == "entered-in-error" {
+		return "", true
+	}
+
+	// An explicit past effectivePeriod.end means the record states the med ended.
+	if r.EffectivePeriod != nil {
+		if end := parseFHIRDate(r.EffectivePeriod.End); end != nil && end.Before(now) {
+			return StatePast, false
+		}
+	}
+
+	switch r.resolvedType() {
+	case "MedicationRequest", "MedicationStatement":
+		switch status {
+		case "active":
+			return StateActive, false
+		case "on-hold":
+			return StateSuspended, false
+		case "stopped", "cancelled", "completed", "not-taken":
+			return StatePast, false
+		default: // draft, intended, unknown, "" → no fabricated state
+			return StateUnknown, false
+		}
+	default: // MedicationDispense and anything else: no state signal
+		return "", false
+	}
+}
+
+// relevantDate is the date used for sorting/last-activity, per resource type.
+func (r *rawMedicationResource) relevantDate() *time.Time {
+	switch r.resolvedType() {
+	case "MedicationRequest":
+		return parseFHIRDate(r.AuthoredOn)
+	case "MedicationDispense":
+		if d := parseFHIRDate(r.WhenHandedOver); d != nil {
+			return d
+		}
+		return parseFHIRDate(r.WhenPrepared)
+	case "MedicationStatement":
+		if d := parseFHIRDate(r.EffectiveDateTime); d != nil {
+			return d
+		}
+		if r.EffectivePeriod != nil {
+			if d := parseFHIRDate(r.EffectivePeriod.Start); d != nil {
+				return d
+			}
+		}
+		return parseFHIRDate(r.DateAsserted)
+	}
+	return nil
+}
+
+func (r *rawMedicationResource) dosages() []fhirDosage {
+	if len(r.DosageInstruction) > 0 {
+		return r.DosageInstruction
+	}
+	return r.Dosage
+}
+
+func (r *rawMedicationResource) doseFrequencySig() (dose, frequency, sig string) {
+	dosages := r.dosages()
+	if len(dosages) == 0 {
+		return "", "", ""
+	}
+	d := dosages[0]
+	sig = d.Text
+
+	for _, dr := range d.DoseAndRate {
+		if dr.DoseQuantity != nil {
+			dose = formatQuantity(dr.DoseQuantity)
+		} else if dr.DoseRange != nil {
+			lo := formatQuantity(dr.DoseRange.Low)
+			hi := formatQuantity(dr.DoseRange.High)
+			if lo != "" || hi != "" {
+				dose = strings.TrimSpace(lo + "-" + hi)
+			}
+		}
+		if dose != "" {
+			break
+		}
+	}
+
+	switch {
+	case d.AsNeededBoolean != nil && *d.AsNeededBoolean:
+		frequency = "As needed (PRN)"
+	case d.AsNeededCodeableConcept != nil:
+		frequency = "As needed (PRN)"
+	case d.Timing != nil && d.Timing.Repeat != nil:
+		frequency = formatFrequency(d.Timing.Repeat)
+	}
+	return dose, frequency, sig
+}
+
+func formatFrequency(rep *fhirTimingRepeat) string {
+	if rep == nil || rep.Frequency == 0 || rep.PeriodUnit == "" {
+		return ""
+	}
+	unit := periodUnitWord[rep.PeriodUnit]
+	if unit == "" {
+		unit = rep.PeriodUnit
+	}
+	times := "1×"
+	if rep.Frequency > 1 {
+		times = fmt.Sprintf("%d×", rep.Frequency)
+	}
+	if rep.Period <= 1 {
+		return times + "/" + unit
+	}
+	period := strings.TrimSuffix(fmt.Sprintf("%g", rep.Period), ".0")
+	return fmt.Sprintf("%s per %s %ss", times, period, unit)
+}
+
+func (r *rawMedicationResource) purpose() string {
+	for _, rc := range r.ReasonCode {
+		if rc.Text != "" {
+			return rc.Text
+		}
+		for _, c := range rc.Coding {
+			if c.Display != "" {
+				return c.Display
+			}
+		}
+	}
+	return ""
+}
+
+func (r *rawMedicationResource) prescriber() string {
+	if r.Requester != nil {
+		return r.Requester.Display
+	}
+	return ""
+}

--- a/backend/pkg/medication/reconcile.go
+++ b/backend/pkg/medication/reconcile.go
@@ -1,0 +1,315 @@
+// Package medication implements the reconciliation of a patient's medication resources
+// (MedicationRequest / MedicationStatement / MedicationDispense / Medication) into a single
+// "Current Medications" list. See docs/planning/medications-brainstorm-session.md.
+//
+// The core Reconcile function is a pure, stateless derivation over the raw FHIR JSON — no database,
+// no HTTP — so the reconciliation rules (dedup, classification, precedence, conflict, sort) are
+// unit-testable in isolation. The "no guessing" principle is load-bearing here: state and fields
+// come only from what the record explicitly states; absent signals yield empty/"Unknown", never a
+// fabricated value.
+package medication
+
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const rxNormSystem = "http://www.nlm.nih.gov/research/umls/rxnorm"
+
+// Classified states. Active/Suspended/Past come only from explicit status (or an explicit past
+// end date); everything unknown/absent is Unknown — shown, never assumed active.
+const (
+	StateActive    = "Active"
+	StateSuspended = "Suspended"
+	StatePast      = "Past"
+	StateUnknown   = "Unknown"
+)
+
+// InputResource is one stored medication resource: its type + id (authoritative, from the DB row)
+// plus the full FHIR JSON body.
+type InputResource struct {
+	SourceResourceType string
+	SourceResourceID   string
+	Raw                json.RawMessage
+}
+
+// Coding is a passthrough of an original FHIR coding (fidelity field — "no proprietary data" means
+// none in the contract/keying, not dropping the source coding).
+type Coding struct {
+	System  string `json:"system,omitempty"`
+	Code    string `json:"code,omitempty"`
+	Display string `json:"display,omitempty"`
+}
+
+// Contributor is one resource that fed a reconciled row — the evidence the frontend can expand.
+type Contributor struct {
+	ResourceType     string     `json:"resourceType"`
+	SourceResourceID string     `json:"sourceResourceId"`
+	Status           string     `json:"status,omitempty"` // raw FHIR status
+	State            string     `json:"state,omitempty"`  // classified state (empty if the type carries no state signal)
+	Date             *time.Time `json:"date,omitempty"`
+	Dose             string     `json:"dose,omitempty"`
+	Frequency        string     `json:"frequency,omitempty"`
+	Sig              string     `json:"sig,omitempty"`
+}
+
+// ReconciledMedication is one drug+strength row in the Current Medications list.
+type ReconciledMedication struct {
+	Key             string        `json:"key"`
+	Title           string        `json:"title"`
+	RxNormCode      string        `json:"rxNormCode,omitempty"`
+	State           string        `json:"state"`
+	StateConflict   bool          `json:"stateConflict"`
+	Dose            string        `json:"dose,omitempty"`
+	Frequency       string        `json:"frequency,omitempty"`
+	Sig             string        `json:"sig,omitempty"`
+	Purpose         string        `json:"purpose,omitempty"`
+	Prescriber      string        `json:"prescriber,omitempty"`
+	LastActivity    *time.Time    `json:"lastActivity,omitempty"`
+	OriginalCodings []Coding      `json:"originalCodings,omitempty"`
+	Contributors    []Contributor `json:"contributors"`
+}
+
+// precedence: a lower number wins for field selection (prescribed > self-reported > dispense).
+var typePrecedence = map[string]int{
+	"MedicationRequest":   0,
+	"MedicationStatement": 1,
+	"MedicationDispense":  2,
+	"Medication":          3,
+}
+
+// Reconcile groups the resources into one row per clinical drug (dose-specific) and derives each
+// row's display fields, state, and evidence. `now` is used only to resolve explicit past end dates.
+func Reconcile(resources []InputResource, now time.Time) []ReconciledMedication {
+	type group struct {
+		med        *ReconciledMedication
+		parsed     []*rawMedicationResource // aligned with med.Contributors
+		seenCoding map[string]bool
+	}
+	groups := map[string]*group{}
+	var order []string // preserve first-seen order before final sort
+
+	for _, in := range resources {
+		var r rawMedicationResource
+		if err := json.Unmarshal(in.Raw, &r); err != nil {
+			continue // unparseable resource is skipped, not guessed at
+		}
+		r.sourceResourceType = in.SourceResourceType
+		r.sourceResourceID = in.SourceResourceID
+
+		// Medication resources are referenced by the others (contained or by-reference); they carry
+		// no status/dosage of their own to reconcile, so skip them as standalone rows.
+		if r.resolvedType() == "Medication" {
+			continue
+		}
+
+		name, codings, rxCode := r.medication()
+		key := dedupKey(name, rxCode)
+
+		g, ok := groups[key]
+		if !ok {
+			g = &group{med: &ReconciledMedication{Key: key, RxNormCode: rxCode}, seenCoding: map[string]bool{}}
+			groups[key] = g
+			order = append(order, key)
+		}
+		// title: prefer a non-empty name; rxNorm code fills in if a later contributor has it
+		if g.med.Title == "" && name != "" {
+			g.med.Title = name
+		}
+		if g.med.RxNormCode == "" && rxCode != "" {
+			g.med.RxNormCode = rxCode
+		}
+		for _, c := range codings {
+			sig := c.System + "|" + c.Code + "|" + c.Display
+			if !g.seenCoding[sig] {
+				g.seenCoding[sig] = true
+				g.med.OriginalCodings = append(g.med.OriginalCodings, Coding{System: c.System, Code: c.Code, Display: c.Display})
+			}
+		}
+
+		state, excluded := r.classifyState(now)
+		if excluded {
+			continue // entered-in-error — drop this contributor entirely
+		}
+		dose, freq, sig := r.doseFrequencySig()
+		date := r.relevantDate()
+		g.med.Contributors = append(g.med.Contributors, Contributor{
+			ResourceType:     r.resolvedType(),
+			SourceResourceID: r.sourceResourceID,
+			Status:           r.Status,
+			State:            state,
+			Date:             date,
+			Dose:             dose,
+			Frequency:        freq,
+			Sig:              sig,
+		})
+		g.parsed = append(g.parsed, &r)
+	}
+
+	result := make([]ReconciledMedication, 0, len(order))
+	for _, key := range order {
+		g := groups[key]
+		if len(g.med.Contributors) == 0 {
+			continue // every contributor was entered-in-error
+		}
+		finalize(g.med, g.parsed)
+		result = append(result, *g.med)
+	}
+
+	// Default order: newest on top (by last activity, desc). Undated rows sink to the bottom.
+	sort.SliceStable(result, func(i, j int) bool {
+		di, dj := result[i].LastActivity, result[j].LastActivity
+		if di == nil && dj == nil {
+			return result[i].Title < result[j].Title
+		}
+		if di == nil {
+			return false
+		}
+		if dj == nil {
+			return true
+		}
+		return di.After(*dj)
+	})
+	return result
+}
+
+// finalize derives the row-level fields from its contributors: field precedence, state +
+// conflict, prescriber, and last-activity.
+func finalize(med *ReconciledMedication, parsed []*rawMedicationResource) {
+	// sort contributor indices by type precedence for field selection
+	idx := make([]int, len(parsed))
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.SliceStable(idx, func(a, b int) bool {
+		return typePrecedence[parsed[idx[a]].resolvedType()] < typePrecedence[parsed[idx[b]].resolvedType()]
+	})
+
+	for _, i := range idx {
+		c := med.Contributors[i]
+		if med.Dose == "" {
+			med.Dose = c.Dose
+		}
+		if med.Frequency == "" {
+			med.Frequency = c.Frequency
+		}
+		if med.Sig == "" {
+			med.Sig = c.Sig
+		}
+		if med.Purpose == "" {
+			med.Purpose = parsed[i].purpose()
+		}
+		if med.Prescriber == "" && parsed[i].resolvedType() == "MedicationRequest" {
+			med.Prescriber = parsed[i].prescriber()
+		}
+	}
+
+	// last activity = max contributor date
+	for _, c := range med.Contributors {
+		if c.Date != nil && (med.LastActivity == nil || c.Date.After(*med.LastActivity)) {
+			med.LastActivity = c.Date
+		}
+	}
+
+	med.State, med.StateConflict = resolveState(med.Contributors)
+}
+
+// resolveState reduces the contributors' classified states to one badge. Only contributors that
+// carry a state signal (Request/Statement) count. Conflicts are surfaced, not resolved away.
+func resolveState(contributors []Contributor) (string, bool) {
+	distinct := map[string]bool{}
+	for _, c := range contributors {
+		if c.State != "" && c.State != StateUnknown {
+			distinct[c.State] = true
+		}
+	}
+	if len(distinct) == 0 {
+		return StateUnknown, false
+	}
+	if len(distinct) == 1 {
+		for s := range distinct {
+			return s, false
+		}
+	}
+	// Conflict: the most-recently-dated stated contributor drives the badge; if none is dated, fall
+	// back to a deterministic priority (Active > Suspended > Past). Either way, flag the conflict.
+	var best Contributor
+	var bestHasDate bool
+	for _, c := range contributors {
+		if c.State == "" || c.State == StateUnknown {
+			continue
+		}
+		if best.State == "" {
+			best = c
+			bestHasDate = c.Date != nil
+			continue
+		}
+		switch {
+		case c.Date != nil && (!bestHasDate || c.Date.After(*best.Date)):
+			best = c
+			bestHasDate = true
+		case c.Date == nil && !bestHasDate && statePriority(c.State) < statePriority(best.State):
+			best = c
+		}
+	}
+	return best.State, true
+}
+
+func statePriority(s string) int {
+	switch s {
+	case StateActive:
+		return 0
+	case StateSuspended:
+		return 1
+	case StatePast:
+		return 2
+	default:
+		return 3
+	}
+}
+
+// dedupKey groups at the clinical-drug (dose-specific) level: by RxNorm code when present,
+// otherwise by exact normalized display string (never fuzzy — under-merge is safe, wrong-merge is
+// dangerous). An un-named resource keys to itself so it is never merged blindly.
+func dedupKey(name, rxCode string) string {
+	if rxCode != "" {
+		return "rxnorm:" + rxCode
+	}
+	norm := strings.ToLower(strings.Join(strings.Fields(name), " "))
+	if norm != "" {
+		return "text:" + norm
+	}
+	return ""
+}
+
+func parseFHIRDate(s string) *time.Time {
+	if s == "" {
+		return nil
+	}
+	layouts := []string{time.RFC3339, time.RFC3339Nano, "2006-01-02T15:04:05", "2006-01-02", "2006-01", "2006"}
+	for _, l := range layouts {
+		if t, err := time.Parse(l, s); err == nil {
+			u := t.UTC()
+			return &u
+		}
+	}
+	return nil
+}
+
+func formatQuantity(q *fhirQuantity) string {
+	if q == nil || q.Value == 0 && q.Unit == "" {
+		return ""
+	}
+	v := strconv.FormatFloat(q.Value, 'g', -1, 64)
+	if q.Unit == "" {
+		return v
+	}
+	return v + " " + q.Unit
+}
+
+var periodUnitWord = map[string]string{
+	"s": "second", "min": "minute", "h": "hour", "d": "day", "wk": "week", "mo": "month", "a": "year",
+}

--- a/backend/pkg/medication/reconcile_test.go
+++ b/backend/pkg/medication/reconcile_test.go
@@ -1,0 +1,188 @@
+package medication
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var now = time.Date(2026, time.June, 9, 0, 0, 0, 0, time.UTC)
+
+func res(t string, id string, body string) InputResource {
+	return InputResource{SourceResourceType: t, SourceResourceID: id, Raw: json.RawMessage(body)}
+}
+
+func find(meds []ReconciledMedication, key string) *ReconciledMedication {
+	for i := range meds {
+		if meds[i].Key == key {
+			return &meds[i]
+		}
+	}
+	return nil
+}
+
+// A MedicationRequest + a MedicationDispense for the same clinical drug collapse into one row.
+// Fields follow precedence (Request wins), state comes from the Request, last-activity is the max date.
+func TestReconcile_DedupRequestPlusDispense(t *testing.T) {
+	req := `{"resourceType":"MedicationRequest","status":"active",
+		"medicationCodeableConcept":{"coding":[{"system":"http://www.nlm.nih.gov/research/umls/rxnorm","code":"314076","display":"Lisinopril 40 MG Oral Tablet"}]},
+		"authoredOn":"2026-01-01",
+		"dosageInstruction":[{"timing":{"repeat":{"frequency":1,"period":1,"periodUnit":"d"}},"doseAndRate":[{"doseQuantity":{"value":40,"unit":"mg"}}]}],
+		"reasonCode":[{"text":"Hypertension"}],
+		"requester":{"display":"Dr. McKinley"}}`
+	disp := `{"resourceType":"MedicationDispense","status":"completed",
+		"medicationCodeableConcept":{"coding":[{"system":"http://www.nlm.nih.gov/research/umls/rxnorm","code":"314076","display":"Lisinopril 40 MG Oral Tablet"}]},
+		"whenHandedOver":"2026-01-15",
+		"dosageInstruction":[{"doseAndRate":[{"doseQuantity":{"value":40,"unit":"mg"}}]}]}`
+
+	meds := Reconcile([]InputResource{res("MedicationRequest", "mr1", req), res("MedicationDispense", "md1", disp)}, now)
+
+	require.Len(t, meds, 1)
+	m := meds[0]
+	require.Equal(t, "rxnorm:314076", m.Key)
+	require.Equal(t, "Lisinopril 40 MG Oral Tablet", m.Title)
+	require.Equal(t, "314076", m.RxNormCode)
+	require.Equal(t, StateActive, m.State)
+	require.False(t, m.StateConflict)
+	require.Equal(t, "40 mg", m.Dose)
+	require.Equal(t, "1×/day", m.Frequency)
+	require.Equal(t, "Hypertension", m.Purpose)
+	require.Equal(t, "Dr. McKinley", m.Prescriber)
+	require.NotNil(t, m.LastActivity)
+	require.Equal(t, time.Date(2026, time.January, 15, 0, 0, 0, 0, time.UTC), *m.LastActivity)
+	require.Len(t, m.Contributors, 2)
+}
+
+// Different strengths of the same ingredient stay as separate rows (dose-specific de-dup).
+func TestReconcile_DoseSpecific_TwoRows(t *testing.T) {
+	r40 := `{"resourceType":"MedicationRequest","status":"active","authoredOn":"2026-02-01",
+		"medicationCodeableConcept":{"coding":[{"system":"http://www.nlm.nih.gov/research/umls/rxnorm","code":"314076","display":"Lisinopril 40 MG Oral Tablet"}]}}`
+	r10 := `{"resourceType":"MedicationRequest","status":"completed","authoredOn":"2025-12-01",
+		"medicationCodeableConcept":{"coding":[{"system":"http://www.nlm.nih.gov/research/umls/rxnorm","code":"197361","display":"Lisinopril 10 MG Oral Tablet"}]}}`
+
+	meds := Reconcile([]InputResource{res("MedicationRequest", "a", r40), res("MedicationRequest", "b", r10)}, now)
+
+	require.Len(t, meds, 2)
+	require.Equal(t, StateActive, find(meds, "rxnorm:314076").State)
+	require.Equal(t, StatePast, find(meds, "rxnorm:197361").State)
+}
+
+// Non-US-Core (FollowMyHealth): no RxNorm, only coding[0].display under a local system. De-dup falls
+// back to the exact normalized display string; the original coding is preserved.
+func TestReconcile_NonUSCore_TextKeyAndPassthrough(t *testing.T) {
+	stmt := `{"resourceType":"MedicationStatement","status":"active",
+		"medicationCodeableConcept":{"coding":[{"system":"https://fhir.followmyhealth.com/id/translation","code":"7c2e9d40-uuid","display":"Omeprazole 20 MG Oral Tablet Delayed Release"}]},
+		"effectivePeriod":{"start":"2025-11-01"},"dateAsserted":"2026-02-20"}`
+
+	meds := Reconcile([]InputResource{res("MedicationStatement", "s1", stmt)}, now)
+
+	require.Len(t, meds, 1)
+	m := meds[0]
+	require.Equal(t, "text:omeprazole 20 mg oral tablet delayed release", m.Key)
+	require.Equal(t, "Omeprazole 20 MG Oral Tablet Delayed Release", m.Title)
+	require.Empty(t, m.RxNormCode)
+	require.Equal(t, StateActive, m.State)
+	require.Equal(t, time.Date(2025, time.November, 1, 0, 0, 0, 0, time.UTC), *m.LastActivity)
+	require.Len(t, m.OriginalCodings, 1)
+	require.Equal(t, "https://fhir.followmyhealth.com/id/translation", m.OriginalCodings[0].System)
+}
+
+func TestReconcile_StateClassification(t *testing.T) {
+	cases := []struct {
+		status string
+		want   string
+	}{
+		{"active", StateActive},
+		{"on-hold", StateSuspended},
+		{"completed", StatePast},
+		{"stopped", StatePast},
+		{"unknown", StateUnknown},
+		{"", StateUnknown},
+	}
+	for _, tc := range cases {
+		body := `{"resourceType":"MedicationRequest","status":"` + tc.status + `",
+			"medicationCodeableConcept":{"text":"Drug ` + tc.status + `"}}`
+		meds := Reconcile([]InputResource{res("MedicationRequest", "x", body)}, now)
+		require.Len(t, meds, 1, "status=%q", tc.status)
+		require.Equal(t, tc.want, meds[0].State, "status=%q", tc.status)
+	}
+}
+
+func TestReconcile_EnteredInError_Dropped(t *testing.T) {
+	body := `{"resourceType":"MedicationRequest","status":"entered-in-error","medicationCodeableConcept":{"text":"Bogus"}}`
+	meds := Reconcile([]InputResource{res("MedicationRequest", "x", body)}, now)
+	require.Empty(t, meds, "entered-in-error contributor should be dropped, leaving no row")
+}
+
+// An explicit past effectivePeriod.end means the record states the med ended → Past, even if status=active.
+func TestReconcile_ExplicitPastEndDate(t *testing.T) {
+	body := `{"resourceType":"MedicationStatement","status":"active","medicationCodeableConcept":{"text":"Old Drug"},
+		"effectivePeriod":{"start":"2024-01-01","end":"2024-06-01"}}`
+	meds := Reconcile([]InputResource{res("MedicationStatement", "x", body)}, now)
+	require.Len(t, meds, 1)
+	require.Equal(t, StatePast, meds[0].State)
+}
+
+// Active request + completed statement for the same drug: conflict flagged; the most-recently-dated
+// stated contributor drives the badge.
+func TestReconcile_StatusConflict(t *testing.T) {
+	req := `{"resourceType":"MedicationRequest","status":"active","authoredOn":"2025-01-01",
+		"medicationCodeableConcept":{"coding":[{"system":"http://www.nlm.nih.gov/research/umls/rxnorm","code":"999","display":"Drug X"}]}}`
+	stmt := `{"resourceType":"MedicationStatement","status":"completed","effectiveDateTime":"2026-01-01",
+		"medicationCodeableConcept":{"coding":[{"system":"http://www.nlm.nih.gov/research/umls/rxnorm","code":"999","display":"Drug X"}]}}`
+	meds := Reconcile([]InputResource{res("MedicationRequest", "r", req), res("MedicationStatement", "s", stmt)}, now)
+	require.Len(t, meds, 1)
+	require.True(t, meds[0].StateConflict)
+	require.Equal(t, StatePast, meds[0].State, "most recent (2026 statement, completed) wins the badge")
+}
+
+// Dose/Frequency follow precedence: the prescribed MedicationRequest wins over the statement.
+func TestReconcile_FieldPrecedence(t *testing.T) {
+	stmt := `{"resourceType":"MedicationStatement","status":"active","effectiveDateTime":"2026-01-01",
+		"medicationCodeableConcept":{"coding":[{"system":"http://www.nlm.nih.gov/research/umls/rxnorm","code":"555","display":"Drug Y"}]},
+		"dosage":[{"doseAndRate":[{"doseQuantity":{"value":5,"unit":"mg"}}]}]}`
+	req := `{"resourceType":"MedicationRequest","status":"active","authoredOn":"2026-01-02",
+		"medicationCodeableConcept":{"coding":[{"system":"http://www.nlm.nih.gov/research/umls/rxnorm","code":"555","display":"Drug Y"}]},
+		"dosageInstruction":[{"doseAndRate":[{"doseQuantity":{"value":10,"unit":"mg"}}]}]}`
+	meds := Reconcile([]InputResource{res("MedicationStatement", "s", stmt), res("MedicationRequest", "r", req)}, now)
+	require.Len(t, meds, 1)
+	require.Equal(t, "10 mg", meds[0].Dose, "MedicationRequest dose should win over MedicationStatement")
+}
+
+// Default order is newest-on-top; an undated row sinks to the bottom.
+func TestReconcile_SortNewestOnTopUndatedLast(t *testing.T) {
+	older := `{"resourceType":"MedicationRequest","status":"active","authoredOn":"2025-01-01","medicationCodeableConcept":{"text":"Older"}}`
+	newer := `{"resourceType":"MedicationRequest","status":"active","authoredOn":"2026-05-01","medicationCodeableConcept":{"text":"Newer"}}`
+	undated := `{"resourceType":"MedicationRequest","status":"active","medicationCodeableConcept":{"text":"Undated"}}`
+	meds := Reconcile([]InputResource{res("MedicationRequest", "a", older), res("MedicationRequest", "b", undated), res("MedicationRequest", "c", newer)}, now)
+	require.Len(t, meds, 3)
+	require.Equal(t, "Newer", meds[0].Title)
+	require.Equal(t, "Older", meds[1].Title)
+	require.Equal(t, "Undated", meds[2].Title, "undated row sorts last")
+}
+
+// The medication name and RxNorm key resolve through a contained Medication referenced by "#id".
+func TestReconcile_ContainedReference(t *testing.T) {
+	body := `{"resourceType":"MedicationDispense","status":"completed","whenHandedOver":"2026-03-01",
+		"medicationReference":{"reference":"#m1"},
+		"contained":[{"resourceType":"Medication","id":"m1","code":{"coding":[{"system":"http://www.nlm.nih.gov/research/umls/rxnorm","code":"213293","display":"Capecitabine 500mg oral tablet (Xeloda)"}]}}]}`
+	meds := Reconcile([]InputResource{res("MedicationDispense", "d", body)}, now)
+	require.Len(t, meds, 1)
+	require.Equal(t, "rxnorm:213293", meds[0].Key)
+	require.Equal(t, "Capecitabine 500mg oral tablet (Xeloda)", meds[0].Title)
+	// dispense alone carries no state signal
+	require.Equal(t, StateUnknown, meds[0].State)
+}
+
+// PRN (asNeeded) renders a clear frequency.
+func TestReconcile_PRNFrequency(t *testing.T) {
+	body := `{"resourceType":"MedicationStatement","status":"active","effectiveDateTime":"2026-01-01",
+		"medicationCodeableConcept":{"text":"Valacyclovir"},
+		"dosage":[{"asNeededBoolean":true,"doseAndRate":[{"doseQuantity":{"value":1,"unit":"g"}}]}]}`
+	meds := Reconcile([]InputResource{res("MedicationStatement", "s", body)}, now)
+	require.Len(t, meds, 1)
+	require.Equal(t, "As needed (PRN)", meds[0].Frequency)
+	require.Equal(t, "1 g", meds[0].Dose)
+}

--- a/backend/pkg/web/handler/medications.go
+++ b/backend/pkg/web/handler/medications.go
@@ -1,0 +1,51 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/fastenhealth/fasten-onprem/backend/pkg"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/database"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/medication"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/models"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+// the resource types that feed the reconciled medications list (Medication is referenced by the
+// others — contained or by-reference — and contributes a name, but is not a row on its own).
+var medicationResourceTypes = []string{
+	"MedicationRequest",
+	"MedicationStatement",
+	"MedicationDispense",
+	"Medication",
+}
+
+// GetMedicationsReconciled returns the derived "Current Medications" list for the authenticated
+// user. It is a stateless compute-on-request derivation over the stored medication resources (never
+// materialized) — see docs/planning/medications-brainstorm-session.md and pkg/medication.
+func GetMedicationsReconciled(c *gin.Context) {
+	logger := c.MustGet(pkg.ContextKeyTypeLogger).(*logrus.Entry)
+	databaseRepo := c.MustGet(pkg.ContextKeyTypeDatabase).(database.DatabaseRepository)
+
+	var inputs []medication.InputResource
+	for _, resourceType := range medicationResourceTypes {
+		resources, err := databaseRepo.ListResources(c, models.ListResourceQueryOptions{SourceResourceType: resourceType})
+		if err != nil {
+			logger.Errorf("error listing %s resources for reconciliation: %v", resourceType, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": err.Error()})
+			return
+		}
+		for i := range resources {
+			inputs = append(inputs, medication.InputResource{
+				SourceResourceType: resources[i].SourceResourceType,
+				SourceResourceID:   resources[i].SourceResourceID,
+				Raw:                json.RawMessage(resources[i].ResourceRaw),
+			})
+		}
+	}
+
+	reconciled := medication.Reconcile(inputs, time.Now().UTC())
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": reconciled})
+}

--- a/backend/pkg/web/handler/medications_test.go
+++ b/backend/pkg/web/handler/medications_test.go
@@ -1,0 +1,113 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/fastenhealth/fasten-onprem/backend/pkg"
+	mock_config "github.com/fastenhealth/fasten-onprem/backend/pkg/config/mock"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/database"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/event_bus"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/medication"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/models"
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"net/http"
+)
+
+type MedicationsHandlerTestSuite struct {
+	suite.Suite
+	MockCtrl      *gomock.Controller
+	TestDatabase  *os.File
+	AppConfig     *mock_config.MockInterface
+	AppRepository database.DatabaseRepository
+	AppEventBus   event_bus.Interface
+}
+
+func (suite *MedicationsHandlerTestSuite) SetupSuite() {
+	suiteName := suite.T().Name()
+	suite.MockCtrl = gomock.NewController(suite.T())
+
+	dbFile, err := os.CreateTemp("", fmt.Sprintf("%s.*.db", suiteName))
+	require.NoError(suite.T(), err)
+	suite.TestDatabase = dbFile
+
+	appConfig := mock_config.NewMockInterface(suite.MockCtrl)
+	appConfig.EXPECT().GetString("database.location").Return(suite.TestDatabase.Name()).AnyTimes()
+	appConfig.EXPECT().GetString("database.type").Return("sqlite").AnyTimes()
+	appConfig.EXPECT().IsSet("database.encryption.key").Return(false).AnyTimes()
+	appConfig.EXPECT().GetString("log.level").Return("INFO").AnyTimes()
+	appConfig.EXPECT().GetBool("database.validation_mode").Return(false).AnyTimes()
+	appConfig.EXPECT().GetBool("database.encryption.enabled").Return(false).AnyTimes()
+	suite.AppConfig = appConfig
+
+	appRepo, err := database.NewRepository(suite.AppConfig, logrus.WithField("test", suiteName), event_bus.NewNoopEventBusServer())
+	require.NoError(suite.T(), err)
+	suite.AppRepository = appRepo
+	suite.AppEventBus = event_bus.NewNoopEventBusServer()
+
+	err = appRepo.CreateUser(context.Background(), &models.User{Username: "test_user", Password: "test"})
+	require.NoError(suite.T(), err)
+
+	// ingest a bundle that contains MedicationRequest resources
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	suite.setupContext(ctx)
+	req, err := CreateManualSourceHttpRequestFromFile("testdata/Tania553_Harris789_545c2380-b77f-4919-ab5d-0f615f877250.json")
+	require.NoError(suite.T(), err)
+	ctx.Request = req
+	CreateManualSource(ctx)
+	require.Equal(suite.T(), http.StatusOK, w.Code)
+}
+
+func (suite *MedicationsHandlerTestSuite) TearDownSuite() {
+	suite.MockCtrl.Finish()
+	os.Remove(suite.TestDatabase.Name())
+}
+
+func (suite *MedicationsHandlerTestSuite) setupContext(ctx *gin.Context) {
+	ctx.Set(pkg.ContextKeyTypeLogger, logrus.WithField("test", suite.T().Name()))
+	ctx.Set(pkg.ContextKeyTypeDatabase, suite.AppRepository)
+	ctx.Set(pkg.ContextKeyTypeConfig, suite.AppConfig)
+	ctx.Set(pkg.ContextKeyTypeEventBusServer, suite.AppEventBus)
+	ctx.Set(pkg.ContextKeyTypeAuthUsername, "test_user")
+}
+
+func (suite *MedicationsHandlerTestSuite) TestGetMedicationsReconciled() {
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	suite.setupContext(ctx)
+	ctx.Request = httptest.NewRequest("GET", "/medications/reconciled", nil)
+
+	GetMedicationsReconciled(ctx)
+	require.Equal(suite.T(), http.StatusOK, w.Code)
+
+	var resp struct {
+		Success bool                              `json:"success"`
+		Data    []medication.ReconciledMedication `json:"data"`
+	}
+	require.NoError(suite.T(), json.Unmarshal(w.Body.Bytes(), &resp))
+	require.True(suite.T(), resp.Success)
+	require.NotEmpty(suite.T(), resp.Data, "bundle has 8 MedicationRequests, so the reconciled list should be non-empty")
+
+	validStates := map[string]bool{
+		medication.StateActive: true, medication.StateSuspended: true,
+		medication.StatePast: true, medication.StateUnknown: true,
+	}
+	for _, m := range resp.Data {
+		require.NotEmpty(suite.T(), m.Title, "every row should have a resolved medication name")
+		require.True(suite.T(), validStates[m.State], "state %q should be one of the classified values", m.State)
+		require.NotEmpty(suite.T(), m.Contributors, "every row must carry its contributing-resource evidence")
+	}
+}
+
+func TestMedicationsHandlerTestSuite(t *testing.T) {
+	suite.Run(t, new(MedicationsHandlerTestSuite))
+}

--- a/backend/pkg/web/server.go
+++ b/backend/pkg/web/server.go
@@ -178,6 +178,7 @@ func (ae *AppEngine) Setup() (*gin.RouterGroup, *gin.Engine) {
 
 					secure.GET("/summary", handler.GetSummary)
 					secure.GET("/summary/ips", handler.GetIPSSummary)
+					secure.GET("/medications/reconciled", handler.GetMedicationsReconciled)
 
 					secure.POST("/source", handler.CreateReconnectSource)
 					secure.POST("/source/authorize", handler.AuthorizeSource)


### PR DESCRIPTION
Part of #174. Fixes #175.

## What

A new secure endpoint **`GET /api/secure/medications/reconciled`** that derives the patient-facing **Current Medications** list across MedicationRequest / MedicationStatement / MedicationDispense / Medication. It is a **stateless compute-on-request** derivation over the stored resources — **never materialized** (no staleness, no PHI duplication), like `/summary` and IPS.

## Design (all from the planning doc)

The real logic is a **pure, DB-free function** `pkg/medication.Reconcile([]InputResource, now) []ReconciledMedication`, so every rule is unit-testable without a database:

- **De-dup at the clinical-drug (dose-specific) level** by RxNorm; when there's no RxNorm code, fall back to **exact normalized display string** — never fuzzy (under-merge is safe, wrong-merge is dangerous). Original codings are preserved as passthrough.
- **State = Active / Suspended / Past / Unknown** from **explicit signals only** (status + explicit past `effectivePeriod.end`). No days-supply extrapolation, no guessing; `entered-in-error` is dropped; MedicationDispense carries no medication-state signal.
- **Field precedence**: Dose/Frequency/SIG → MedicationRequest > MedicationStatement > MedicationDispense; prescriber from `requester`; last-activity = max date. **Every contributor is returned as evidence** (the frontend expander).
- **Status conflicts are flagged** (`stateConflict`), with the most-recently-dated stated contributor driving the badge — exposed, not resolved away.
- **Newest-on-top** default order; undated rows sink to the bottom.
- Resolves **contained Medication** references and **FollowMyHealth** local-code shapes (coding[0].display under a local system, no RxNorm).

The handler is thin: load the four resource types via `ListResources`, hand the raw JSON to `Reconcile`, return `{success, data}`.

## Tests

- `pkg/medication/reconcile_test.go` — **11 unit tests**: dedup (+dispense), dose-specific two-rows, non-US-Core text-key + coding passthrough, state classification table, entered-in-error dropped, explicit past end date, status conflict, field precedence, newest-on-top sort, contained-reference, PRN frequency.
- `handler/medications_test.go` — drives the endpoint end-to-end off the existing Synthea bundle (8 MedicationRequests); asserts shape, valid states, and contributor evidence.

All green locally. Frontend consumer is #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)