### PR TITLE
chore(kit): sync to v1.0.0-67-g9c345a5

### DIFF
--- a/.claude/commands/context.md
+++ b/.claude/commands/context.md
@@ -1,26 +1,15 @@
 # Context Command
 
-Read project continuity and the agent brief at the start of a session.
+Read the AGENTS.md file to understand the current project state and context.
+
+This command helps ensure you're aligned with the project's current status, goals, and any ongoing work by other agents.
 
 ## Usage
 
-Use `/context` at the start of a session to get up to speed.
-
-### Order (required)
-
-1. **`TODO.md` — `▶ Resume here` block** between `<!-- RESUME:START -->` and `<!-- RESUME:END -->`
-   (if present). That is the last session’s handoff — branch, next steps, blockers. Do this first
-   so you do not repeat finished work.
-2. **`AGENTS.md`** — kit protocol (above `KIT:END`) and repo project context (below).
-3. Recent `git log` and, if useful, the top of `private/project_log.md`.
-
-### Also cover
+Use `/context` at the start of a session to get up to speed on:
 
 - Project overview and goals
 - Current progress and status
 - Architecture and tech stack decisions
 - Any blockers or issues
 - Upcoming tasks and priorities
-
-Note: `/pstatus` regenerates priority bands but **preserves** the resume block. Only `/wrap`
-refreshes resume content.

--- a/.claude/commands/pstatus.md
+++ b/.claude/commands/pstatus.md
@@ -16,7 +16,6 @@ recommends what to do next. It does not start work.
 - Security signals (quote the URL — an unquoted `?` is glob-expanded by zsh and the call silently fails with `no matches found`, which reads as a false "clean"):
   - `gh api "/repos/{owner}/{repo}/dependabot/alerts?state=open"`
   - `gh api "/repos/{owner}/{repo}/code-scanning/alerts?state=open"` (ignore a 404 — feature off)
