### PR TITLE
feat(search): support token `:text` modifier (#171)

### DIFF
--- a/backend/pkg/database/gorm_repository_query.go
+++ b/backend/pkg/database/gorm_repository_query.go
@@ -330,7 +330,7 @@ func ProcessSearchParameter(searchCodeWithModifier string, searchParamTypeLookup
 	}
 
 	//only a limited set of token modifiers are allowed. Otherwise we need to throw an error
-	allowedTokenModifiers := []string{"not"}
+	allowedTokenModifiers := []string{"not", "text"}
 	if searchParameter.Type == SearchParameterTypeToken && len(searchParameter.Modifier) > 0 && !lo.Contains(allowedTokenModifiers, searchParameter.Modifier) {
 		return searchParameter, fmt.Errorf("token search parameter %s does not support this modifier: %s", searchParameter.Name, searchParameter.Modifier)
 	}
@@ -595,8 +595,6 @@ func SearchCodeToWhereClause(searchParam SearchParameter, searchParamValue Searc
 		// - uri - https://hl7.org/fhir/r4/datatypes.html#uri
 		// - string - https://hl7.org/fhir/r4/datatypes.html#string
 
-		//TODO: support ":text" modifier
-
 		//setup the clause
 		clause := []string{}
 		if searchParamValue.Value.(string) != "" {
@@ -604,6 +602,12 @@ func SearchCodeToWhereClause(searchParam SearchParameter, searchParamValue Searc
 				clause = append(clause, fmt.Sprintf("%sJson.value ->> '$.code' = @%s", searchParam.Name, NamedParameterWithSuffix(searchParam.Name, searchParam.Modifier, namedParameterSuffix)))
 			} else if searchParam.Modifier == "not" {
 				clause = append(clause, fmt.Sprintf("%sJson.value ->> '$.code' <> @%s", searchParam.Name, NamedParameterWithSuffix(searchParam.Name, searchParam.Modifier, namedParameterSuffix)))
+			} else if searchParam.Modifier == "text" {
+				// FHIR `:text` modifier — case-insensitive partial match against the token's text/display
+				// ($.text = CodeableConcept.text / coding.display, populated by searchParameterExtractor.js).
+				// Critical for non-US-Core data (#171): when the code system is local/proprietary, the
+				// display text is often the only reliable way to find the record.
+				clause = append(clause, fmt.Sprintf("%sJson.value ->> '$.text' LIKE '%%' || @%s || '%%'", searchParam.Name, NamedParameterWithSuffix(searchParam.Name, searchParam.Modifier, namedParameterSuffix)))
 			}
 		}
 
@@ -716,4 +720,3 @@ func ProcessAggregationParameter(aggregationFieldWithFn models.QueryResourceAggr
 	}
 	return aggregationParameter, nil
 }
-

--- a/backend/pkg/database/gorm_repository_query_test.go
+++ b/backend/pkg/database/gorm_repository_query_test.go
@@ -40,6 +40,7 @@ func TestProcessSearchParameter(t *testing.T) {
 
 		{"display", map[string]string{"display": "token"}, SearchParameter{Type: "token", Name: "display", Modifier: ""}, false},
 		{"display:not", map[string]string{"display": "token"}, SearchParameter{Type: "token", Name: "display", Modifier: "not"}, false},
+		{"display:text", map[string]string{"display": "token"}, SearchParameter{Type: "token", Name: "display", Modifier: "text"}, false},
 		{"display:unsupported", map[string]string{"display": "token"}, SearchParameter{}, true},
 	}
 
@@ -166,6 +167,8 @@ func TestSearchCodeToWhereClause(t *testing.T) {
 		{SearchParameter{Type: "token", Name: "identifier", Modifier: ""}, SearchParameterValue{Value: "MR|446053", Prefix: "", SecondaryValues: map[string]interface{}{"identifierSystem": "http://terminology.hl7.org/CodeSystem/v2-0203"}}, "0_0", "(identifierJson.value ->> '$.code' = @identifier_0_0 AND identifierJson.value ->> '$.system' = @identifierSystem_0_0)", map[string]interface{}{"identifier_0_0": "MR|446053", "identifierSystem_0_0": "http://terminology.hl7.org/CodeSystem/v2-0203"}, false},
 		{SearchParameter{Type: "token", Name: "gender", Modifier: ""}, SearchParameterValue{Value: "male", Prefix: "", SecondaryValues: map[string]interface{}{"genderSystem": "http://terminology.hl7.org/CodeSystem/v2-0203"}}, "0_0", "(genderJson.value ->> '$.code' = @gender_0_0 AND genderJson.value ->> '$.system' = @genderSystem_0_0)", map[string]interface{}{"gender_0_0": "male", "genderSystem_0_0": "http://terminology.hl7.org/CodeSystem/v2-0203"}, false},
 		{SearchParameter{Type: "token", Name: "gender", Modifier: "not"}, SearchParameterValue{Value: "male", Prefix: "", SecondaryValues: map[string]interface{}{"genderSystem": "http://terminology.hl7.org/CodeSystem/v2-0203"}}, "0_0", "(genderJson.value ->> '$.code' <> @gender_not_0_0 AND genderJson.value ->> '$.system' = @genderSystem_not_0_0)", map[string]interface{}{"gender_not_0_0": "male", "genderSystem_not_0_0": "http://terminology.hl7.org/CodeSystem/v2-0203"}, false},
+		//#171: the `:text` modifier matches the token's text/display (CodeableConcept.text / coding.display) — the key to finding non-US-Core records whose code system is local/proprietary.
+		{SearchParameter{Type: "token", Name: "code", Modifier: "text"}, SearchParameterValue{Value: "headache", Prefix: "", SecondaryValues: map[string]interface{}{}}, "0_0", "(codeJson.value ->> '$.text' LIKE '%' || @code_text_0_0 || '%')", map[string]interface{}{"code_text_0_0": "headache"}, false},
 
 		{SearchParameter{Type: "keyword", Name: "id", Modifier: ""}, SearchParameterValue{Value: "1234", Prefix: "", SecondaryValues: map[string]interface{}{}}, "0_0", "(id = @id_0_0)", map[string]interface{}{"id_0_0": "1234"}, false},
 	}
@@ -309,4 +312,41 @@ func (suite *RepositoryTestSuite) TestQueryResources_SQL() {
 	require.Equal(suite.T(), sqlParams, []interface{}{
 		"test_code", "00000000-0000-0000-0000-000000000000",
 	})
+}
+
+// #171: the token `:text` modifier flows through the full query builder, matching the indexed
+// text/display with a case-insensitive partial LIKE — the key to finding non-US-Core records whose
+// code system is local/proprietary but whose display text is present.
+func (suite *RepositoryTestSuite) TestQueryResources_SQL_TextModifier() {
+	fakeConfig := mock_config.NewMockInterface(suite.MockCtrl)
+	fakeConfig.EXPECT().GetString("database.location").Return(suite.TestDatabase.Name()).AnyTimes()
+	fakeConfig.EXPECT().GetString("database.type").Return("sqlite").AnyTimes()
+	fakeConfig.EXPECT().IsSet("database.encryption.key").Return(false).AnyTimes()
+	fakeConfig.EXPECT().GetString("log.level").Return("INFO").AnyTimes()
+	fakeConfig.EXPECT().GetBool("database.validation_mode").Return(false).AnyTimes()
+	fakeConfig.EXPECT().GetBool("database.encryption.enabled").Return(false).AnyTimes()
+	dbRepo, err := NewRepository(fakeConfig, logrus.WithField("test", suite.T().Name()), event_bus.NewNoopEventBusServer())
+	require.NoError(suite.T(), err)
+	require.NoError(suite.T(), dbRepo.CreateUser(context.Background(), &models.User{Username: "test_username", Password: "testpassword", Email: "test@test.com"}))
+
+	sqliteRepo := dbRepo.(*GormRepository)
+	sqliteRepo.GormClient = sqliteRepo.GormClient.Session(&gorm.Session{DryRun: true})
+
+	authContext := context.WithValue(context.Background(), pkg.ContextKeyTypeAuthUsername, "test_username")
+	sqlQuery, err := sqliteRepo.sqlQueryResources(authContext, models.QueryResource{
+		Select: []string{},
+		Where:  map[string]interface{}{"code:text": "omeprazole"},
+		From:   "Observation",
+	})
+	require.NoError(suite.T(), err)
+	statement := sqlQuery.Find(&[]map[string]interface{}{}).Statement
+
+	require.Equal(suite.T(),
+		strings.Join([]string{
+			"SELECT fhir.*",
+			"FROM fhir_observation as fhir, json_each(fhir.code) as codeJson",
+			"WHERE ((codeJson.value ->> '$.text' LIKE '%' || ? || '%')) AND (user_id = ?) GROUP BY `fhir`.`id`",
+			"ORDER BY fhir.sort_date DESC"}, " "),
+		statement.SQL.String())
+	require.Equal(suite.T(), []interface{}{"omeprazole", "00000000-0000-0000-0000-000000000000"}, statement.Vars)
 }


### PR DESCRIPTION
Part of #171 (the query half — does **not** close it). Adds the FHIR `:text` token-search modifier.

## What

`:text` does a **case-insensitive partial match against the token's indexed text/display** (`$.text` = `CodeableConcept.text` / `coding.display`, already stored by `searchParameterExtractor.js`).

This is the query half of **non-US-Core findability**: when a source uses a local/proprietary code system (e.g. FollowMyHealth), the `code` is effectively unsearchable, but the display text is present — `code:text=omeprazole` now finds the record.

- Allowlist `text` as a token modifier (was `not` only) — so `code:text=…` parses instead of erroring.
- Token clause: `$.text LIKE '%' || @param || '%'` for the `text` modifier.

## Tests

- **Parse-validation**: `display:text` accepted (and unsupported modifiers still error).
- **Clause generation**: `code:text` → `(codeJson.value ->> '$.text' LIKE '%' || @code_text_0_0 || '%')`.
- **Full-query integration** (DryRun through `sqlQueryResources`): `code:text` produces the `$.text LIKE` WHERE clause + bound param.

## Does NOT close #171

The **extraction-fallback** half remains: e.g. Encounter `class`→`type` fallback, and indexing **text-only CodeableConcepts that have no `coding[]`** (the extractor stores `text` only when a coding or value/code is present). Those touch the generated FHIRPath extraction and benefit from real non-US-Core sample data (overlaps #20/#53). #171 stays open for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)