### PR TITLE
fix(document-reference): meaningful titles for non-US-Core docs (#198)

### DIFF
--- a/frontend/src/app/components/fhir-card/resources/document-reference/document-reference.component.html
+++ b/frontend/src/app/components/fhir-card/resources/document-reference/document-reference.component.html
@@ -1,7 +1,7 @@
 <div class="card card-fhir-resource" >
   <div class="card-header" (click)="isCollapsed = ! isCollapsed">
     <div>
-      <h6 class="card-title">{{displayModel?.category?.text}}</h6>
+      <h6 class="card-title">{{displayModel?.title}}</h6>
       <p class="card-text tx-gray-400" *ngIf="displayModel?.created_at"><strong>Created at</strong> {{displayModel?.created_at | date}}</p>
     </div>
     <fhir-ui-badge class="float-right" [status]="displayModel?.status">{{displayModel?.status}}</fhir-ui-badge>
@@ -12,7 +12,6 @@
     <!--    </div>-->
   </div>
   <div #collapse="ngbCollapse" [(ngbCollapse)]="isCollapsed" class="card-body">
-    <p class="az-content-text mg-b-20">An action that is or was performed on or for a patient, practitioner, device, organization, or location. For example, this can be a physical intervention on a patient like an operation, or less invasive like long term services, counseling, or hypnotherapy.</p>
     <fhir-ui-table [displayModel]="displayModel" [tableData]="tableData"></fhir-ui-table>
 
     <div *ngIf="!showDetails">

--- a/frontend/src/lib/fixtures/r4/resources/documentReference/example-followmyhealth.json
+++ b/frontend/src/lib/fixtures/r4/resources/documentReference/example-followmyhealth.json
@@ -1,0 +1,37 @@
+{
+  "resourceType": "DocumentReference",
+  "id": "example-followmyhealth",
+  "meta": {
+    "lastUpdated": "2026-03-05T20:21:12.744+00:00"
+  },
+  "identifier": [
+    {
+      "use": "official",
+      "system": "https://fhir.followmyhealth.com/id/global",
+      "value": "example-followmyhealth"
+    }
+  ],
+  "status": "current",
+  "type": {
+    "coding": [
+      {
+        "display": "Release of Information Authorization, Example Hospital"
+      }
+    ],
+    "text": "HIPAA"
+  },
+  "subject": {
+    "reference": "Patient/example"
+  },
+  "date": "2026-03-05T20:21:12.744+00:00",
+  "content": [
+    {
+      "attachment": {
+        "contentType": "text/plain",
+        "url": "./Release%20of%20Information%20Authorization_aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.txt",
+        "title": "Release of Information Authorization, Example Hospital",
+        "creation": "2026-03-05T20:21:12.744+00:00"
+      }
+    }
+  ]
+}

--- a/frontend/src/lib/models/resources/document-reference-model.spec.ts
+++ b/frontend/src/lib/models/resources/document-reference-model.spec.ts
@@ -2,6 +2,7 @@ import { DocumentReferenceModel } from './document-reference-model';
 import {AdverseEventModel} from './adverse-event-model';
 import {CodableConceptModel} from '../datatypes/codable-concept-model';
 import * as example1Fixture from "../../fixtures/r4/resources/documentReference/example1.json"
+import * as exampleFmhFixture from "../../fixtures/r4/resources/documentReference/example-followmyhealth.json"
 import {AttachmentModel} from '../datatypes/attachment-model';
 
 
@@ -50,13 +51,32 @@ describe('DocumentReferenceModel', () => {
       }
       // expected.context: any | undefined
       expected.code = { coding: [{ system: 'http://loinc.org', code: '34108-1', display: 'Outpatient Note' }] }
-      expected.title = 'History and Physical'
+      // title now leads with `description` (matches the backend sort_title), so it is 'Physical'
+      // rather than the category display 'History and Physical'.
+      expected.title = 'Physical'
       // US Core Must-Support (#147)
       expected.subject = { reference: 'Patient/xcda' }
       expected.authors = [{ reference: 'Practitioner/xcda1' }, { reference: '#a2' }]
       expected.content_formats = [{ system: 'urn:oid:1.3.6.1.4.1.19376.1.2.3', code: 'urn:ihe:pcc:handp:2008', display: 'History and Physical Specification' }]
 
       expect(new DocumentReferenceModel(example1Fixture)).toEqual(expected);
+    });
+
+    // Non-US-Core (FollowMyHealth): no description/category, a `type` whose coding carries a
+    // meaningful display but no code/system, and a generic `type.text` ("HIPAA"). The title must
+    // fall back to the meaningful `type.coding[0].display` (or the attachment title) — never the
+    // generic "HIPAA", and never blank.
+    it('should title a FollowMyHealth document from its meaningful type display, not the generic text', () => {
+      const model = new DocumentReferenceModel(exampleFmhFixture);
+      expect(model.title).toEqual('Release of Information Authorization, Example Hospital');
+      expect(model.title).not.toEqual('HIPAA');
+      expect(model.status).toEqual('current');
+      expect(model.created_at).toEqual('2026-03-05T20:21:12.744+00:00');
+    });
+
+    it('should never render a blank title (falls back to a generic label)', () => {
+      const model = new DocumentReferenceModel({ resourceType: 'DocumentReference' });
+      expect(model.title).toEqual('Document');
     });
   })
 

