### PR TITLE
feat(search): index text-only CodeableConcepts in token extraction (#171)

### DIFF
--- a/backend/pkg/models/database/fhir_condition_test.go
+++ b/backend/pkg/models/database/fhir_condition_test.go
@@ -171,3 +171,28 @@ func TestFhirCondition2_ExtractSearchParameters(t *testing.T) {
 	require.Equal(t, SearchParameterStringType{"approximately November 2012"}, testOnsetInfo)
 
 }
+
+// #171: a non-US-Core Condition whose clinicalStatus / category / code are text-only
+// CodeableConcepts (no coding[]) must still index their display text — previously these matched no
+// branch in the token extractor and were dropped, leaving the record unfindable (even by :text).
+func TestFhirCondition_TextOnlyCodeableConcept_ExtractSearchParameters(t *testing.T) {
+	t.Parallel()
+	conditionBytes, err := os.ReadFile("../../../../frontend/src/lib/fixtures/r4/resources/condition/example-text-only.json")
+	require.NoError(t, err)
+
+	conditionModel := FhirCondition{}
+	err = conditionModel.PopulateAndExtractSearchParameters(conditionBytes)
+	require.NoError(t, err)
+
+	var code SearchParameterTokenType
+	require.NoError(t, json.Unmarshal(json.RawMessage(conditionModel.Code), &code))
+	require.Equal(t, SearchParameterTokenType{{Text: "Chronic sinusitis"}}, code)
+
+	var clinicalStatus SearchParameterTokenType
+	require.NoError(t, json.Unmarshal(json.RawMessage(conditionModel.ClinicalStatus), &clinicalStatus))
+	require.Equal(t, SearchParameterTokenType{{Text: "Active"}}, clinicalStatus)
+
+	var category SearchParameterTokenType
+	require.NoError(t, json.Unmarshal(json.RawMessage(conditionModel.Category), &category))
+	require.Equal(t, SearchParameterTokenType{{Text: "Problem List Item"}}, category)
+}

--- a/backend/pkg/models/database/searchParameterExtractor.js
+++ b/backend/pkg/models/database/searchParameterExtractor.js
@@ -72,7 +72,7 @@ function extractTokenSearchParameters(fhirResource, expression){
     let result = fhirpathEvaluate(fhirResource, expression)
 
     let processed = result.reduce((accumulator, currentValue) => {
-        if (currentValue.coding) {
+        if (currentValue.coding && currentValue.coding.length) {
             //CodeableConcept
             currentValue.coding.map((coding) => {
                 accumulator.push({
@@ -94,6 +94,13 @@ function extractTokenSearchParameters(fhirResource, expression){
                 "code": currentValue.code,
                 "system": currentValue.system,
                 "text": currentValue.display
+            })
+        } else if (currentValue.text) {
+            //text-only CodeableConcept (no usable coding[]) — common in non-US-Core exports (#171).
+            //Index the display text (no code/system) so the record is still findable, e.g. via the
+            //token `:text` modifier. Without this it matched no branch above and was dropped.
+            accumulator.push({
+                "text": currentValue.text
             })
         } else if ((typeof currentValue === 'string') || (typeof currentValue === 'boolean')) {
             //string, boolean

--- a/frontend/src/lib/fixtures/r4/resources/condition/example-text-only.json
+++ b/frontend/src/lib/fixtures/r4/resources/condition/example-text-only.json
@@ -1,0 +1,21 @@
+{
+  "resourceType": "Condition",
+  "id": "example-text-only",
+  "meta": {
+    "lastUpdated": "2026-02-24T14:34:58.26+00:00"
+  },
+  "clinicalStatus": {
+    "text": "Active"
+  },
+  "category": [
+    {
+      "text": "Problem List Item"
+    }
+  ],
+  "code": {
+    "text": "Chronic sinusitis"
+  },
+  "subject": {
+    "reference": "Patient/example"
+  }
+}


### PR DESCRIPTION
Part of #171 (the extraction half). Closes a concrete non-US-Core findability gap.

## The gap
Non-US-Core exports (Veradigm/FollowMyHealth) frequently carry a CodeableConcept with only `text` and **no `coding[]`** — e.g. a Condition's `clinicalStatus` / `category` / `code`. The token extractor (`searchParameterExtractor.js`) had branches for `coding[]` / `value` / `code` / `string|boolean` but **none for text-only**, so such concepts matched nothing and were **silently dropped** — the record was unindexed and unfindable, even by the new `:text` modifier.

## The fix
- New **text-only branch**: index `{ text }` (no code/system) so the display text is searchable.
- Treat an empty `coding: []` as no-coding (falls through to the text branch) — more robust.
- `searchParameterExtractor.js` is `go:embed`'d + goja-compiled **at runtime**, so this changes extraction with **no codegen** and no regenerated `fhir_*.go`.

## Tests
- New synthetic **text-only Condition** fixture; asserts `code` / `clinicalStatus` / `category` each index their `text`.
- **Full `pkg/models/database` suite green** — the `coding.length` tweak doesn't regress any existing resource's extraction.

## Still on #171
Per-search-param **FHIRPath fallbacks** (e.g. Encounter `class`→`type`) — those need a generator-level expression override and benefit from real non-US-Core sample data (overlaps #53). This PR is the general text-only indexing fix that helps every token field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)