### PR TITLE
feat(us-core): complete Immunization Must-Support display (#210)

### DIFF
--- a/frontend/src/app/components/fhir-card/resources/immunization/immunization.component.html
+++ b/frontend/src/app/components/fhir-card/resources/immunization/immunization.component.html
@@ -2,7 +2,7 @@
   <div class="card-header" (click)="isCollapsed = ! isCollapsed">
     <div>
       <h6 class="card-title">{{displayModel?.title}}</h6>
-      <p class="card-text tx-gray-400" *ngIf="displayModel?.sort_date"><strong>Start date</strong> {{displayModel?.sort_date | date}}</p>
+      <p class="card-text tx-gray-400" *ngIf="displayModel?.provided_date || displayModel?.sort_date"><strong>Date administered</strong> {{(displayModel?.provided_date || displayModel?.sort_date) | date}}</p>
     </div>
     <fhir-ui-badge class="float-right" [status]="displayModel?.status">{{displayModel?.status}}</fhir-ui-badge>
 <!--    <div class="btn-group">-->

--- a/frontend/src/app/components/fhir-card/resources/immunization/immunization.component.ts
+++ b/frontend/src/app/components/fhir-card/resources/immunization/immunization.component.ts
@@ -26,14 +26,32 @@ export class ImmunizationComponent implements OnInit, FhirCardComponentInterface
 
   ngOnInit(): void {
 
-    this.tableData.push(    {
-        label: 'Manufacturer Text',
+    this.tableData.push(
+      {
+        // US Core MS: statusReason — only present when a dose was not given (status=not-done)
+        label: 'Status reason',
+        data: this.displayModel?.status_reason,
+        data_type: TableRowItemDataType.CodableConcept,
+        enabled: !!this.displayModel?.status_reason,
+      },
+      {
+        // US Core MS: primarySource — was this recorded from the primary source, or reported?
+        label: 'Primary source',
+        data: this.displayModel?.primary_source ? 'Yes' : 'No',
+        enabled: this.displayModel?.primary_source !== undefined && this.displayModel?.primary_source !== null,
+      },
+      {
+        label: 'Manufacturer',
         data: this.displayModel?.manufacturer_text,
         enabled: !!this.displayModel?.manufacturer_text,
       },
       {
-        label: 'Manufacturer Text',
-        data: `${this.displayModel?.lot_number}` + this.displayModel?.lot_number_expiration_date ? ` expires on ${this.displayModel?.lot_number_expiration_date}` : '',
+        // Previously mislabeled "Manufacturer Text" with a broken expression that dropped the
+        // lot number; this is the lot number (+ expiration when present).
+        label: 'Lot number',
+        data: this.displayModel?.lot_number_expiration_date
+          ? `${this.displayModel?.lot_number} (expires ${this.displayModel?.lot_number_expiration_date})`
+          : this.displayModel?.lot_number,
         enabled: this.displayModel?.has_lot_number,
       },
       {

--- a/frontend/src/lib/models/resources/immunization-model.spec.ts
+++ b/frontend/src/lib/models/resources/immunization-model.spec.ts
@@ -12,6 +12,7 @@ describe('ImmunizationModel', () => {
 
       expected.title = 'Fluvax (Influenza)'
       expected.status = 'completed'
+      expected.primary_source = true // US Core MS: example1 has primarySource: true
       expected.provided_date  = '2013-01-10'
       // manufacturerText: string | undefined
       expected.has_lot_number = true
@@ -30,6 +31,22 @@ describe('ImmunizationModel', () => {
       expected.note = [ { text: 'Notes on adminstration of vaccine' } ]
 
       expect(new ImmunizationModel(example1Fixture)).toEqual(expected);
+    });
+
+    // US Core 9.0.0 Must-Support: statusReason (why a dose was not given) and primarySource.
+    it('should capture statusReason and primarySource (a not-done immunization)', () => {
+      const model = new ImmunizationModel({
+        resourceType: 'Immunization',
+        status: 'not-done',
+        statusReason: { text: 'Patient allergy to vaccine component' },
+        primarySource: false,
+        vaccineCode: { text: 'Influenza vaccine' },
+        patient: { reference: 'Patient/example' },
+      })
+      expect(model.status).toEqual('not-done')
+      expect(model.status_reason).toEqual({ text: 'Patient allergy to vaccine component' })
+      expect(model.primary_source).toEqual(false)
+      expect(model.title).toEqual('Influenza vaccine')
     });
   })
 });

--- a/frontend/src/lib/models/resources/immunization-model.ts
+++ b/frontend/src/lib/models/resources/immunization-model.ts
@@ -10,6 +10,8 @@ export class ImmunizationModel extends FastenDisplayModel {
 
   title: string | undefined
   status: string | undefined
+  status_reason: CodableConceptModel | undefined  // US Core MS: statusReason (why a dose was not given)
+  primary_source: boolean | undefined             // US Core MS: primarySource
   provided_date: string | undefined
   manufacturer_text: string | undefined
   has_lot_number: boolean | undefined
@@ -40,6 +42,8 @@ export class ImmunizationModel extends FastenDisplayModel {
       _.get(fhirResource, 'vaccineCode.text') ||
       _.get(fhirResource, 'vaccineCode.coding[0].display', 'Immunization');
     this.status = _.get(fhirResource, 'status', null);
+    this.status_reason = _.get(fhirResource, 'statusReason');
+    this.primary_source = _.get(fhirResource, 'primarySource');
     this.provided_date = _.get(fhirResource, 'date', null);
     this.reported = _.get(fhirResource, 'reported') && ' - self reported';
     this.manufacturer_text = _.get(fhirResource, 'manufacturer.display');


### PR DESCRIPTION
Closes #210. Part of the US Core 9.0.0 epic #136 — the first of the "still-generic" profiles audited + completed.

## Gaps fixed (vs US Core 9.0.0 Immunization Must-Support)
- **`occurrence` date** — the header bound `sort_date` (the DB-computed field, empty when rendering raw FHIR), so the date given often didn't show. Now binds `provided_date` (occurrenceDateTime/String) with a `sort_date` fallback, labelled **"Date administered."**
- **`primarySource`** (MS) — now captured + shown (Yes/No).
- **`statusReason`** (MS) — now captured + shown (only when a dose was not given).
- **Bug:** the lot-number row was mislabeled **"Manufacturer Text"** and its expression had an operator-precedence bug (`` `${lot_number}` + expiration ? … :  ``) that **dropped the lot number entirely**. Fixed: labelled "Lot number" with `(expires …)` formatting; the real manufacturer row relabelled "Manufacturer."

(Already present: `vaccineCode` → title, `status` → header badge, patient, route, site, dose.)

## Tests (4/4 green)
- `example1` now asserts `primary_source = true`.
- New case: a `not-done` immunization asserts `statusReason` + `primarySource = false` are captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)