### PR TITLE
fix(encounter): proper non-US-Core Encounter display

### DIFF
--- a/frontend/src/app/components/fhir-card/resources/encounter/encounter.component.html
+++ b/frontend/src/app/components/fhir-card/resources/encounter/encounter.component.html
@@ -1,7 +1,7 @@
 <div class="card  card-fhir-resource">
   <div class="card-header" (click)="isCollapsed = ! isCollapsed">
     <div>
-      <h6 class="card-title">{{displayModel?.sort_title || displayModel?.code?.text}}</h6>
+      <h6 class="card-title">{{displayModel?.display}}</h6>
       <p class="card-text tx-gray-400" *ngIf="displayModel?.period_start"><strong>Start date</strong> {{displayModel?.period_start | date}}</p>
     </div>
     <!--    <div class="btn-group">-->

--- a/frontend/src/app/components/fhir-card/resources/encounter/encounter.component.ts
+++ b/frontend/src/app/components/fhir-card/resources/encounter/encounter.component.ts
@@ -34,6 +34,18 @@ export class EncounterComponent implements OnInit, FhirCardEditableComponentInte
   constructor(public changeRef: ChangeDetectorRef, public router: Router) { }
 
   ngOnInit(): void {
+    // US Core Encounter Must-Support: type, class, status, period, participant, reasonCode,
+    // hospitalization.dischargeDisposition, location. Each row is gated on presence (detect-don't-
+    // require), so a conformant Encounter shows the full set and a sparse non-US-Core one shows only
+    // what it has — the title fallback (model.display) keeps it from rendering blank.
+    const participants = (this.displayModel?.participant || [])
+      .map((p) => {
+        const name = p.display || p.text || p.reference?.reference;
+        if (!name) { return null; }
+        return p.role ? `${p.role}: ${name}` : name;
+      })
+      .filter(Boolean) as string[];
+
     this.tableData = [
       {
         label: 'Type',
@@ -42,9 +54,41 @@ export class EncounterComponent implements OnInit, FhirCardEditableComponentInte
         enabled: !!this.displayModel?.encounter_type?.[0],
       },
       {
+        label: 'Class',
+        data: this.displayModel?.resource_class,
+        enabled: !!this.displayModel?.resource_class,
+      },
+      {
+        label: 'Status',
+        data: this.displayModel?.resource_status,
+        enabled: !!this.displayModel?.resource_status,
+      },
+      {
+        label: 'Reason',
+        data: this.displayModel?.reasonCode?.[0],
+        data_type: TableRowItemDataType.CodableConcept,
+        enabled: !!this.displayModel?.reasonCode?.[0],
+      },
+      {
+        label: 'Participants',
+        data: participants.join(', '),
+        enabled: participants.length > 0,
+      },
+      {
+        label: 'Discharge disposition',
+        data: this.displayModel?.discharge_disposition,
+        data_type: TableRowItemDataType.CodableConcept,
+        enabled: !!this.displayModel?.discharge_disposition,
+      },
+      {
         label: 'Location',
         data: this.displayModel?.location_display,
         enabled: !!this.displayModel?.location_display,
+      },
+      {
+        label: 'End date',
+        data: this.displayModel?.period_end,
+        enabled: !!this.displayModel?.period_end,
       },
     ];
   }

--- a/frontend/src/lib/fixtures/r4/resources/encounter/example-followmyhealth.json
+++ b/frontend/src/lib/fixtures/r4/resources/encounter/example-followmyhealth.json
@@ -1,0 +1,41 @@
+{
+  "resourceType": "Encounter",
+  "id": "example-followmyhealth",
+  "meta": {
+    "extension": [
+      {
+        "url": "https://fhir.followmyhealth.com/api/FirstCreatedExtension?_format=application/json",
+        "valueInstant": "2026-03-05T20:21:12.744+00:00"
+      }
+    ],
+    "lastUpdated": "2026-03-05T20:21:12.744+00:00"
+  },
+  "identifier": [
+    {
+      "use": "official",
+      "system": "https://fhir.followmyhealth.com/id/global",
+      "value": "example-followmyhealth",
+      "assigner": {
+        "display": "FollowMyHealth"
+      }
+    }
+  ],
+  "status": "unknown",
+  "class": {
+    "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode"
+  },
+  "subject": {
+    "reference": "Patient/example"
+  },
+  "period": {
+    "start": "2026-03-05",
+    "end": "2026-03-05"
+  },
+  "location": [
+    {
+      "location": {
+        "display": "Department of Primary Care - Family Medicine, Example"
+      }
+    }
+  ]
+}

