### PR TITLE
feat(smart): scheduled OAuth token-refresh worker (#51)

### DIFF
--- a/backend/pkg/web/server.go
+++ b/backend/pkg/web/server.go
@@ -448,6 +448,12 @@ func (ae *AppEngine) Start() error {
 
 	ae.startServer(r)
 
+	// Scheduled SMART OAuth token-refresh worker (#51). Skipped in StandbyMode (no DB-backed
+	// sources to refresh there).
+	if !ae.StandbyMode {
+		go ae.startTokenRefreshWorker()
+	}
+
 	// Block indefinitely to keep the server running until process termination
 	select {}
 }

--- a/backend/pkg/web/token_refresh.go
+++ b/backend/pkg/web/token_refresh.go
@@ -1,0 +1,101 @@
+package web
+
+import (
+	"context"
+	"time"
+
+	"github.com/fastenhealth/fasten-onprem/backend/pkg"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/models"
+	"github.com/fastenhealth/fasten-sources/clients/factory"
+)
+
+// Scheduled OAuth token-refresh worker (#51, EPIC #20 component E). SMART sources obtain
+// offline_access refresh tokens at connect time; tokens then refresh reactively during a sync. This
+// worker additionally refreshes them on a timer so a source that is not being actively synced does
+// not let its access token lapse. It reuses the same discovery + refresh path as sync
+// (factory.RefreshAccessToken) — no OAuth logic is reimplemented here.
+
+const tokenRefreshSkew = 60 * time.Second
+
+// tokenNeedsRefresh reports whether a source has an OAuth access token worth refreshing now: present,
+// with a known expiry, and within the skew window of expiring. Manual-upload sources (no access
+// token), sources with an unknown (zero) expiry, and still-valid tokens are skipped — no guessing.
+func tokenNeedsRefresh(cred *models.SourceCredential, now time.Time, skew time.Duration) bool {
+	if cred == nil || cred.AccessToken == "" || cred.ExpiresAt == 0 {
+		return false
+	}
+	return cred.ExpiresAt <= now.Add(skew).Unix()
+}
+
+// tokenRefresher refreshes (and mutates) a credential in place, returning whether it changed.
+// Injected so refreshExpiringTokens is testable without network/OAuth.
+type tokenRefresher func(ctx context.Context, cred *models.SourceCredential) (bool, error)
+
+// refreshExpiringTokens scans every user's sources and refreshes the access tokens that are near
+// expiry, persisting any that change. One source's failure is logged and skipped so it never blocks
+// the rest. Returns (attempted, refreshed) counts.
+func (ae *AppEngine) refreshExpiringTokens(now time.Time, skew time.Duration, refresh tokenRefresher) (int, int) {
+	attempted, refreshed := 0, 0
+
+	users, err := ae.deviceRepo.GetUsers(context.Background())
+	if err != nil {
+		ae.Logger.Errorf("token-refresh: could not list users: %v", err)
+		return attempted, refreshed
+	}
+
+	for _, user := range users {
+		userCtx := context.WithValue(context.Background(), pkg.ContextKeyTypeAuthUsername, user.Username)
+		sources, err := ae.deviceRepo.GetSources(userCtx)
+		if err != nil {
+			ae.Logger.Warnf("token-refresh: could not list sources for user %s: %v", user.Username, err)
+			continue
+		}
+		for i := range sources {
+			source := sources[i]
+			if !tokenNeedsRefresh(&source, now, skew) {
+				continue
+			}
+			attempted++
+			didRefresh, err := refresh(userCtx, &source)
+			if err != nil {
+				ae.Logger.Warnf("token-refresh: source %s (user %s): %v", source.ID, user.Username, err)
+				continue
+			}
+			if !didRefresh {
+				continue
+			}
+			if err := ae.deviceRepo.UpdateSource(userCtx, &source); err != nil {
+				ae.Logger.Warnf("token-refresh: persisting source %s failed: %v", source.ID, err)
+				continue
+			}
+			refreshed++
+		}
+	}
+
+	if attempted > 0 {
+		ae.Logger.Infof("token-refresh: attempted %d, refreshed %d", attempted, refreshed)
+	}
+	return attempted, refreshed
+}
+
+// startTokenRefreshWorker runs refreshExpiringTokens on a ticker for the server's lifetime. Set
+// sync.token_refresh.interval_minutes <= 0 to disable. Blocks; launch in a goroutine.
+func (ae *AppEngine) startTokenRefreshWorker() {
+	ae.Config.SetDefault("sync.token_refresh.interval_minutes", 30)
+	intervalMin := ae.Config.GetInt("sync.token_refresh.interval_minutes")
+	if intervalMin <= 0 {
+		ae.Logger.Info("token-refresh worker disabled (sync.token_refresh.interval_minutes <= 0)")
+		return
+	}
+
+	prod := func(ctx context.Context, cred *models.SourceCredential) (bool, error) {
+		return factory.RefreshAccessToken(ctx, ae.Logger, cred)
+	}
+
+	ticker := time.NewTicker(time.Duration(intervalMin) * time.Minute)
+	defer ticker.Stop()
+	ae.Logger.Infof("token-refresh worker started (every %d min)", intervalMin)
+	for range ticker.C {
+		ae.refreshExpiringTokens(time.Now(), tokenRefreshSkew, prod)
+	}
+}

--- a/backend/pkg/web/token_refresh_test.go
+++ b/backend/pkg/web/token_refresh_test.go
@@ -1,0 +1,135 @@
+package web
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/fastenhealth/fasten-onprem/backend/pkg"
+	mock_config "github.com/fastenhealth/fasten-onprem/backend/pkg/config/mock"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/database"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/event_bus"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/models"
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenNeedsRefresh(t *testing.T) {
+	now := time.Date(2026, time.June, 9, 12, 0, 0, 0, time.UTC)
+	skew := 60 * time.Second
+	cases := []struct {
+		name string
+		cred *models.SourceCredential
+		want bool
+	}{
+		{"nil", nil, false},
+		{"no access token (manual source)", &models.SourceCredential{ExpiresAt: now.Add(-time.Hour).Unix()}, false},
+		{"unknown expiry", &models.SourceCredential{AccessToken: "a", ExpiresAt: 0}, false},
+		{"still valid", &models.SourceCredential{AccessToken: "a", ExpiresAt: now.Add(time.Hour).Unix()}, false},
+		{"within skew", &models.SourceCredential{AccessToken: "a", ExpiresAt: now.Add(30 * time.Second).Unix()}, true},
+		{"already expired", &models.SourceCredential{AccessToken: "a", ExpiresAt: now.Add(-time.Minute).Unix()}, true},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, tokenNeedsRefresh(tc.cred, now, skew), tc.name)
+	}
+}
+
+func TestRefreshExpiringTokens(t *testing.T) {
+	now := time.Date(2026, time.June, 9, 12, 0, 0, 0, time.UTC)
+
+	ctrl := gomock.NewController(t)
+	dbFile, err := os.CreateTemp("", "tokenrefresh.*.db")
+	require.NoError(t, err)
+	defer os.Remove(dbFile.Name())
+
+	cfg := mock_config.NewMockInterface(ctrl)
+	cfg.EXPECT().GetString("database.location").Return(dbFile.Name()).AnyTimes()
+	cfg.EXPECT().GetString("database.type").Return("sqlite").AnyTimes()
+	cfg.EXPECT().IsSet("database.encryption.key").Return(false).AnyTimes()
+	cfg.EXPECT().GetString("log.level").Return("INFO").AnyTimes()
+	cfg.EXPECT().GetBool("database.validation_mode").Return(false).AnyTimes()
+	cfg.EXPECT().GetBool("database.encryption.enabled").Return(false).AnyTimes()
+
+	logger := logrus.WithField("test", t.Name())
+	repo, err := database.NewRepository(cfg, logger, event_bus.NewNoopEventBusServer())
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateUser(context.Background(), &models.User{Username: "u1", Password: "p"}))
+
+	uctx := context.WithValue(context.Background(), pkg.ContextKeyTypeAuthUsername, "u1")
+	mkSource := func(accessToken string, expiresAt int64) *models.SourceCredential {
+		s := &models.SourceCredential{
+			EndpointID:         uuid.New(),
+			ApiEndpointBaseUrl: "https://fhir.example.com",
+			AccessToken:        accessToken,
+			RefreshToken:       "refresh",
+			ExpiresAt:          expiresAt,
+		}
+		require.NoError(t, repo.CreateSource(uctx, s))
+		return s
+	}
+	expiring := mkSource("old", now.Add(30*time.Second).Unix()) // within skew → refresh
+	mkSource("valid", now.Add(time.Hour).Unix())                // still valid → skip
+	mkSource("", now.Add(-time.Hour).Unix())                    // manual/no token → skip
+
+	ae := &AppEngine{Config: cfg, Logger: logger, deviceRepo: repo}
+
+	// fake refresher: only the expiring source should reach it; it rotates the token
+	fake := func(ctx context.Context, cred *models.SourceCredential) (bool, error) {
+		cred.SetTokens("new", "refresh2", now.Add(time.Hour).Unix())
+		return true, nil
+	}
+
+	attempted, refreshed := ae.refreshExpiringTokens(now, tokenRefreshSkew, fake)
+	require.Equal(t, 1, attempted, "only the near-expiry source should be attempted")
+	require.Equal(t, 1, refreshed)
+
+	// the rotated token must be persisted
+	sources, err := repo.GetSources(uctx)
+	require.NoError(t, err)
+	var got *models.SourceCredential
+	for i := range sources {
+		if sources[i].EndpointID == expiring.EndpointID {
+			got = &sources[i]
+		}
+	}
+	require.NotNil(t, got)
+	require.Equal(t, "new", got.AccessToken, "refreshed access token should be persisted")
+	require.Equal(t, "refresh2", got.RefreshToken, "rotated refresh token should be persisted")
+}
+
+// ensure a failing refresher never persists and never blocks the others
+func TestRefreshExpiringTokens_ErrorIsSkipped(t *testing.T) {
+	now := time.Now()
+	ctrl := gomock.NewController(t)
+	dbFile, err := os.CreateTemp("", "tokenrefresh2.*.db")
+	require.NoError(t, err)
+	defer os.Remove(dbFile.Name())
+
+	cfg := mock_config.NewMockInterface(ctrl)
+	cfg.EXPECT().GetString("database.location").Return(dbFile.Name()).AnyTimes()
+	cfg.EXPECT().GetString("database.type").Return("sqlite").AnyTimes()
+	cfg.EXPECT().IsSet("database.encryption.key").Return(false).AnyTimes()
+	cfg.EXPECT().GetString("log.level").Return("INFO").AnyTimes()
+	cfg.EXPECT().GetBool("database.validation_mode").Return(false).AnyTimes()
+	cfg.EXPECT().GetBool("database.encryption.enabled").Return(false).AnyTimes()
+
+	logger := logrus.WithField("test", t.Name())
+	repo, err := database.NewRepository(cfg, logger, event_bus.NewNoopEventBusServer())
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateUser(context.Background(), &models.User{Username: "u1", Password: "p"}))
+	uctx := context.WithValue(context.Background(), pkg.ContextKeyTypeAuthUsername, "u1")
+	s := &models.SourceCredential{EndpointID: uuid.New(), ApiEndpointBaseUrl: "https://x", AccessToken: "old", ExpiresAt: now.Add(10 * time.Second).Unix()}
+	require.NoError(t, repo.CreateSource(uctx, s))
+
+	ae := &AppEngine{Config: cfg, Logger: logger, deviceRepo: repo}
+	boom := func(ctx context.Context, cred *models.SourceCredential) (bool, error) {
+		return false, fmt.Errorf("token endpoint unreachable")
+	}
+	attempted, refreshed := ae.refreshExpiringTokens(now, tokenRefreshSkew, boom)
+	require.Equal(t, 1, attempted)
+	require.Equal(t, 0, refreshed, "a failed refresh must not count as refreshed")
+}

