### PR TITLE
fix(import): keep manual import running if the client leaves the page (#205)

### DIFF
--- a/backend/pkg/web/handler/source.go
+++ b/backend/pkg/web/handler/source.go
@@ -345,6 +345,18 @@ func CreateManualSource(c *gin.Context) {
 	databaseRepo := c.MustGet(pkg.ContextKeyTypeDatabase).(database.DatabaseRepository)
 	eventBus := c.MustGet(pkg.ContextKeyTypeEventBusServer).(event_bus.Interface)
 
+	// The import must survive the client disconnecting mid-upload — closing the tab, navigating
+	// away, or a reverse-proxy read-timeout. The import runs inline here (the request still blocks
+	// until it finishes), but Go does not kill the handler goroutine on client disconnect; it only
+	// cancels the *request* context. So every DB write below — the source upsert and the import
+	// itself — runs under a context detached from the request (GetBackgroundContext is rooted at
+	// context.Background() and carries only the auth username), so a cancelled request context can
+	// no longer abort an in-flight import and leave partial data. (#196 link repair and #201 sort
+	// titles are computed during the import, so a half-finished import would be visibly broken.)
+	// Only the upload read (storeFileLocally → temp file on disk) and the final JSON response use
+	// the request context.
+	backgroundContext := GetBackgroundContext(c)
+
 	// store the bundle file locally
 	bundleFile, err := storeFileLocally(c)
 	if err != nil {
@@ -358,7 +370,7 @@ func CreateManualSource(c *gin.Context) {
 	manualSourceCredential := models.SourceCredential{
 		PlatformType: sourcePkg.PlatformTypeManual,
 	}
-	tempSourceClient, err := factory.GetSourceClient("", c, logger, &manualSourceCredential)
+	tempSourceClient, err := factory.GetSourceClient("", backgroundContext, logger, &manualSourceCredential)
 	if err != nil {
 		err = fmt.Errorf("an error occurred while initializing hub client using manual source without credentials: %w", err)
 		logger.Errorln(err)
@@ -376,7 +388,7 @@ func CreateManualSource(c *gin.Context) {
 	manualSourceCredential.Patient = patientId
 
 	//store the manualSourceCredential
-	err = databaseRepo.CreateSource(c, &manualSourceCredential)
+	err = databaseRepo.CreateSource(backgroundContext, &manualSourceCredential)
 	if err != nil {
 		err = fmt.Errorf("an error occurred while creating manual source: %w", err)
 		logger.Errorln(err)
@@ -385,7 +397,7 @@ func CreateManualSource(c *gin.Context) {
 	}
 
 	summary, err := BackgroundJobSyncResourcesWrapper(
-		c,
+		backgroundContext,
 		logger,
 		databaseRepo,
 		&manualSourceCredential,
@@ -417,8 +429,8 @@ func CreateManualSource(c *gin.Context) {
 		return
 	}
 
-	//publish event
-	currentUser, _ := databaseRepo.GetCurrentUser(c)
+	//publish event (use the detached context so completion still records if the client has gone)
+	currentUser, _ := databaseRepo.GetCurrentUser(backgroundContext)
 	err = eventBus.PublishMessage(
 		models.NewEventSourceComplete(
 			currentUser.ID.String(),

--- a/backend/pkg/web/handler/source_test.go
+++ b/backend/pkg/web/handler/source_test.go
@@ -250,6 +250,48 @@ func (suite *SourceHandlerTestSuite) TestCreateManualSourceHandler() {
 
 }
 
+// A client disconnecting mid-upload (closing the tab, navigating away, a proxy read-timeout)
+// cancels the request context. The import must NOT be abortable by that — it runs under a context
+// detached from the request — otherwise a half-finished import leaves partial data. Here the request
+// context is already cancelled before the handler runs; the import must still complete in full.
+func (suite *SourceHandlerTestSuite) TestCreateManualSourceHandler_SurvivesClientDisconnect() {
+	//setup
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Set(pkg.ContextKeyTypeLogger, logrus.WithField("test", suite.T().Name()))
+	ctx.Set(pkg.ContextKeyTypeDatabase, suite.AppRepository)
+	ctx.Set(pkg.ContextKeyTypeConfig, suite.AppConfig)
+	ctx.Set(pkg.ContextKeyTypeEventBusServer, suite.AppEventBus)
+	ctx.Set(pkg.ContextKeyTypeAuthUsername, "test_username")
+
+	req, err := CreateManualSourceHttpRequestFromFile("testdata/Tania553_Harris789_545c2380-b77f-4919-ab5d-0f615f877250.json")
+	require.NoError(suite.T(), err)
+
+	// simulate the client already gone: a cancelled request context
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ctx.Request = req.WithContext(cancelledCtx)
+
+	//test
+	CreateManualSource(ctx)
+
+	//assert: the import completed in full despite the cancelled request context
+	require.Equal(suite.T(), http.StatusOK, w.Code)
+
+	type ResponseWrapper struct {
+		Data struct {
+			TotalResources int `json:"TotalResources"`
+		} `json:"data"`
+		Success bool                    `json:"success"`
+		Source  models.SourceCredential `json:"source"`
+	}
+	var respWrapper ResponseWrapper
+	err = json.Unmarshal(w.Body.Bytes(), &respWrapper)
+	require.NoError(suite.T(), err)
+	require.True(suite.T(), respWrapper.Success)
+	require.Equal(suite.T(), 196, respWrapper.Data.TotalResources, "the full bundle must import even though the request context was cancelled")
+}
+
 // bug: https://github.com/fastenhealth/fasten-onprem/pull/486
 func (suite *SourceHandlerTestSuite) TestCreateManualSourceHandler_ShouldExtractPatientIdFromConvertedCCDA() {
 	//setup

--- a/frontend/src/app/components/medical-sources-connected/medical-sources-connected.component.ts
+++ b/frontend/src/app/components/medical-sources-connected/medical-sources-connected.component.ts
@@ -62,9 +62,16 @@ export class MedicalSourcesConnectedComponent implements OnInit {
           for(const ndx in connectedSources){
             console.log(connectedSources[ndx])
             this.connectedSourceList.push({source: connectedSources[ndx], brand: connectedBrand[ndx]})
-            if(connectedSources[ndx].latest_background_job?.job_status == "STATUS_LOCKED"){
+            // Re-show the in-progress/failed indicator when returning to the page mid-sync. Key by
+            // source.id (the template checks status[source.id] first) AND brand_id — manual sources
+            // (e.g. an uploaded bundle still importing) have no brand_id, so keying only by brand_id
+            // left their progress bar invisible on return even though the import was still running.
+            const jobStatus = connectedSources[ndx].latest_background_job?.job_status
+            if(jobStatus == "STATUS_LOCKED"){
+              this.status[connectedSources[ndx].id] = "token"
               this.status[connectedSources[ndx].brand_id] = "token"
-            } else if (connectedSources[ndx].latest_background_job?.job_status === "STATUS_FAILED") {
+            } else if (jobStatus === "STATUS_FAILED") {
+              this.status[connectedSources[ndx].id] = "failed"
               this.status[connectedSources[ndx].brand_id] = "failed"
             }
           }


### PR DESCRIPTION
Closes #205. The "both" fix for the import-survives-leaving concern raised while validating the FollowMyHealth re-import.

## Problem
The manual bundle import runs **inline inside the upload request**, and its context was derived from the **gin request context** — which Go cancels on client disconnect (tab close, hard refresh, reverse-proxy read-timeout). So a long import could be aborted partway, leaving partial data. (In-app SPA navigation was already safe — the XHR stays open — but the other cases were not.) This matters more now that #196 (link repair) and #201 (sort titles) are computed *during* import.

## Fix
**Backend** (`source.go`): run the source upsert and the import under a context **detached from the request** (`GetBackgroundContext`, rooted at `context.Background()`, carrying only the auth username). The request still blocks until the import finishes, but a cancelled request context can no longer abort it. Only the upload read (temp file) and the final JSON response use the request context. *No behavior change for connected clients; the import simply also survives a disconnect.*

**Frontend** (`medical-sources-connected`): the page already re-shows an in-progress sync from `latest_background_job.job_status == STATUS_LOCKED` on load — but keyed only by `brand_id`, which manual sources lack. Now also keyed by `source.id` so a still-importing manual source re-shows its progress bar when you return to the page.

## Why detached-context instead of a fire-and-return goroutine
It delivers the same guarantee (import cant be killed by the client leaving) with far less risk: no SQLite concurrent-write goroutine, no change to the response contract, and the existing synchronous handler test stays valid. Fire-and-return remains a possible future enhancement.

## Tests
- `TestCreateManualSourceHandler_SurvivesClientDisconnect` — handler runs with an **already-cancelled** request context; asserts the full bundle (196 resources) still imports. (Would fail before this change, since the source upsert ran on the cancelled context.)
- Existing `TestCreateManualSourceHandler` + CCDA test still green; frontend component specs green; `go vet` clean.

Builds on PR #203/#204 (the "Starting import…" cue + footer year).

🤖 Generated with [Claude Code](https://claude.com/claude-code)