--- a/frontend/src/lib/models/resources/document-reference-model.ts
+++ b/frontend/src/lib/models/resources/document-reference-model.ts
@@ -42,7 +42,20 @@ export class DocumentReferenceModel extends FastenDisplayModel {
 
   commonDTO(fhirResource:any){
     this.code = _.get(fhirResource, 'type');
-    this.title = _.get(fhirResource, 'category.0.text') || _.get(fhirResource, 'category.0.coding.0.display') || _.get(fhirResource, 'type.text') || _.get(fhirResource, 'type.coding.0.display');
+    // Card title. Prefer the instance's human-meaningful labels and demote the generic
+    // `type.text` to a last resort: FollowMyHealth/Veradigm exports carry the real document
+    // name in `description` / `type.coding[0].display` / `content[0].attachment.title` but
+    // a generic `type.text` (e.g. "HIPAA"), so titling off `type.text` first labelled
+    // thousands of distinct documents identically. `description` leads so the card matches
+    // the backend sort_title. Falls back to a generic 'Document' so the header is never blank.
+    this.title =
+      _.get(fhirResource, 'description') ||
+      _.get(fhirResource, 'category.0.text') ||
+      _.get(fhirResource, 'category.0.coding.0.display') ||
+      _.get(fhirResource, 'type.coding.0.display') ||
+      _.get(fhirResource, 'content.0.attachment.title') ||
+      _.get(fhirResource, 'type.text') ||
+      'Document';
     this.description = _.get(fhirResource, 'description');
     this.status = _.get(fhirResource, 'status');
     this.subject = _.get(fhirResource, 'subject');


### PR DESCRIPTION
Closes #198.

## Problem

DocumentReference cards rendered **blank or generic ("HIPAA")** titles for FollowMyHealth/Veradigm documents — ~85% of a typical FMH export (5,564 / 6,563 resources in one real bundle). Two compounding causes:

1. The card header bound `displayModel?.category?.text`; FMH docs have no `category` → **blank header**.
2. `DocumentReferenceModel.title` resolved `type.text` before `type.coding[0].display`. FMH carries the real document name in `description` / `type.coding[0].display` / `content[0].attachment.title` but a generic `type.text` like **"HIPAA"** → thousands of distinct docs titled identically.

(Also: the card body had a stray paragraph describing a *Procedure*, copy-pasted from that card.)

## Fix (frontend, display-only — applies on deploy, no re-import)

- Bind the header to `displayModel?.title`.
- Re-order `title`: `description` → `category.text` → `category.coding[0].display` → `type.coding[0].display` → `content[0].attachment.title` → `type.text` → `"Document"`. `description` leads so the card matches the backend `sort_title`; generic `type.text` is the last resort; `"Document"` guarantees the header is never blank.
- Remove the stray Procedure paragraph.

## Tests (4/4 green locally)

- `example1` now titles from its `description` ("Physical"), matching the backend sort_title.
- New synthetic FMH fixture + cases: title comes from `type.coding[0].display` (**never "HIPAA"**), and an empty resource never renders a blank title (falls back to "Document").

## Notes / follow-ups

- **Document bodies are not in the bundle.** FMH stores them as sibling files referenced by relative `./…` URLs, so manual upload never carries them — the card can only show metadata. Rendering bodies would need a separate file-upload import path.
- Backend `sort_title` already leads with `description` but falls to `type.text` before `type.coding[0].display`; aligning it (regen + re-import) is a small follow-up for description-less docs.

Part of the non-US-Core FollowMyHealth display series (#54, #195, #196).

🤖 Generated with [Claude Code](https://claude.com/claude-code)