--- a/fasten-sources-stub/clients/factory/refresh_test.go
+++ b/fasten-sources-stub/clients/factory/refresh_test.go
@@ -1,0 +1,61 @@
+package factory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fastenhealth/fasten-sources/clients/models"
+	"github.com/fastenhealth/fasten-sources/pkg"
+	"github.com/sirupsen/logrus"
+)
+
+// fakeCred is a minimal SourceCredential for exercising RefreshAccessToken's network-free guards.
+type fakeCred struct {
+	accessToken string
+	expiresAt   int64
+	fhirBase    string
+}
+
+func (f *fakeCred) GetSourceId() string                   { return "" }
+func (f *fakeCred) GetEndpointId() string                 { return "" }
+func (f *fakeCred) GetPortalId() string                   { return "" }
+func (f *fakeCred) GetBrandId() string                    { return "" }
+func (f *fakeCred) GetPlatformType() pkg.PlatformType     { return "" }
+func (f *fakeCred) GetClientId() string                   { return "" }
+func (f *fakeCred) GetPatientId() string                  { return "" }
+func (f *fakeCred) GetRefreshToken() string               { return "" }
+func (f *fakeCred) GetAccessToken() string                { return f.accessToken }
+func (f *fakeCred) GetExpiresAt() int64                   { return f.expiresAt }
+func (f *fakeCred) SetTokens(a string, r string, e int64) { f.accessToken, f.expiresAt = a, e }
+func (f *fakeCred) IsDynamicClient() bool                 { return false }
+func (f *fakeCred) GetApiEndpointBaseUrl() string         { return f.fhirBase }
+func (f *fakeCred) GetScopes() []string                   { return nil }
+
+var _ models.SourceCredential = (*fakeCred)(nil)
+
+// No access token (e.g. a manual-upload source) → nothing to refresh, no network.
+func TestRefreshAccessToken_NoAccessToken(t *testing.T) {
+	refreshed, err := RefreshAccessToken(context.Background(), logrus.WithField("t", t.Name()), &fakeCred{})
+	if err != nil || refreshed {
+		t.Fatalf("expected (false, nil), got (%v, %v)", refreshed, err)
+	}
+}
+
+// A token that is still comfortably valid is left alone without contacting the provider.
+func TestRefreshAccessToken_StillValid(t *testing.T) {
+	cred := &fakeCred{accessToken: "tok", expiresAt: time.Now().Add(time.Hour).Unix(), fhirBase: "https://example.invalid"}
+	refreshed, err := RefreshAccessToken(context.Background(), logrus.WithField("t", t.Name()), cred)
+	if err != nil || refreshed {
+		t.Fatalf("expected (false, nil) for a still-valid token (no network), got (%v, %v)", refreshed, err)
+	}
+}
+
+// An expired token with no FHIR base URL can't be refreshed — error, but still no network attempt.
+func TestRefreshAccessToken_ExpiredNoBaseURL(t *testing.T) {
+	cred := &fakeCred{accessToken: "tok", expiresAt: time.Now().Add(-time.Hour).Unix()}
+	refreshed, err := RefreshAccessToken(context.Background(), logrus.WithField("t", t.Name()), cred)
+	if err == nil || refreshed {
+		t.Fatalf("expected an error (no FHIR base URL) and refreshed=false, got (%v, %v)", refreshed, err)
+	}
+}

