### PR TITLE
feat(medications): Current Medications view (#179)

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -14,6 +14,7 @@ import { DashboardComponent } from './pages/dashboard/dashboard.component';
 import { DesktopCallbackComponent } from './pages/desktop-callback/desktop-callback.component';
 import { ExploreComponent } from './pages/explore/explore.component';
 import { MedicalHistoryComponent } from './pages/medical-history/medical-history.component';
+import { CurrentMedicationsComponent } from './pages/current-medications/current-medications.component';
 import { MedicalSourcesComponent } from './pages/medical-sources/medical-sources.component';
 import { PatientProfileComponent } from './pages/patient-profile/patient-profile.component';
 import { ReportLabsComponent } from './pages/report-labs/report-labs.component';
@@ -60,6 +61,7 @@ const routes: Routes = [
   { path: 'background-jobs', component: BackgroundJobsComponent, canActivate: [ IsAuthenticatedAuthGuard ] },
   { path: 'patient-profile', component: PatientProfileComponent, canActivate: [ IsAuthenticatedAuthGuard ] },
   { path: 'medical-history', component: MedicalHistoryComponent, canActivate: [ IsAuthenticatedAuthGuard ] },
+  { path: 'medications', component: CurrentMedicationsComponent, canActivate: [ IsAuthenticatedAuthGuard ] },
   { path: 'labs', component: ReportLabsComponent, canActivate: [ IsAuthenticatedAuthGuard ] },
   { path: 'labs/report/:source_id/:resource_type/:resource_id', component: ReportLabsComponent, canActivate: [ IsAuthenticatedAuthGuard ] },
 

--- a/frontend/src/app/components/header/header.component.html
+++ b/frontend/src/app/components/header/header.component.html
@@ -17,6 +17,9 @@
         <li class="nav-item" ngbDropdown [ngClass]="{ 'active': medicalHistory?.isActive }">
           <a routerLink="/medical-history" routerLinkActive="active" #medicalHistory="routerLinkActive" class="nav-link"><fa-icon [icon]="['fas', 'book-medical']"></fa-icon>&nbsp; Medical History</a>
         </li>
+        <li class="nav-item" ngbDropdown [ngClass]="{ 'active': medications?.isActive }">
+          <a routerLink="/medications" routerLinkActive="active" #medications="routerLinkActive" class="nav-link"><fa-icon [icon]="['fas', 'pills']"></fa-icon>&nbsp; Medications</a>
+        </li>
         <li class="nav-item" ngbDropdown [ngClass]="{ 'active': labs?.isActive }">
           <a routerLink="/labs" routerLinkActive="active" #labs="routerLinkActive" class="nav-link"><fa-icon [icon]="['fas', 'heart-pulse']"></fa-icon>&nbsp; Labs</a>
         </li>

--- a/frontend/src/app/models/fasten/reconciled-medication.ts
+++ b/frontend/src/app/models/fasten/reconciled-medication.ts
@@ -1,0 +1,35 @@
+// Mirrors the backend pkg/medication.ReconciledMedication contract returned by
+// GET /api/secure/medications/reconciled. Hand-maintained (this endpoint is not tygo-exported).
+
+export interface MedicationCoding {
+  system?: string;
+  code?: string;
+  display?: string;
+}
+
+export interface MedicationContributor {
+  resourceType: string;
+  sourceResourceId: string;
+  status?: string;   // raw FHIR status
+  state?: string;    // classified state (empty if the type carries no state signal)
+  date?: string;
+  dose?: string;
+  frequency?: string;
+  sig?: string;
+}
+
+export interface ReconciledMedication {
+  key: string;
+  title: string;
+  rxNormCode?: string;
+  state: string;            // Active | Suspended | Past | Unknown
+  stateConflict?: boolean;
+  dose?: string;
+  frequency?: string;
+  sig?: string;
+  purpose?: string;
+  prescriber?: string;
+  lastActivity?: string;
+  originalCodings?: MedicationCoding[];
+  contributors?: MedicationContributor[];
+}

--- a/frontend/src/app/pages/current-medications/current-medications.component.html
+++ b/frontend/src/app/pages/current-medications/current-medications.component.html
@@ -1,0 +1,81 @@
+<div class="az-content-body">
+  <div class="d-flex justify-content-between align-items-center mg-b-20">
+    <div>
+      <h4 class="mg-b-5">Current Medications</h4>
+      <p class="tx-gray-500 mg-b-0">From your records, as of your last import. A reconciled view across prescriptions, dispenses, and self-reported medications.</p>
+    </div>
+    <div class="btn-group" role="group" aria-label="Filter">
+      <button type="button" class="btn btn-sm" [class.btn-primary]="showActiveOnly" [class.btn-outline-primary]="!showActiveOnly" (click)="showActiveOnly || toggleActiveOnly()">Active only</button>
+      <button type="button" class="btn btn-sm" [class.btn-primary]="!showActiveOnly" [class.btn-outline-primary]="showActiveOnly" (click)="!showActiveOnly || toggleActiveOnly()">All</button>
+    </div>
+  </div>
+
+  <app-loading-spinner *ngIf="loading" loadingTitle="Loading your medications..."></app-loading-spinner>
+
+  <div *ngIf="!loading && errored" class="alert alert-danger">Could not load your medications. Please try again.</div>
+
+  <div *ngIf="!loading && !errored && filtered.length === 0" class="alert alert-info">
+    No medications found in your records{{ showActiveOnly ? ' that are currently active' : '' }}.
+  </div>
+
+  <div class="table-responsive" *ngIf="!loading && !errored && filtered.length > 0">
+    <table class="table table-hover">
+      <thead>
+        <tr>
+          <th style="width:1%"></th>
+          <th class="sortable" (click)="sortBy('title')">Medication <i class="fas" [ngClass]="sortColumn==='title' ? (sortDirection==='asc' ? 'fa-caret-up' : 'fa-caret-down') : ''"></i></th>
+          <th>Dose</th>
+          <th>Frequency</th>
+          <th>Purpose</th>
+          <th class="sortable" (click)="sortBy('state')">Status <i class="fas" [ngClass]="sortColumn==='state' ? (sortDirection==='asc' ? 'fa-caret-up' : 'fa-caret-down') : ''"></i></th>
+          <th class="sortable" (click)="sortBy('lastActivity')">Last activity <i class="fas" [ngClass]="sortColumn==='lastActivity' ? (sortDirection==='asc' ? 'fa-caret-up' : 'fa-caret-down') : ''"></i></th>
+        </tr>
+      </thead>
+      <tbody>
+        <ng-container *ngFor="let med of filtered">
+          <tr class="med-row" (click)="toggleExpanded(med.key)">
+            <td><i class="fas" [ngClass]="expanded[med.key] ? 'fa-chevron-down' : 'fa-chevron-right'"></i></td>
+            <td>
+              <strong>{{ med.title }}</strong>
+              <span *ngIf="med.stateConflict" class="tx-warning" title="The records disagree on this medication's status — see details."> &#9888;</span>
+            </td>
+            <td><span *ngIf="med.dose; else noDose">{{ med.dose }}</span><ng-template #noDose><app-missing-data field="Dose"></app-missing-data></ng-template></td>
+            <td><span *ngIf="med.frequency; else noFreq">{{ med.frequency }}</span><ng-template #noFreq><app-missing-data field="Frequency"></app-missing-data></ng-template></td>
+            <td><span *ngIf="med.purpose; else noPurpose">{{ med.purpose }}</span><ng-template #noPurpose><app-missing-data field="Purpose"></app-missing-data></ng-template></td>
+            <td><span class="badge" [ngClass]="stateBadgeClass(med.state)">{{ med.state }}</span></td>
+            <td><span *ngIf="med.lastActivity; else noDate">{{ med.lastActivity | date }}</span><ng-template #noDate><span class="tx-gray-400">—</span></ng-template></td>
+          </tr>
+          <tr *ngIf="expanded[med.key]" class="med-detail">
+            <td></td>
+            <td colspan="6">
+              <div class="mg-b-15">
+                <strong class="tx-12 tx-uppercase tx-gray-500">More information</strong>
+                <div class="mg-t-5">
+                  <a *ngIf="medlinePlusUrl(med) as mp" [href]="mp" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-outline-info mg-r-5">MedlinePlus (consumer info)</a>
+                  <a [href]="dailyMedUrl(med)" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-outline-info">DailyMed (FDA label)</a>
+                </div>
+              </div>
+
+              <div *ngIf="med.sig" class="mg-b-15"><strong class="tx-12 tx-uppercase tx-gray-500">Instructions</strong><div class="mg-t-5">{{ med.sig }}</div></div>
+              <div *ngIf="med.prescriber" class="mg-b-15"><strong class="tx-12 tx-uppercase tx-gray-500">Prescriber</strong><div class="mg-t-5">{{ med.prescriber }}</div></div>
+
+              <strong class="tx-12 tx-uppercase tx-gray-500">Source records</strong>
+              <table class="table table-sm mg-t-5 mg-b-0">
+                <thead><tr><th>Resource</th><th>Status</th><th>Date</th><th>Dose</th><th>Frequency</th></tr></thead>
+                <tbody>
+                  <tr *ngFor="let c of med.contributors">
+                    <td>{{ c.resourceType }}</td>
+                    <td>{{ c.status || '—' }}<span *ngIf="c.state"> ({{ c.state }})</span></td>
+                    <td>{{ c.date ? (c.date | date) : '—' }}</td>
+                    <td>{{ c.dose || '—' }}</td>
+                    <td>{{ c.frequency || '—' }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </td>
+          </tr>
+        </ng-container>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/frontend/src/app/pages/current-medications/current-medications.component.scss
+++ b/frontend/src/app/pages/current-medications/current-medications.component.scss
@@ -1,0 +1,13 @@
+.sortable {
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.med-row {
+  cursor: pointer;
+}
+
+.med-detail > td {
+  background-color: rgba(0, 0, 0, 0.02);
+}

--- a/frontend/src/app/pages/current-medications/current-medications.component.spec.ts
+++ b/frontend/src/app/pages/current-medications/current-medications.component.spec.ts
@@ -1,0 +1,76 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {of} from 'rxjs';
+import {RouterTestingModule} from '@angular/router/testing';
+
+import {CurrentMedicationsComponent} from './current-medications.component';
+import {FastenApiService} from '../../services/fasten-api.service';
+import {ReconciledMedication} from '../../models/fasten/reconciled-medication';
+
+function med(partial: Partial<ReconciledMedication>): ReconciledMedication {
+  return {key: partial.title || 'k', title: 'Drug', state: 'Unknown', ...partial} as ReconciledMedication;
+}
+
+describe('CurrentMedicationsComponent', () => {
+  let component: CurrentMedicationsComponent;
+  let fixture: ComponentFixture<CurrentMedicationsComponent>;
+  let api: jasmine.SpyObj<FastenApiService>;
+
+  beforeEach(async () => {
+    api = jasmine.createSpyObj('FastenApiService', ['getReconciledMedications']);
+    api.getReconciledMedications.and.returnValue(of([]));
+
+    await TestBed.configureTestingModule({
+      imports: [CurrentMedicationsComponent, RouterTestingModule],
+      providers: [{provide: FastenApiService, useValue: api}],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CurrentMedicationsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('creates and loads medications on init', () => {
+    expect(component).toBeTruthy();
+    expect(api.getReconciledMedications).toHaveBeenCalled();
+    expect(component.loading).toBeFalse();
+  });
+
+  it('filters to Active only when toggled', () => {
+    component.medications = [med({title: 'A', state: 'Active'}), med({title: 'B', state: 'Past'})];
+    component.toggleActiveOnly();
+    expect(component.filtered.length).toBe(1);
+    expect(component.filtered[0].title).toBe('A');
+  });
+
+  it('sorts undated rows to the bottom under the default newest-first order', () => {
+    component.medications = [
+      med({title: 'Undated'}),
+      med({title: 'Newer', lastActivity: '2026-05-01'}),
+      med({title: 'Older', lastActivity: '2025-01-01'}),
+    ];
+    (component as any).applyView();
+    expect(component.filtered.map((m) => m.title)).toEqual(['Newer', 'Older', 'Undated']);
+  });
+
+  it('toggling a sort column flips direction', () => {
+    component.sortBy('title');
+    expect(component.sortColumn).toBe('title');
+    expect(component.sortDirection).toBe('asc');
+    component.sortBy('title');
+    expect(component.sortDirection).toBe('desc');
+  });
+
+  it('builds a MedlinePlus link only when an RxNorm code is present', () => {
+    expect(component.medlinePlusUrl(med({title: 'X'}))).toBeNull();
+    const url = component.medlinePlusUrl(med({title: 'Lisinopril', rxNormCode: '314076'}));
+    expect(url).toContain('connect.medlineplus.gov/application');
+    expect(url).toContain('2.16.840.1.113883.6.88');
+    expect(url).toContain('314076');
+  });
+
+  it('always builds a DailyMed name-search link', () => {
+    expect(component.dailyMedUrl(med({title: 'Omeprazole 20 MG'}))).toBe(
+      'https://dailymed.nlm.nih.gov/dailymed/search.cfm?query=Omeprazole%2020%20MG'
+    );
+  });
+});

--- a/frontend/src/app/pages/current-medications/current-medications.component.ts
+++ b/frontend/src/app/pages/current-medications/current-medications.component.ts
@@ -1,0 +1,123 @@
+import {Component, OnInit} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {RouterModule} from '@angular/router';
+import {NgbCollapseModule} from '@ng-bootstrap/ng-bootstrap';
+import {FastenApiService} from '../../services/fasten-api.service';
+import {ReconciledMedication} from '../../models/fasten/reconciled-medication';
+import {MissingDataComponent} from '../../components/missing-data/missing-data.component';
+import {LoadingSpinnerComponent} from '../../components/loading-spinner/loading-spinner.component';
+
+type SortColumn = 'title' | 'state' | 'lastActivity';
+
+// The patient-facing "Current Medications" view (#179): a reconciled, de-duplicated list derived by
+// the backend (GET /secure/medications/reconciled). The frontend does not re-derive — it renders the
+// list, lets the user sort/filter, and links out to authoritative drug info. Absent expected fields
+// show the shared "Data Not Provided" marker (no guessing).
+@Component({
+  standalone: true,
+  imports: [CommonModule, RouterModule, NgbCollapseModule, MissingDataComponent, LoadingSpinnerComponent],
+  selector: 'app-current-medications',
+  templateUrl: './current-medications.component.html',
+  styleUrls: ['./current-medications.component.scss'],
+})
+export class CurrentMedicationsComponent implements OnInit {
+  loading = true;
+  errored = false;
+  medications: ReconciledMedication[] = [];
+  filtered: ReconciledMedication[] = [];
+  expanded: Record<string, boolean> = {};
+
+  showActiveOnly = false;
+  sortColumn: SortColumn = 'lastActivity';
+  sortDirection: 'asc' | 'desc' = 'desc'; // default: newest on top
+
+  // RxNorm code-system OID for MedlinePlus Connect.
+  private static readonly RXNORM_OID = '2.16.840.1.113883.6.88';
+
+  constructor(private fastenApi: FastenApiService) {}
+
+  ngOnInit(): void {
+    this.fastenApi.getReconciledMedications().subscribe({
+      next: (meds) => {
+        this.medications = meds || [];
+        this.applyView();
+        this.loading = false;
+      },
+      error: () => {
+        this.errored = true;
+        this.loading = false;
+      },
+    });
+  }
+
+  toggleActiveOnly(): void {
+    this.showActiveOnly = !this.showActiveOnly;
+    this.applyView();
+  }
+
+  toggleExpanded(key: string): void {
+    this.expanded[key] = !this.expanded[key];
+  }
+
+  sortBy(column: SortColumn): void {
+    if (this.sortColumn === column) {
+      this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
+    } else {
+      this.sortColumn = column;
+      // dates default to newest-first; text columns to A→Z
+      this.sortDirection = column === 'lastActivity' ? 'desc' : 'asc';
+    }
+    this.applyView();
+  }
+
+  private applyView(): void {
+    let rows = [...this.medications];
+    if (this.showActiveOnly) {
+      rows = rows.filter((m) => m.state === 'Active');
+    }
+    rows.sort((a, b) => this.compare(a, b));
+    this.filtered = rows;
+  }
+
+  private compare(a: ReconciledMedication, b: ReconciledMedication): number {
+    const dir = this.sortDirection === 'asc' ? 1 : -1;
+    if (this.sortColumn === 'lastActivity') {
+      // Undated rows always sink to the bottom, regardless of direction (no invented dates).
+      if (!a.lastActivity && !b.lastActivity) return (a.title || '').localeCompare(b.title || '');
+      if (!a.lastActivity) return 1;
+      if (!b.lastActivity) return -1;
+      return dir * (new Date(a.lastActivity).getTime() - new Date(b.lastActivity).getTime());
+    }
+    const av = String((a as any)[this.sortColumn] || '');
+    const bv = String((b as any)[this.sortColumn] || '');
+    return dir * av.localeCompare(bv);
+  }
+
+  // Authoritative consumer drug info (MedlinePlus, NLM). Only when we have an RxCUI — the Connect
+  // endpoint is code-based; we don't fabricate a link without one. Pure href; nothing is fetched
+  // until the patient clicks, and only the drug name/RxCUI travels — never patient identity.
+  medlinePlusUrl(med: ReconciledMedication): string | null {
+    if (!med.rxNormCode) return null;
+    const params = new URLSearchParams({
+      'mainSearchCriteria.v.cs': CurrentMedicationsComponent.RXNORM_OID,
+      'mainSearchCriteria.v.c': med.rxNormCode,
+      'mainSearchCriteria.v.dn': med.title || '',
+      'informationRecipient.languageCode.c': 'en',
+    });
+    return `https://connect.medlineplus.gov/application?${params.toString()}`;
+  }
+
+  // FDA label via DailyMed — works by drug name, so it is always available.
+  dailyMedUrl(med: ReconciledMedication): string {
+    return `https://dailymed.nlm.nih.gov/dailymed/search.cfm?query=${encodeURIComponent(med.title || '')}`;
+  }
+
+  stateBadgeClass(state: string): string {
+    switch (state) {
+      case 'Active': return 'badge-success';
+      case 'Suspended': return 'badge-warning';
+      case 'Past': return 'badge-secondary';
+      default: return 'badge-light';
+    }
+  }
+}

--- a/frontend/src/app/services/fasten-api.service.ts
+++ b/frontend/src/app/services/fasten-api.service.ts
@@ -5,6 +5,7 @@ import {Observable, of} from 'rxjs';
 import { Router } from '@angular/router';
 import {map} from 'rxjs/operators';
 import {ResponseWrapper} from '../models/response-wrapper';
+import {ReconciledMedication} from '../models/fasten/reconciled-medication';
 import {Source} from '../models/fasten/source';
 import {User} from '../models/fasten/user';
 import {ResourceFhir} from '../models/fasten/resource_fhir';
@@ -131,6 +132,15 @@ export class FastenApiService {
       .pipe(
         map((response: ResponseWrapper) => {
           return response.data as Summary
+        })
+      );
+  }
+
+  getReconciledMedications(): Observable<ReconciledMedication[]> {
+    return this._httpClient.get<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/medications/reconciled`)
+      .pipe(
+        map((response: ResponseWrapper) => {
+          return (response.data || []) as ReconciledMedication[]
         })
       );
   }


### PR DESCRIPTION
Part of #174. Fixes #179. **This closes out the medications epic** (5 of 5).

## What

The patient-facing **`/medications`** page — the visible payoff of the epic. It consumes the reconciled endpoint (`GET /secure/medications/reconciled`, #175) and renders Jim's MEW column model.

- Columns **Medication · Dose · Frequency · Purpose · Status**, **newest-on-top** by default and **user-sortable** client-side (Medication / Status / Last activity); **Active only / All** filter.
- Absent expected fields render the shared **`<app-missing-data>`** "Data Not Provided" marker (#178) — no guessing. Undated rows sort to the bottom (no invented dates).
- **Expand a row** → instructions (SIG), prescriber, the **contributing source records** (the evidence the endpoint returns), and **user-clicked drug-info links**: MedlinePlus Connect by RxCUI (when present) + DailyMed by name. Links open in a new tab with `rel="noopener noreferrer"`; nothing is fetched until the patient clicks.

## Notes / scope

- **Standalone** page component (Angular 20 idiom) so it can import the standalone `app-missing-data` + `loading-spinner` without app.module churn.
- New hand-maintained `ReconciledMedication` TS model, `getReconciledMedications()` API method, `/medications` route + a header nav entry (pills icon).
- **MedlinePlus link only when an RxCUI is present** — the Connect endpoint is code-based, so I don't fabricate one without a code (DailyMed name-search is always shown). Honest over guessing.
- **Dashboard widget deferred** — the widget system is data-driven off backend dashboard configs, so a "Medications" widget is a clean follow-up, not part of this frontend page. Flagging rather than silently dropping.

## Tests

`current-medications.component.spec.ts` — 6 specs: loads on init, Active-only filter, undated-last sort, sort-direction toggle, MedlinePlus link only with RxCUI, DailyMed URL encoding. Verified locally: specs green, `ng lint` 0 errors, header template compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)