-  - `cd frontend && yarn audit --groups dependencies` — **not optional, and not covered by the two above.** Dependabot matches advisories by registry coordinates, so a dependency resolved from a **git URL** can never raise an alert. A critical one sat in the shipped bundle for months while the alerts page read `0 open` ([#530](https://github.com/jwilleke/yourphr/issues/530)). Its exit code is a bitmask of severities found (1 info, 2 low, 4 moderate, 8 high, 16 critical), not pass/fail. See [`docs/security/dependency-scanning.md`](../../docs/security/dependency-scanning.md).
   - any other scanner signal available (e.g. GitGuardian)
 - `gh issue list --state open --limit 100 --json number,title,labels`
 - `gh pr list --state open --limit 50 --json number,title,isDraft,mergeStateStatus,createdAt,labels,body,closingIssuesReferences`
@@ -40,82 +39,99 @@ For each open Dependabot / code-scanning / GitGuardian alert:
 
 ### Step 3: Triage gate
 
-- Any open issue **or pull request** with **no** placement label (`P0` / `P1` / `P2` / `deferred` /
-  `in-review`) gets `needs-triage` so it shows up as awaiting a decision rather than being silently
-  mis-ranked. An `in-review` item is already placed (it lands in the In review band) and is never
-  flagged.
-- PRs are triaged on the same scale as issues, because a PR *is* work: a merge-ready security fix is
-  `P0`, a routine dependency bump nobody is waiting on is `P2`, one held pending an unrelated
-  upgrade is `deferred`. Apply the label with `gh pr edit <n> --add-label <band>`.
+- Any open **issue** with **no** placement label (`P0` / `P1` / `P2` / `deferred` / `in-review`) gets
+  `needs-triage` so it shows up as awaiting a decision rather than being silently mis-ranked. An
+  `in-review` issue is already placed (it lands in the In review band) and is never flagged.
+- Open **PRs** are not auto-labeled; their band is derived in Step 4 (see **PR priority**). Unplaced
+  PRs land in **Needs triage** the same way unplaced issues do — never a separate unranked dump.
 
 ### Step 4: Rank and regenerate `TODO.md`
 
-Regenerate the **priority-band section** of `TODO.md` from open issues/PRs. Do **not** wipe session continuity.
+Overwrite `TODO.md` with open issues **and** open PRs grouped into the **same** priority bands.
 
-**Preserve the `▶ Resume here` block** when present:
+**Remove the `▶ Resume here` block, including its `RESUME:START` / `RESUME:END` markers.** The
+pointer is written by `/wrap` at session end and read by `/context` at session open; by the time
+`/pstatus` runs you have already resumed, so it has served its purpose. The output of this step is a
+bands-only `TODO.md` — that is intended, not a loss. `/pstatus` never reads the block and never
+preserves it.
 
-1. Before writing, if `TODO.md` contains a block between `<!-- RESUME:START -->` and
-   `<!-- RESUME:END -->` (inclusive), capture that exact text.
-2. Write `TODO.md` in this order:
-   - `# TODO`
-   - the preserved resume block (if any), unchanged — do not invent or refresh its content here
-   - a blank line, then `> Generated from live GitHub state — ranked by priority label.`
-   - the regenerated bands below
-3. If there is no resume block, omit it (bands-only is fine until `/wrap` writes one).
-4. **Never** delete or rewrite the resume markers or body. Only `/wrap` updates resume content.
+**`TODO.md` carries no history.** It is a snapshot of what is open *right now* — nothing else. No
+"merged since last run", no "4 of 7 have landed", no counts of what was closed, no narrative of what
+happened this session, no dated changelog, and no section for work in other repos. If an item is
+closed or merged, it simply stops appearing; that disappearance is the only record `TODO.md` keeps.
 
-**Escape bare URLs taken from issue titles.** Titles are copied verbatim into `TODO.md`, so a title
-containing a URL — e.g. `[FEATURE] Send to Email (https://demo.yourphr.org/web/)` — emits a bare URL
-and fails markdownlint MD034, which is a red CI run for a file nobody hand-edited. Wrap any `http(s)`
-URL appearing in the **title text** in angle brackets (`<https://…>`); never touch the link target of
-the `[#N](…)` reference itself.
+Session history belongs in `docs/project_log.md` (or `private/project_log.md` where the repo keeps
+it there), written by `/session-commit` and `/wrap`. Never in `TODO.md`. Two files recording the
+same events drift apart, and the drift is silent: the ranked backlog starts reading as a status
+report and the operator has to work out which half is current.
 
-`/wrap` owns the handoff text; `/pstatus` only refreshes ranked work so multi-machine continuity
-survives mid-session status runs. See [yourphr#410](https://github.com/jwilleke/yourphr/issues/410).
+The bands, in this order (issues **and** PRs share these bands):
 
-The bands, in this order:
-
-- `🔴 P0 — Security & Critical` (list `security` / vulnerability issues first)
+- `🔴 P0 — Security & Critical` (list `security` / vulnerability items first)
 - `🟠 P1`
 - `🟡 P2`
 - `🔵 In review` (items labeled `in-review` — work complete and pushed, awaiting the operator's
-  decision to close; takes precedence over an item's priority band so it surfaces as "ready for your call")
+  decision to close; takes precedence over a priority label so it surfaces as "ready for your call")
 - `⏸ Deferred`
-- `❓ Needs triage` (count + titles)
+- `❓ Needs triage` (issues and PRs with no resolvable placement)
 
-**Open PRs are not a separate band.** Every open pull request is ranked into the bands above by its
-own placement label, interleaved with issues. A merge-ready security PR belongs in `P0` next to the
-advisory it fixes — parking it in a trailing "Open PRs" section is exactly how finished, shippable
-work goes unread. Dependency-bump PRs (Dependabot / Renovate) are ranked the same way: they are
-frequently security-relevant and are easy to miss, because the corresponding scanner alert often
-looks *already tracked* by an unrelated issue.
+**There is no separate `🔀 Open PRs` band.** Every open PR appears exactly once under the same
+priority band as issues. A flat PR-only section hid deps work from the ranked backlog (Dependabot
+PRs sat at the bottom while P1 coding looked "empty").
 
-Within a band, list PRs **before** issues of the same priority — a written change is closer to done
-than an unstarted one.
+**One entry per line — never bundle.** Each issue or PR gets its OWN bullet, starting with a full
+clickable GitHub link. No grouping headers that pack several refs onto one bullet, no
+comma-separated runs of numbers, no bare `#<num>`.
 
-**One item per line — never bundle.** Each issue and each PR gets its OWN bullet, starting with a
-full clickable GitHub link. No grouping headers that pack several refs onto one bullet, no
-comma-separated runs, no bare `#<num>`. Issue lines:
+Issue line:
 
 `- [#<num>](https://github.com/{owner}/{repo}/issues/<num>) — <title>`
 
-PR lines use the `/pull/` path, are prefixed `PR:` so they are distinguishable at a glance inside a
-mixed band, carry their merge state, and **must name their related issues**:
+PR line (always mark state; always name related issues when any):
 
-`- PR: [#<num>](https://github.com/{owner}/{repo}/pull/<num>) — <title> _(ready | draft | conflicted | CI red)_ — closes [#<n>](…/issues/<n>)`
+`- [#<num>](https://github.com/{owner}/{repo}/pull/<num>) — <title> _(PR · ready | draft | conflicted)[ · stale Nd]_ — closes|refs|likely [#n](…) | no linked issue`
 
-Mark each `draft`, `ready`, or `conflicted` from `isDraft` / `mergeStateStatus`, note failing
-required checks, and flag any PR open more than 7 days as stale.
+Use **underscore** emphasis, not asterisks. The kit's own `.markdownlint.jsonc` sets MD049 to
+`underscore`, so an asterisk-wrapped state marker makes the generated `TODO.md` fail
+`npm run lint:md` in the very repo that produced it.
 
-**Use `_underscore_` for the status annotation, never `*asterisk*`.** `TODO.md` is linted under
-MD049 `consistent`, and the issue lines already use underscores — a single asterisk annotation
-turns the whole file red in the `Lint Markdown` job of `.github/workflows/development.yaml`. This
-has broken CI before. Verify with `npx markdownlint-cli2 TODO.md` before committing.
+#### PR priority (same bands as issues)
+
+Resolve related issues first (next subsection), then place the PR:
+
+1. **Explicit PR labels** — if the PR itself has `P0` / `P1` / `P2` / `deferred` / `in-review`, use
+   that (same precedence as issues: `in-review` wins over a priority label).
+2. **Inherit from linked issues** — among open issues linked via `closes` / `refs` / `likely`, take
+   the **highest** priority: `P0` > `P1` > `P2`. Prefer a linked `security` issue's grade when
+   present. If every linked open issue is only `in-review` or `deferred`, place the PR with that
+   placement (`in-review` / `deferred`).
+3. **Else Needs triage** — including Dependabot/Renovate PRs with no resolvable issue. Do **not**
+   invent a silent default priority for unlinked deps bumps; they must show up as untriaged so
+   someone grades them (or links them to a tracking issue).
+
+Within a band, list **security-related** items first, then by descending number. Interleave issues
+and PRs in that order (do not dump all PRs at the bottom of the band).
+
+**No entry may appear twice in `TODO.md`.** Every issue and every PR gets exactly one line in the
+whole file. When an issue's fix is already in an open PR, it belongs to the PR's line — as a
+`closes` / `refs` / `likely` link — and is **not** also listed as a standalone issue line. Two lines
+for one piece of work inflates the apparent backlog and makes the file read as though the fix has
+not been written yet.
+
+State the absence rather than deleting it silently: a band with no remaining open items says so,
+e.g. `_None._` An empty band and a band whose work is only awaiting merge of a PR listed in another
+band are different — the PR's placement is the truth; do not leave a ghost issue line.
+
+Verify before finishing — every count must be 1:
+
+```bash
+grep -oE '/(issues|pull)/[0-9]+' TODO.md | sort | uniq -c | sort -rn
+```
 
 #### Resolving a PR's related issues
 
 A PR shown without its issue context reads as unrelated housekeeping, so resolve the link for every
-PR in the band. In order:
+PR. In order:
 
 1. **Declared** — `closingIssuesReferences` from Step 1. These are the issues GitHub will
    auto-close on merge; render them as `closes #<n>`.
@@ -128,22 +144,24 @@ PR in the band. In order:
 If none of the three resolve, write `no linked issue` explicitly rather than leaving the line bare.
 A silent absence is indistinguishable from "not checked".
 
-Cross-reference both ways: an issue whose fix is already sitting in an open PR is **not** actually
-open work. Annotate it in its own priority band as `— PR open: [#<pr>](…/pull/<pr>)` so the ranking
-does not recommend starting something that is already written.
+An issue whose fix is already sitting in an open PR is **not** actually open work, and the ranking
+must not recommend starting something already written. Per the no-duplicate rule above, it is
+carried by the PR's line in the PR's priority band, where the actionable verb is "merge" rather
+than "start".
 
 Where a PR turns out to be redundant — the change is already on the default branch, or a tracking
 issue was resolved another way — say so on the PR line as `_(redundant — already on <branch>)_`.
-Stale dependency PRs routinely outlive the fix that superseded them.
+Stale dependency PRs routinely outlive the fix that superseded them. Flag open more than 7 days as
+`stale Nd` in the state marker.
 
 ### Step 5: Brief the user
 
 Print the ranked bands, then a single **"Do this next"** recommendation — the highest-value
 P0 (else the top P1, and so on) with one line of why. Stop. Do not begin the work.
 
-A **merge-ready PR outranks starting new work** when it carries a security fix or a dependency
-bump: it is finished work sitting one click from shipping, so leaving it open while beginning
-something else is strictly worse than merging it first.
+A **merge-ready PR outranks starting new work** when it sits in P0/P1 (or carries a security /
+dependency fix): it is finished work sitting one click from shipping, so leaving it open while
+beginning something else is strictly worse than merging it first.
 
 State the PR ↔ issue linkage in the recommendation itself. "Merge #24 — it closes P0 #25" is
 actionable; "merge #24" alone makes the operator go look up why it matters.

--- a/.claude/commands/session-commit.md
+++ b/.claude/commands/session-commit.md
@@ -21,11 +21,8 @@ related GitHub issues. The personal log is **never committed**.
 ### Step 3: Refresh `TODO.md` and commit it
 
 - Regenerate `TODO.md` from the current GitHub issue labels (same banding as `/pstatus`:
-  P0 / P1 / P2 / Deferred / Needs triage / In review / Open PRs). **Preserve** any
-  `<!-- RESUME:START -->` … `<!-- RESUME:END -->` block exactly — only `/wrap` updates resume
-  content. If `/pstatus` was just run, bands are already current.
-- **Escape bare URLs copied from issue titles** — wrap them in angle brackets (`<https://…>`).
-  A title containing a URL otherwise fails markdownlint MD034 on a file nobody hand-edited.
+  P0 / P1 / P2 / Deferred / Needs triage). The `▶ Resume here` pointer is owned by `/wrap`; no need
+  to preserve it here. If `/pstatus` was just run, it is already current.
 - Stage and commit `TODO.md` if it changed: `docs: refresh TODO from issue labels`.
 
 ### Step 4: Journal the session (local only — NOT committed)
@@ -55,9 +52,6 @@ For each related open issue:
 - If the work fully resolves it, say so but do **not** close it — let the operator decide
   (consider adding `in-review`).
 - Use `gh issue comment <number> --body "<comment>"`.
-- **When closing an issue (operator request or explicit close):** always
-  `gh issue edit <N> --remove-label in-review` **before or when closing**. Never leave
-  `in-review` on a closed issue.
 
 ### Step 6: Push
 

--- a/.claude/commands/wrap.md
+++ b/.claude/commands/wrap.md
@@ -48,10 +48,10 @@ pick up:
 <!-- RESUME:END -->
 ```
 
-Insert (or replace) the block right after the `# TODO` title, **above** the generated priority bands.
-If a resume block is already present, overwrite only that marker region with the new handoff — leave
-the `/pstatus`-generated bands intact unless you also refresh them. `/pstatus` **preserves** this
-block when regenerating bands; only `/wrap` updates the resume text.
+Insert the block right after the `# TODO` title (the markers will usually be absent, since `/pstatus`
+regenerated a bands-only `TODO.md` during the session; replace the block if it is present). This
+reflects only the latest handoff — `/context` reads it next session, then the first `/pstatus` clears
+it again.
 
 ### Step 4: Commit the refreshed pointer & push (ask)
 
@@ -71,7 +71,8 @@ Report one clear verdict:
 ## Notes
 
 - `/wrap` is the close bookend to `/context` (open) and complements `/session-commit` (per-chunk).
-- `/context` should read the `▶ Resume here` block at the top of `TODO.md` first to restore
-  continuity. `/pstatus` **preserves** that block when it regenerates priority bands (it does not
-  clear it). `/wrap` is the only skill that refreshes resume content. Dated session history still
-  lives in `private/project_log.md` (local, not committed).
+- `/context` reads the `▶ Resume here` block at the top of `TODO.md` first to restore continuity.
+  `/pstatus` does **not** read it — it removes the block when it regenerates the bands. So the
+  block survives exactly one hop: `/wrap` writes it, the next session's `/context` reads it, the
+  first `/pstatus` of that session clears it. Open a session with `/context`, not `/pstatus`, or
+  the pointer is discarded unread. The dated session history stays in `private/project_log.md`.

--- a/.github/workflows/kit-check.yml
+++ b/.github/workflows/kit-check.yml
@@ -1,0 +1,37 @@
+# Seeded by mjs-project-template's install-kit.sh. Reports when this repo is behind
+# the kit; never changes a file. Delete it if you do not want the notification.
+# Seeded create-if-absent, so local edits here survive the next kit sync.
+
+name: Kit Check
+
+on:
+  schedule:
+    # Mondays, 06:00 UTC.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  kit-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out this repo
+        uses: actions/checkout@v4
+
+      # The kit is checked out beside this repo rather than installed: Actions
+      # runners already ship Node, so no dependency is added to a repo that may
+      # not be a Node project at all.
+      - name: Check out the kit
+        uses: actions/checkout@v4
+        with:
+          repository: jwilleke/mjs-project-template
+          path: .kit-check
+          fetch-depth: 0
+
+      - name: Compare kit version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node .kit-check/bin/kit.mjs check . --kit .kit-check --report-issue

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- KIT:START v1.0.0-49-g7e03e8d — managed by mjs-project-template; edit below the KIT:END marker -->
+<!-- KIT:START v1.0.0-67-g9c345a5 — managed by mjs-project-template; edit below the KIT:END marker -->
 # Agent Context & Protocols
 
 This section is **managed by the kit** (`install-kit.sh`) — it is identical across repos. Put repo-specific context **below the `KIT:END` marker**; do not edit here.
@@ -23,6 +23,8 @@ Then:
 
 - Security comes first. Scanner alerts (Dependabot / code-scanning / GitGuardian) become issues labeled `security` + a graded priority: critical/high → `P0`, medium → `P1`, low → `P2`.
 - `TODO.md` = a `▶ Resume here` block (maintained by `/wrap`) on top, then priority bands that `/pstatus` regenerates from the labels. Do not hand-edit the bands.
+- The two halves have one writer each and a deliberate handover: `/wrap` writes the resume pointer at session end, `/context` reads it at session open, and the first `/pstatus` of the session **removes** it — by then you have already resumed, so it has served its purpose. A bands-only `TODO.md` mid-session is expected, not a loss.
+- `TODO.md` holds **no history** — only what is open right now. Never add "merged since last run", closed/merged counts, a session narrative, a dated changelog, or work from other repos. A closed item just stops appearing; that disappearance is the whole record. Session history goes in `private/project_log.md` via `/session-commit` and `/wrap`, and nowhere else.
 
 ## Working agreement
 
@@ -32,8 +34,8 @@ Then:
 - Issue decomposition — NEVER put "Steps", "Phases", or numbered sequences inside a single GitHub issue. Break each step into its own issue and link them using GitHub relationships: `closes #N` / `fixes #N` (resolves another), `blocked by #N` (dependency), `relates to #N` (context link). Example: a 3-phase migration = 3 issues with "blocked by" chains, not one issue with Phase headings.
 - Issue/PR links — Never use a bare `#N` reference alone. Always pair it with the full GitHub URL: `[#333](https://github.com/owner/repo/issues/333)`. This applies in commit messages, PR descriptions, comments, and any agent output. Use `/issues/N` for issues and `/pull/N` for PRs.
 - Awaiting approval — When work is complete but requires human sign-off before closing, apply the `in-review` label and leave a comment on the issue/PR that states: what was done, what the human needs to verify, and what action closes it. Never self-close an issue or PR.
+- Closing issues — **Always remove the `in-review` label when closing** an issue or PR (`gh issue edit N --remove-label in-review` before or with the close). Closed items must not keep `in-review`, or the label stops meaning "awaiting a decision" and the queue it drives can no longer be trusted.
 - Commits — always use the `/session-commit` skill. Never run a bare `git commit` directly. `/session-commit` enforces the session log update, conventional commit format, and co-author trailer.
-- Closing issues — **Always remove the `in-review` label when closing** an issue or PR (`gh issue edit N --remove-label in-review` before or with close). Closed issues must not keep `in-review`.
 - Direct commits by default — commit to the default branch; do not open a pull request unless someone other than you will actually look at it before it lands. On a single-maintainer repo a self-opened, self-merged PR reviews nothing: it just splits one explanation across a commit message and a near-identical PR body. Put the reasoning in the commit message. A change touching a "risky" path, closing an issue, or feeling significant is **not** a reason to open one — CI runs on `push` as well as `pull_request`, so a direct commit is still tested. Where a PR does exist, its body points at the commit message rather than restating it.
 
 ## Markdown conventions

--- a/utility/sync-labels.sh
+++ b/utility/sync-labels.sh
@@ -10,6 +10,10 @@
 #   utility/sync-labels.sh --all owner     # every active (non-archived, source) repo for owner
 #
 # Requires: gh (authenticated).
+#
+# Note: macOS ships bash 3.2, where `set -u` treats "${arr[@]}" on an EMPTY array as an
+# unbound variable (fixed in bash 4.4). Expand possibly-empty arrays as
+# ${arr[@]+"${arr[@]}"} — outer unquoted, inner quoted — or the no-arg path aborts.
 
 set -euo pipefail
 
@@ -35,7 +39,8 @@ apply_to() {
   local spec name color desc
   for spec in "${LABELS[@]}"; do
     IFS='|' read -r name color desc <<<"$spec"
-    gh label create "$name" --color "$color" --description "$desc" --force "${repo_args[@]}" >/dev/null
+    # ${repo_args[@]+...} — empty-safe on bash 3.2; a plain "${repo_args[@]}" aborts under set -u
+    gh label create "$name" --color "$color" --description "$desc" --force ${repo_args[@]+"${repo_args[@]}"} >/dev/null
     echo "   ✓ $name"
   done
 }


### PR DESCRIPTION
Automated kit sync from [mjs-project-template](https://github.com/jwilleke/mjs-project-template), applied by `install-kit.sh`.

Kit version: `v1.0.0-67-g9c345a5`

## Files changed

```text
  M	.claude/commands/context.md
  M	.claude/commands/pstatus.md
  M	.claude/commands/session-commit.md
  M	.claude/commands/wrap.md
  A	.github/workflows/kit-check.yml
  M	AGENTS.md
  M	utility/sync-labels.sh
```

Canonical kit files are overwritten wholesale; your own content is untouched. `AGENTS.md` changes
are confined to the managed block between the `KIT:START` / `KIT:END` markers.

Merging when CI is green is the expected path. If a change here is wrong, fix it upstream in the
template rather than in this repo — the next sync would overwrite a local fix.