--- a/fasten-sources-stub/clients/factory/smart_client.go
+++ b/fasten-sources-stub/clients/factory/smart_client.go
@@ -101,6 +101,35 @@ func (c *smartClient) SyncAll(db models.DatabaseRepository) (models.UpsertSummar
 }
 
 // ensureValidToken refreshes the access token if it is missing or within the skew window of expiry.
+// RefreshAccessToken ensures the SMART source's access token is valid, refreshing it in place when
+// it is missing or within the skew window of expiry. It reuses the exact discovery + ensureValidToken
+// path that SyncAll uses, so there is a single source of truth for SMART token refresh. Returns
+// whether a refresh actually occurred; the caller persists the (mutated) credential. Used by the
+// scheduled token-refresh worker (#51).
+func RefreshAccessToken(ctx context.Context, logger *logrus.Entry, cred models.SourceCredential) (bool, error) {
+	const skewSeconds = 60
+	// Network-free guards: nothing to do for non-OAuth sources or still-valid tokens.
+	if cred.GetAccessToken() == "" {
+		return false, nil
+	}
+	if cred.GetExpiresAt() > time.Now().Add(skewSeconds*time.Second).Unix() {
+		return false, nil
+	}
+	c := newSmartClient(ctx, logger, cred)
+	if c.cfg.FHIRBaseURL == "" {
+		return false, fmt.Errorf("source has no FHIR base URL (api_endpoint_base_url); reconnect the source")
+	}
+	ep, err := c.cfg.Discover(ctx)
+	if err != nil {
+		return false, fmt.Errorf("SMART discovery failed: %w", err)
+	}
+	before := cred.GetExpiresAt()
+	if err := c.ensureValidToken(ep); err != nil {
+		return false, err
+	}
+	return cred.GetExpiresAt() != before, nil
+}
+
 func (c *smartClient) ensureValidToken(ep smart.Endpoints) error {
 	const skewSeconds = 60
 	if c.cred.GetAccessToken() != "" && c.cred.GetExpiresAt() > time.Now().Add(skewSeconds*time.Second).Unix() {


### PR DESCRIPTION
Part of #20. Fixes #51 (completes the one unmet acceptance item — the scheduled refresh worker; authorize/connect/poll + encrypted storage already landed in part 1).

## What

SMART access tokens currently refresh **reactively** (during a sync, via `ensureValidToken`). This adds a **scheduled** refresh so a source that isn't being actively synced doesn't let its `offline_access` token lapse.

- **`factory.RefreshAccessToken`** — a thin exported wrapper that reuses the **exact** discovery + `ensureValidToken` path `SyncAll` uses. Single source of truth for SMART refresh; no OAuth is reimplemented. Network-free guards return early for non-OAuth sources (no access token) and still-valid tokens.
- **Backend worker** (`pkg/web/token_refresh.go`) — a `time.Ticker` started in `Start()` (skipped in `StandbyMode`). Each tick scans **every user's** sources (`GetUsers` → per-user context → `GetSources`), refreshes those within 60s of expiry, and persists rotations via `UpdateSource`. One source's failure is logged and skipped so it never blocks the rest. Interval is `sync.token_refresh.interval_minutes` (default **30**; `<=0` disables).

## Tests

- `tokenNeedsRefresh` — pure table (nil / no-token / unknown-expiry / valid / within-skew / expired).
- `refreshExpiringTokens` — over an **in-memory repo** with an **injected** refresher: only the near-expiry source is attempted, the rotated access+refresh tokens are persisted, and a failing refresh is skipped (not counted).
- `factory.RefreshAccessToken` — the network-free guards (no-token, still-valid, expired-without-base-URL).

## Honest scope note

This is **auth/token-sensitive** code, so it wants careful review. It also **cannot be validated end-to-end yet**: #53 (a live Veradigm connection) is still blocked, so there are no long-lived real tokens in any running instance to observe refreshing. The actual network refresh reuses the same code the sandbox-proven sync path uses (#52/#51 milestone); this PR schedules it and is covered by unit tests for the decision + orchestration logic. Worth a close look before merge rather than a fast-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)