--- a/frontend/src/lib/models/resources/encounter-model.spec.ts
+++ b/frontend/src/lib/models/resources/encounter-model.spec.ts
@@ -3,6 +3,7 @@ import {DocumentReferenceModel} from './document-reference-model';
 import * as example1Fixture from "../../fixtures/r4/resources/encounter/example1.json"
 import * as example2Fixture from "../../fixtures/r4/resources/encounter/example2.json"
 import * as example3Fixture from "../../fixtures/r4/resources/encounter/example3.json"
+import * as exampleFmhFixture from "../../fixtures/r4/resources/encounter/example-followmyhealth.json"
 
 
 describe('EncounterModel', () => {
@@ -20,6 +21,8 @@ describe('EncounterModel', () => {
       // encounterType: string | undefined
       expected.resource_class = 'inpatient encounter'
       expected.resource_status = 'in-progress'
+      // no type/serviceType → title falls back to class.display
+      expected.display = 'inpatient encounter'
       // participant
 
       expect(new EncounterModel(example1Fixture)).toEqual(expected);
@@ -31,11 +34,12 @@ describe('EncounterModel', () => {
       expected.period_start = '2015-01-17T16:00:00Z'
       expected.has_participant = true
       expected.location_display = 'Client\'s home'
-      // example2.json has no encounter-level `type`, so the model synthesises a display-only
-      // encounter_type from the location (Veradigm/FollowMyHealth non-US-Core fallback).
-      expected.encounter_type = [{ text: 'Client\'s home', coding: [] }] as any
+      // example2.json has no encounter-level `type`; encounter_type stays undefined (we no longer
+      // synthesise it from location — that duplicated the Location row). The title instead falls
+      // back through class.display below.
       expected.resource_class =  'home health'
       expected.resource_status = 'finished'
+      expected.display = 'home health'
       expected.participant = [
         {
           display: 'Dr Adam Careful',
@@ -54,10 +58,11 @@ describe('EncounterModel', () => {
       // expected.periodEnd = '2015-01-17T16:30:00+10:00'
       // expected.periodStart = '2015-01-17T16:00:00+10:00'
       expected.has_participant = true
-      expected.location_display = 'Encounter'
+      // no location in example3 → location_display undefined (we dropped the 'Encounter' default)
       expected.encounter_type = [ { coding: [ Object({ system: 'http://snomed.info/sct', code: '11429006', display: 'Consultation' }) ] } ]
       expected.resource_class = 'ambulatory'
       expected.resource_status = 'finished'
+      expected.display = 'Consultation' // title from type.coding.display
       expected.reasonCode = [
         {
           text: 'The patient had fever peaks over the last couple of days. He is worried about these peaks.'
@@ -74,6 +79,18 @@ describe('EncounterModel', () => {
       expected.code = { coding: [{ system: 'http://snomed.info/sct', code: '11429006', display: 'Consultation' }] }
 
       expect(new EncounterModel(example3Fixture)).toEqual(expected);
+    });
+
+    // Non-US-Core (FollowMyHealth): no type/serviceType, a class with a system but no code/display,
+    // only a location. The title must fall back to the location (not render blank), and the location
+    // is not duplicated into a synthesised type.
+    it('should title a FollowMyHealth encounter from its location', () => {
+      const model = new EncounterModel(exampleFmhFixture);
+      expect(model.display).toEqual('Department of Primary Care - Family Medicine, Example');
+      expect(model.location_display).toEqual('Department of Primary Care - Family Medicine, Example');
+      expect(model.encounter_type).toBeUndefined();
+      expect(model.resource_status).toEqual('unknown');
+      expect(model.period_start).toEqual('2026-03-05');
     });
 
   })

--- a/frontend/src/lib/models/resources/encounter-model.ts
+++ b/frontend/src/lib/models/resources/encounter-model.ts
@@ -8,6 +8,7 @@ import {FastenOptions} from '../fasten/fasten-options';
 
 export class EncounterModel extends FastenDisplayModel {
   code: CodableConceptModel | undefined
+  display: string | undefined
   period_end: string | undefined
   period_start: string | undefined
   has_participant: boolean | undefined
@@ -15,6 +16,7 @@ export class EncounterModel extends FastenDisplayModel {
   encounter_type: CodableConceptModel[] | undefined
   resource_class: string | undefined
   resource_status: string | undefined
+  discharge_disposition: CodableConceptModel | undefined
   participant: {
     display?: string,
     role?: string,
@@ -34,18 +36,25 @@ export class EncounterModel extends FastenDisplayModel {
   commonDTO(fhirResource:any){
     this.code = _.get(fhirResource, 'serviceType') || _.get(fhirResource, 'type.0');
     this.resource_status = _.get(fhirResource, 'status');
-    this.location_display = _.get(
-      fhirResource,
-      'location[0].location.display',
-      'Encounter',
-    );
+    this.location_display = _.get(fhirResource, 'location[0].location.display');
     this.encounter_type = _.get(fhirResource, 'type');
-    // Veradigm/FollowMyHealth omits type entirely; synthesise a display-only entry from location
-    if (!this.encounter_type?.length && this.location_display && this.location_display !== 'Encounter') {
-      this.encounter_type = [{ text: this.location_display, coding: [] }] as any;
-    }
     this.has_participant = _.has(fhirResource, 'participant');
     this.reasonCode = _.get(fhirResource, 'reasonCode');
+    this.discharge_disposition = _.get(fhirResource, 'hospitalization.dischargeDisposition');
+
+    // Card title fallback. US Core titles off type/serviceType; Veradigm/FollowMyHealth often omits
+    // both and ships only a location + a class with a system but no code — so without this the title
+    // renders blank (#54 follow-up). Fall back: type → serviceType → class → location → generic.
+    // (Note: the backend sort_title isn't in resource_raw, so the card can't rely on it.)
+    this.display =
+      _.get(fhirResource, 'type.0.text') ||
+      _.get(fhirResource, 'type.0.coding.0.display') ||
+      _.get(fhirResource, 'serviceType.text') ||
+      _.get(fhirResource, 'serviceType.coding.0.display') ||
+      _.get(fhirResource, 'class.display') ||
+      _.get(fhirResource, 'class.code') ||
+      this.location_display ||
+      'Encounter';
   };
 
   dstu2DTO(fhirResource:any){


### PR DESCRIPTION
Follow-up to #54 (non-US-Core display). Fixes Encounters rendering blank/sparse — confirmed against a real FollowMyHealth export: **78/78 Encounters** have no `type`, a `class` with only a system (no code/display), no `participant`/`reasonCode` — just `status`, `period`, and a `location`.

## The bug
The card title was `sort_title || code?.text`. `sort_title` is a DB column **not present in `resource_raw`** (so undefined when the card builds from raw FHIR), and `code` (= `serviceType || type[0]`) is absent here → **blank title**. The card also synthesized `encounter_type` from the location (so Type + Location showed the *same* string) and omitted date/status/class.

## The fix
- **`EncounterModel`**: add a `display` title fallback — `type` → `serviceType` → `class` → `location` → `'Encounter'`; drop the synthesize-from-location hack and the `'Encounter'` location default; parse `hospitalization.dischargeDisposition`.
- **Card**: title from `display`; render the **US Core Encounter Must-Support** set — type, class, status, reason, participants, discharge disposition, location, period — each gated on presence.

## Proper Encounters are not messed up
A US Core Encounter still titles off `type` (the fallback only triggers when type/serviceType are absent) and now shows **more** fields. Verified against the **3 existing US Core example fixtures** (regression) + a synthetic FMH fixture. 6 specs green, lint 0 errors.

**Display-only (render-time)** — applies to already-imported records on deploy; no re-import needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)