### PR TITLE
feat(admin): Admin Dashboard with Server Logs card (#170)

### DIFF
--- a/backend/pkg/web/handler/admin.go
+++ b/backend/pkg/web/handler/admin.go
@@ -1,0 +1,102 @@
+package handler
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/fastenhealth/fasten-onprem/backend/pkg"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/config"
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+// Admin Dashboard endpoints (#170). Admin-only; the dashboard is a set of cards that grows over
+// time — the first is "Server Logs".
+
+// ServerLogsResponse is the payload for GET /api/secure/admin/logs.
+type ServerLogsResponse struct {
+	// Configured is false when no log.file is set (logs go to STDOUT only and can't be read back).
+	Configured bool     `json:"configured"`
+	Path       string   `json:"path,omitempty"`
+	Lines      []string `json:"lines"`
+}
+
+const serverLogsMaxLines = 500
+const serverLogsMaxBytes = 256 * 1024 // bound memory: only the tail of the file is read
+
+// GetServerLogs returns the tail of the configured log file. Admin-only — server logs can contain
+// sensitive operational detail, so this is gated behind the admin role and only works when the
+// deployment has opted in by setting `log.file` (otherwise logs are STDOUT-only).
+func GetServerLogs(c *gin.Context) {
+	logger := c.MustGet(pkg.ContextKeyTypeLogger).(*logrus.Entry)
+	if !IsAdmin(c) {
+		c.JSON(http.StatusForbidden, gin.H{"success": false, "error": "admin role required"})
+		return
+	}
+
+	appConfig := c.MustGet(pkg.ContextKeyTypeConfig).(config.Interface)
+	logPath := appConfig.GetString("log.file")
+	if logPath == "" {
+		// Not an error — the deployment simply logs to STDOUT. The card explains how to enable.
+		c.JSON(http.StatusOK, gin.H{"success": true, "data": ServerLogsResponse{Configured: false, Lines: []string{}}})
+		return
+	}
+
+	lines, err := tailFile(logPath, serverLogsMaxLines, serverLogsMaxBytes)
+	if err != nil {
+		logger.Errorf("admin: could not read log file %s: %v", logPath, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "could not read log file"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": ServerLogsResponse{Configured: true, Path: logPath, Lines: lines}})
+}
+
+// tailFile returns the last maxLines lines of the file, reading at most the final maxBytes so a large
+// log can't blow up memory.
+func tailFile(path string, maxLines int, maxBytes int64) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	start := int64(0)
+	if info.Size() > maxBytes {
+		start = info.Size() - maxBytes
+	}
+	if _, err := f.Seek(start, io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+	// If we started mid-file, drop the (likely partial) first line.
+	if start > 0 {
+		if idx := bytes.IndexByte(data, '\n'); idx >= 0 {
+			data = data[idx+1:]
+		}
+	}
+
+	lines := []string{}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if len(lines) > maxLines {
+		lines = lines[len(lines)-maxLines:]
+	}
+	return lines, nil
+}

--- a/backend/pkg/web/handler/admin_test.go
+++ b/backend/pkg/web/handler/admin_test.go
@@ -1,0 +1,118 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/fastenhealth/fasten-onprem/backend/pkg"
+	mock_config "github.com/fastenhealth/fasten-onprem/backend/pkg/config/mock"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/database"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/event_bus"
+	"github.com/fastenhealth/fasten-onprem/backend/pkg/models"
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type AdminHandlerTestSuite struct {
+	suite.Suite
+	MockCtrl      *gomock.Controller
+	TestDatabase  *os.File
+	LogFile       *os.File
+	AppConfig     *mock_config.MockInterface
+	AppRepository database.DatabaseRepository
+}
+
+func (suite *AdminHandlerTestSuite) SetupSuite() {
+	suite.MockCtrl = gomock.NewController(suite.T())
+	dbFile, err := os.CreateTemp("", "admin.*.db")
+	require.NoError(suite.T(), err)
+	suite.TestDatabase = dbFile
+	logFile, err := os.CreateTemp("", "admin.*.log")
+	require.NoError(suite.T(), err)
+	suite.LogFile = logFile
+
+	cfg := mock_config.NewMockInterface(suite.MockCtrl)
+	cfg.EXPECT().GetString("database.location").Return(suite.TestDatabase.Name()).AnyTimes()
+	cfg.EXPECT().GetString("database.type").Return("sqlite").AnyTimes()
+	cfg.EXPECT().IsSet("database.encryption.key").Return(false).AnyTimes()
+	cfg.EXPECT().GetString("log.level").Return("INFO").AnyTimes()
+	cfg.EXPECT().GetBool("database.validation_mode").Return(false).AnyTimes()
+	cfg.EXPECT().GetBool("database.encryption.enabled").Return(false).AnyTimes()
+	cfg.EXPECT().GetString("log.file").Return(suite.LogFile.Name()).AnyTimes()
+	suite.AppConfig = cfg
+
+	repo, err := database.NewRepository(cfg, logrus.WithField("test", suite.T().Name()), event_bus.NewNoopEventBusServer())
+	require.NoError(suite.T(), err)
+	suite.AppRepository = repo
+	require.NoError(suite.T(), repo.CreateUser(context.Background(), &models.User{Username: "admin_user", Password: "p", Role: pkg.UserRoleAdmin}))
+	require.NoError(suite.T(), repo.CreateUser(context.Background(), &models.User{Username: "reg_user", Password: "p", Role: pkg.UserRoleUser}))
+}
+
+func (suite *AdminHandlerTestSuite) TearDownSuite() {
+	suite.MockCtrl.Finish()
+	os.Remove(suite.TestDatabase.Name())
+	os.Remove(suite.LogFile.Name())
+}
+
+func (suite *AdminHandlerTestSuite) ctxFor(username string, w *httptest.ResponseRecorder) *gin.Context {
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Set(pkg.ContextKeyTypeLogger, logrus.WithField("test", suite.T().Name()))
+	ctx.Set(pkg.ContextKeyTypeDatabase, suite.AppRepository)
+	ctx.Set(pkg.ContextKeyTypeConfig, suite.AppConfig)
+	ctx.Set(pkg.ContextKeyTypeAuthUsername, username)
+	ctx.Request = httptest.NewRequest("GET", "/admin/logs", nil)
+	return ctx
+}
+
+func (suite *AdminHandlerTestSuite) TestGetServerLogs_NonAdminForbidden() {
+	w := httptest.NewRecorder()
+	GetServerLogs(suite.ctxFor("reg_user", w))
+	require.Equal(suite.T(), http.StatusForbidden, w.Code)
+}
+
+func (suite *AdminHandlerTestSuite) TestGetServerLogs_AdminReadsTail() {
+	require.NoError(suite.T(), os.WriteFile(suite.LogFile.Name(), []byte("line one\nline two\nline three\n"), 0644))
+	w := httptest.NewRecorder()
+	GetServerLogs(suite.ctxFor("admin_user", w))
+	require.Equal(suite.T(), http.StatusOK, w.Code)
+
+	var resp struct {
+		Success bool               `json:"success"`
+		Data    ServerLogsResponse `json:"data"`
+	}
+	require.NoError(suite.T(), json.Unmarshal(w.Body.Bytes(), &resp))
+	require.True(suite.T(), resp.Success)
+	require.True(suite.T(), resp.Data.Configured)
+	require.Equal(suite.T(), []string{"line one", "line two", "line three"}, resp.Data.Lines)
+}
+
+// when log.file is unset, it's not an error — the card just reports "not configured".
+func (suite *AdminHandlerTestSuite) TestGetServerLogs_AdminNotConfigured() {
+	noLogCfg := mock_config.NewMockInterface(suite.MockCtrl)
+	noLogCfg.EXPECT().GetString("log.file").Return("").AnyTimes()
+
+	w := httptest.NewRecorder()
+	ctx := suite.ctxFor("admin_user", w)
+	ctx.Set(pkg.ContextKeyTypeConfig, noLogCfg)
+	GetServerLogs(ctx)
+	require.Equal(suite.T(), http.StatusOK, w.Code)
+
+	var resp struct {
+		Success bool               `json:"success"`
+		Data    ServerLogsResponse `json:"data"`
+	}
+	require.NoError(suite.T(), json.Unmarshal(w.Body.Bytes(), &resp))
+	require.False(suite.T(), resp.Data.Configured)
+	require.Empty(suite.T(), resp.Data.Lines)
+}
+
+func TestAdminHandlerTestSuite(t *testing.T) {
+	suite.Run(t, new(AdminHandlerTestSuite))
+}

--- a/backend/pkg/web/server.go
+++ b/backend/pkg/web/server.go
@@ -211,6 +211,9 @@ func (ae *AppEngine) Setup() (*gin.RouterGroup, *gin.Engine) {
 					secure.GET("/users", handler.GetUsers)
 					secure.POST("/users", handler.CreateUser)
 
+					//admin dashboard (#170) — handlers self-gate on the admin role
+					secure.GET("/admin/logs", handler.GetServerLogs)
+
 					secure.POST("/practitioners", handler.CreatePractitioner)
 					secure.PUT("/practitioners/:practitionerId", handler.UpdatePractitioner)
 					secure.GET("/practitioners/:practitionerId/history", handler.GetPractitionerEncounterHistory)

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -15,6 +15,7 @@ import { DesktopCallbackComponent } from './pages/desktop-callback/desktop-callb
 import { ExploreComponent } from './pages/explore/explore.component';
 import { MedicalHistoryComponent } from './pages/medical-history/medical-history.component';
 import { CurrentMedicationsComponent } from './pages/current-medications/current-medications.component';
+import { AdminDashboardComponent } from './pages/admin-dashboard/admin-dashboard.component';
 import { MedicalSourcesComponent } from './pages/medical-sources/medical-sources.component';
 import { PatientProfileComponent } from './pages/patient-profile/patient-profile.component';
 import { ReportLabsComponent } from './pages/report-labs/report-labs.component';
@@ -62,6 +63,7 @@ const routes: Routes = [
   { path: 'patient-profile', component: PatientProfileComponent, canActivate: [ IsAuthenticatedAuthGuard ] },
   { path: 'medical-history', component: MedicalHistoryComponent, canActivate: [ IsAuthenticatedAuthGuard ] },
   { path: 'medications', component: CurrentMedicationsComponent, canActivate: [ IsAuthenticatedAuthGuard ] },
+  { path: 'admin', component: AdminDashboardComponent, canActivate: [ IsAuthenticatedAuthGuard, IsAdminAuthGuard ] },
   { path: 'labs', component: ReportLabsComponent, canActivate: [ IsAuthenticatedAuthGuard ] },
   { path: 'labs/report/:source_id/:resource_type/:resource_id', component: ReportLabsComponent, canActivate: [ IsAuthenticatedAuthGuard ] },
 

--- a/frontend/src/app/components/header/header.component.html
+++ b/frontend/src/app/components/header/header.component.html
@@ -85,6 +85,7 @@
 
           <a (click)="openSupportForm(content)" class="dropdown-item  cursor-pointer"><i style="font-size: medium;" class="fas fa-question-circle"></i> Get Support</a>
           <a *ngIf="!is_environment_desktop" class="dropdown-item cursor-pointer" href="https://yourphr.org" externalLink><i style="font-size: medium;" class="fas fa-hand-holding-medical"></i> Donate</a>
+          <a *ngIf="isAdmin" routerLink="/admin" class="dropdown-item cursor-pointer"><i style="font-size: medium;" class="fas fa-cogs"></i> Admin Dashboard</a>
           <a routerLink="/settings" class="dropdown-item cursor-pointer"><i style="font-size: medium;" class="fas fa-cog"></i> Settings</a>
           <a (click)="signOut($event)" class="dropdown-item  cursor-pointer"><i style="font-size: medium;" class="fas fa-power-off"></i> Sign Out</a>
         </div><!-- dropdown-menu -->

--- a/frontend/src/app/models/fasten/server-logs.ts
+++ b/frontend/src/app/models/fasten/server-logs.ts
@@ -1,0 +1,7 @@
+// Response from GET /api/secure/admin/logs (admin-only). `configured` is false when the deployment
+// logs to STDOUT only (no log.file set), in which case `lines` is empty.
+export interface ServerLogs {
+  configured: boolean;
+  path?: string;
+  lines: string[];
+}

--- a/frontend/src/app/pages/admin-dashboard/admin-dashboard.component.html
+++ b/frontend/src/app/pages/admin-dashboard/admin-dashboard.component.html
@@ -1,0 +1,33 @@
+<div class="az-content-body">
+  <div class="mg-b-20">
+    <h4 class="mg-b-5"><i class="fas fa-cogs"></i>&nbsp; Admin Dashboard</h4>
+    <p class="tx-gray-500 mg-b-0">Administration tools. Available to admin users only; more cards will be added over time.</p>
+  </div>
+
+  <div class="row">
+    <!-- Server Logs card -->
+    <div class="col-lg-8 mg-b-20">
+      <div class="card">
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <h6 class="card-title mg-b-0"><i class="fas fa-file-alt"></i>&nbsp; Server Logs</h6>
+          <button class="btn btn-sm btn-outline-secondary" (click)="loadLogs()" [disabled]="logsLoading">Refresh</button>
+        </div>
+        <div class="card-body">
+          <app-loading-spinner *ngIf="logsLoading" loadingTitle="Loading logs..."></app-loading-spinner>
+
+          <div *ngIf="!logsLoading && logsErrored" class="alert alert-danger mg-b-0">Could not load server logs.</div>
+
+          <div *ngIf="!logsLoading && !logsErrored && logs && !logs.configured" class="alert alert-info mg-b-0">
+            Logs are written to STDOUT only. To view them here, set <code>log.file</code> in the server config (or the <code>--log-file</code> flag) and restart.
+          </div>
+
+          <ng-container *ngIf="!logsLoading && !logsErrored && logs?.configured">
+            <p class="tx-gray-500 tx-12 mg-b-5" *ngIf="logs?.path">{{ logs?.path }} · last {{ logs?.lines?.length || 0 }} lines</p>
+            <pre *ngIf="logs?.lines?.length" class="admin-logs">{{ logs?.lines?.join('\n') }}</pre>
+            <p *ngIf="!logs?.lines?.length" class="tx-gray-500 mg-b-0">Log file is empty.</p>
+          </ng-container>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/pages/admin-dashboard/admin-dashboard.component.scss
+++ b/frontend/src/app/pages/admin-dashboard/admin-dashboard.component.scss
@@ -1,0 +1,7 @@
+.admin-logs {
+  max-height: 480px;
+  overflow: auto;
+  font-size: 0.8rem;
+  white-space: pre;
+  margin-bottom: 0;
+}

--- a/frontend/src/app/pages/admin-dashboard/admin-dashboard.component.spec.ts
+++ b/frontend/src/app/pages/admin-dashboard/admin-dashboard.component.spec.ts
@@ -1,0 +1,39 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {of, throwError} from 'rxjs';
+
+import {AdminDashboardComponent} from './admin-dashboard.component';
+import {FastenApiService} from '../../services/fasten-api.service';
+
+describe('AdminDashboardComponent', () => {
+  let component: AdminDashboardComponent;
+  let fixture: ComponentFixture<AdminDashboardComponent>;
+  let api: jasmine.SpyObj<FastenApiService>;
+
+  beforeEach(async () => {
+    api = jasmine.createSpyObj('FastenApiService', ['getServerLogs']);
+    api.getServerLogs.and.returnValue(of({configured: true, path: '/var/log/fasten.log', lines: ['a', 'b']}));
+
+    await TestBed.configureTestingModule({
+      imports: [AdminDashboardComponent],
+      providers: [{provide: FastenApiService, useValue: api}],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AdminDashboardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('creates and loads logs on init', () => {
+    expect(component).toBeTruthy();
+    expect(api.getServerLogs).toHaveBeenCalled();
+    expect(component.logsLoading).toBeFalse();
+    expect(component.logs?.lines.length).toBe(2);
+  });
+
+  it('flags an error when the logs request fails', () => {
+    api.getServerLogs.and.returnValue(throwError(() => new Error('boom')));
+    component.loadLogs();
+    expect(component.logsErrored).toBeTrue();
+    expect(component.logsLoading).toBeFalse();
+  });
+});

--- a/frontend/src/app/pages/admin-dashboard/admin-dashboard.component.ts
+++ b/frontend/src/app/pages/admin-dashboard/admin-dashboard.component.ts
@@ -1,0 +1,43 @@
+import {Component, OnInit} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {FastenApiService} from '../../services/fasten-api.service';
+import {ServerLogs} from '../../models/fasten/server-logs';
+import {LoadingSpinnerComponent} from '../../components/loading-spinner/loading-spinner.component';
+
+// Admin Dashboard (#170): an admin-only page, a grid of cards that grows over time. v1 card:
+// Server Logs. The route is gated by IsAdminAuthGuard and each backend endpoint also self-gates on
+// the admin role.
+@Component({
+  standalone: true,
+  imports: [CommonModule, LoadingSpinnerComponent],
+  selector: 'app-admin-dashboard',
+  templateUrl: './admin-dashboard.component.html',
+  styleUrls: ['./admin-dashboard.component.scss'],
+})
+export class AdminDashboardComponent implements OnInit {
+  // --- Server Logs card ---
+  logsLoading = true;
+  logsErrored = false;
+  logs?: ServerLogs;
+
+  constructor(private fastenApi: FastenApiService) {}
+
+  ngOnInit(): void {
+    this.loadLogs();
+  }
+
+  loadLogs(): void {
+    this.logsLoading = true;
+    this.logsErrored = false;
+    this.fastenApi.getServerLogs().subscribe({
+      next: (logs) => {
+        this.logs = logs;
+        this.logsLoading = false;
+      },
+      error: () => {
+        this.logsErrored = true;
+        this.logsLoading = false;
+      },
+    });
+  }
+}

--- a/frontend/src/app/services/fasten-api.service.ts
+++ b/frontend/src/app/services/fasten-api.service.ts
@@ -6,6 +6,7 @@ import { Router } from '@angular/router';
 import {map} from 'rxjs/operators';
 import {ResponseWrapper} from '../models/response-wrapper';
 import {ReconciledMedication} from '../models/fasten/reconciled-medication';
+import {ServerLogs} from '../models/fasten/server-logs';
 import {Source} from '../models/fasten/source';
 import {User} from '../models/fasten/user';
 import {ResourceFhir} from '../models/fasten/resource_fhir';
@@ -141,6 +142,16 @@ export class FastenApiService {
       .pipe(
         map((response: ResponseWrapper) => {
           return (response.data || []) as ReconciledMedication[]
+        })
+      );
+  }
+
+  //admin-only (#170): server logs for the Admin Dashboard
+  getServerLogs(): Observable<ServerLogs> {
+    return this._httpClient.get<any>(`${GetEndpointAbsolutePath(globalThis.location, environment.fasten_api_endpoint_base)}/secure/admin/logs`)
+      .pipe(
+        map((response: ResponseWrapper) => {
+          return response.data as ServerLogs
         })
       );
   }


### PR DESCRIPTION
Part of #170. v1 = the admin dashboard **scaffold** + the first card (**Server Logs**); the card grid grows over time (modeled on the ngdpbase admin dashboard).

## Backend
- **`GET /api/secure/admin/logs`** — self-gated on the **admin role** (`handler.IsAdmin`). Returns the **tail** (≤500 lines, bounded ≤256 KB read so a big log can't blow up memory) of the configured `log.file`. When `log.file` is unset (STDOUT-only), returns `configured:false` rather than erroring.
- **Security posture:** server logs can carry sensitive operational detail, so the endpoint is **admin-only** *and* requires the deployment to opt in by setting `log.file`. Read-only, tail-only.
- Tests: non-admin → 403, admin reads the tail, admin + not-configured.

## Frontend
- **`/admin`** route guarded by `IsAuthenticatedAuthGuard` + the existing `IsAdminAuthGuard`.
- Standalone **`AdminDashboardComponent`** — Bootstrap card grid. The Server Logs card shows the tail in a scrollable `<pre>` with a Refresh button, and a clear "set `log.file` to enable" hint when not configured.
- **`getServerLogs()`** API method + `ServerLogs` model.
- **"Admin Dashboard"** entry in the profile dropdown, shown only when `isAdmin` (the header already computes it).

## Scope
The role system already exists (`User.Role`, `AuthService.IsAdmin()`, `/account/me`). This delivers the three things #170 asked for — dropdown entry, admin-only page, view server logs — as an extensible base. **Leaving #170 open** as the umbrella for future cards (backup, health, config, …), per "expand capabilities as time goes on."

🤖 Generated with [Claude Code](https://claude.com/claude-code)