### PR TITLE
fix(document-reference): align backend sort_title with card title order (#201)

### DIFF
--- a/backend/pkg/models/database/fhir_document_reference.go
+++ b/backend/pkg/models/database/fhir_document_reference.go
@@ -381,7 +381,7 @@ func (s *FhirDocumentReference) PopulateAndExtractSearchParameters(resourceRaw j
 		s.Type = []byte(typeResult.String())
 	}
 	// set sort_title from best available human-readable display text (Fasten-specific, not a FHIR search parameter)
-	sortTitleResult, err := vm.RunString("(function(){var r=fhirResource;if(r.description)return r.description;var c=r.type;if(c){if(c.text)return c.text;if(c.coding&&c.coding[0]&&c.coding[0].display)return c.coding[0].display;}return undefined;})()")
+	sortTitleResult, err := vm.RunString("(function(){var r=fhirResource;if(r.description)return r.description;var cat=r.category&&r.category[0];if(cat){if(cat.text)return cat.text;if(cat.coding&&cat.coding[0]&&cat.coding[0].display)return cat.coding[0].display;}var t=r.type;if(t&&t.coding&&t.coding[0]&&t.coding[0].display)return t.coding[0].display;if(r.content&&r.content[0]&&r.content[0].attachment&&r.content[0].attachment.title)return r.content[0].attachment.title;if(t&&t.text)return t.text;return undefined;})()")
 	if err == nil && sortTitleResult.String() != "undefined" && sortTitleResult.String() != "null" {
 		sortTitle := sortTitleResult.String()
 		s.SetSortTitle(&sortTitle)

--- a/backend/pkg/models/database/fhir_document_reference_sort_test.go
+++ b/backend/pkg/models/database/fhir_document_reference_sort_test.go
@@ -1,0 +1,48 @@
+package database
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// #198 follow-up: the DocumentReference sort_title previously resolved type.text before
+// type.coding[0].display, so FollowMyHealth docs (generic type.text like "HIPAA", real name in
+// type.coding[0].display / description / attachment.title) sorted/labelled identically. The
+// extractor now mirrors the frontend DocumentReferenceModel.title order. These tests pin both the
+// non-US-Core shape and the standard shape.
+
+func TestFhirDocumentReference_FollowMyHealth_SortTitle(t *testing.T) {
+	t.Parallel()
+	bytes, err := os.ReadFile("../../../../frontend/src/lib/fixtures/r4/resources/documentReference/example-followmyhealth.json")
+	require.NoError(t, err)
+
+	model := FhirDocumentReference{}
+	err = model.PopulateAndExtractSearchParameters(bytes)
+	require.NoError(t, err)
+
+	// No description/category — the title must come from the meaningful type.coding[0].display,
+	// never the generic type.text ("HIPAA").
+	require.NotNil(t, model.SortTitle, "FMH document should derive a sort_title")
+	require.Equal(t, "Release of Information Authorization, Example Hospital", *model.SortTitle)
+	require.NotEqual(t, "HIPAA", *model.SortTitle)
+
+	require.NotNil(t, model.SortDate, "FMH document should derive sort_date from `date`")
+}
+
+func TestFhirDocumentReference_Standard_SortTitle(t *testing.T) {
+	t.Parallel()
+	bytes, err := os.ReadFile("../../../../frontend/src/lib/fixtures/r4/resources/documentReference/example1.json")
+	require.NoError(t, err)
+
+	model := FhirDocumentReference{}
+	err = model.PopulateAndExtractSearchParameters(bytes)
+	require.NoError(t, err)
+
+	// description leads, so a standard doc with a description titles from it (matching the card).
+	require.NotNil(t, model.SortTitle, "standard document should derive a sort_title")
+	require.Equal(t, "Physical", *model.SortTitle)
+
+	require.NotNil(t, model.SortDate, "standard document should derive sort_date from `date`")
+}

--- a/backend/pkg/models/database/generate.go
+++ b/backend/pkg/models/database/generate.go
@@ -676,7 +676,10 @@ var resourceSortConfig = map[string]resourceSortConfigEntry{
 		SortDateJS:  `(function(){var r=fhirResource;if(r.recordedDate)return r.recordedDate;if(r.onsetDateTime)return r.onsetDateTime;return undefined;})()`,
 	},
 	"DocumentReference": {
-		SortTitleJS: `(function(){var r=fhirResource;if(r.description)return r.description;var c=r.type;if(c){if(c.text)return c.text;if(c.coding&&c.coding[0]&&c.coding[0].display)return c.coding[0].display;}return undefined;})()`,
+		// Mirror the frontend DocumentReferenceModel.title order: prefer instance-meaningful
+		// labels and demote the generic `type.text` (e.g. "HIPAA" on FollowMyHealth docs, which
+		// would otherwise label thousands of distinct documents identically) to a last resort.
+		SortTitleJS: `(function(){var r=fhirResource;if(r.description)return r.description;var cat=r.category&&r.category[0];if(cat){if(cat.text)return cat.text;if(cat.coding&&cat.coding[0]&&cat.coding[0].display)return cat.coding[0].display;}var t=r.type;if(t&&t.coding&&t.coding[0]&&t.coding[0].display)return t.coding[0].display;if(r.content&&r.content[0]&&r.content[0].attachment&&r.content[0].attachment.title)return r.content[0].attachment.title;if(t&&t.text)return t.text;return undefined;})()`,
 		SortDateJS:  `(function(){var r=fhirResource;if(r.date)return r.date;return undefined;})()`,
 	},
 	"Appointment": {


### PR DESCRIPTION
Closes #201. Backend half of the DocumentReference title work (frontend was #198 / PR #199).

## Problem

The `sort_title` extractor (list ordering + list-row label) resolved `type.text` before `type.coding[0].display`, so description-less FollowMyHealth docs sorted/labelled by the generic `type.text` ("HIPAA") instead of the meaningful display — inconsistent with the card fixed in #198.

## Fix

Align `resourceSortConfig["DocumentReference"].SortTitleJS` in `generate.go` to mirror `DocumentReferenceModel.title`:
`description` → `category.text` → `category.coding[0].display` → `type.coding[0].display` → `content[0].attachment.title` → `type.text`.

Regenerated `fhir_document_reference.go` — **only that model changed** (verified diff is the single SortTitle JS string).

## Tests

`fhir_document_reference_sort_test.go` (mirrors the medication sort tests):
- FMH fixture → `sort_title` = `"Release of Information Authorization, Example Hospital"` (from `type.coding[0].display`), **never "HIPAA"**.
- Standard `example1` → `sort_title` = `"Physical"` (description), matching the card.

`go vet` clean; build OK.

## ⚠️ Re-import required

`sort_title` is computed at import time, so existing records need a re-import for the new ordering — rides along with the #196 re-import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)