### PR TITLE
chore(kit): sync to v1.11.1-0-g71bbbdf

### DIFF
--- a/.agent-kit.json
+++ b/.agent-kit.json
@@ -1,9 +1,9 @@
 {
   "schema": 1,
   "source": "https://github.com/jwilleke/mjs-project-template",
-  "installed": "v1.10.2",
-  "installed_ref": "v1.10.2-0-g0903de6",
-  "installed_at": "2026-08-17",
+  "installed": "v1.11.1",
+  "installed_ref": "v1.11.1-0-g71bbbdf",
+  "installed_at": "2026-08-18",
   "files": {
     ".claude/commands/pstatus.md": { "behavior": "overwrite", "sha256": "d01fc63bde87b183d8d544bedbbfb0d86a76882881d8927d71acf97cba11d0a7" },
     ".claude/commands/session-commit.md": { "behavior": "overwrite", "sha256": "62c6d562b8ad9a57622d295c33a0847041fcaada87ad80c3e900292a86171068" },
@@ -13,6 +13,7 @@
     ".claude/commands/update-agents.md": { "behavior": "overwrite", "sha256": "1f4c6433448658be783b09007be99fbcad1d1d7b75daab66624e7a45940ac4e6" },
     ".markdownlint-cli2.jsonc": { "behavior": "overwrite", "sha256": "a269ec1af759cd56af8dc9b6393148a587cfcb5d03af3d4c8999a95bbab1057d" },
     "utility/set-version.mjs": { "behavior": "overwrite", "sha256": "292730d5df9c923f57dde984bc132ebfd2ba92fb83c9494f5b6ac3d0f6dcbc6c" },
+    "utility/kit-sync.sh": { "behavior": "overwrite", "sha256": "dd2fa16d22a71222695941d9542996ee57193d4a80fad6a9baa9b9d2bb074fe7" },
     ".claude/commands/semver-kit.md": { "behavior": "overwrite-or-suffix", "sha256": "0b94552c7a4447ab265c2761b1edcb76afb1ea99322221936b7a24b1b9749e3b" }
   }
 }

--- a/.github/workflows/kit-sync.yml
+++ b/.github/workflows/kit-sync.yml
@@ -1,35 +1,28 @@
-# Seeded by mjs-project-template's install-kit.sh. Keeps this repo up to date with
-# the agent kit by opening a pull request — it never pushes to the default branch.
-# Delete it if you do not want that. Seeded create-if-absent, so local edits here
-# survive the next kit sync.
+# Seeded by mjs-project-template's install-kit.sh. Keeps this repo up to date
+# with the agent kit by opening a pull request — it never pushes to the default
+# branch. Delete it if you do not want that.
 #
-# It replaces the older Kit Check workflow, which only filed an issue telling
-# someone to go and run the installer. This runs the installer.
+# DELIBERATELY THIN. GITHUB_TOKEN may not push a file under .github/workflows/,
+# so anything in here can only be changed by a human running install-kit.sh
+# against every consumer. The logic therefore lives in utility/kit-sync.sh inside
+# the kit, which the sync delivers like any other file — five defects in this
+# mechanism have each cost a manual round across twelve repos, and every one of
+# them was in the logic rather than the trigger.
 #
-# No cron, on purpose. A schedule fires while you are asleep, and GitHub disables
+# Change this file only for triggers, permissions or the checkout steps.
+#
+# No cron. A schedule fires while nobody is looking, and GitHub disables
 # scheduled workflows after 60 days of repository inactivity — so it stops firing
-# in exactly the dormant repos that drift furthest. This runs when you push, which
-# is when you are already here, and on demand.
+# in exactly the dormant repos that drift furthest. This runs on push, which is
+# when someone is already here, and on demand.
 #
-# No PAT and no GitHub App. The built-in GITHUB_TOKEN is scoped to this repo and
-# expires with the job. The one thing it cannot do is start a CI run for a PR it
-# opened, so the sync validates itself in-job and reports the result in the PR
-# body rather than waiting for checks that will not come.
-#
-# PREREQUISITE, and no `permissions:` block can grant it:
+# PREREQUISITE, which no `permissions:` block can grant:
 #
 #   Settings > Actions > General > Workflow permissions
 #   [x] Allow GitHub Actions to create and approve pull requests
 #
-# That setting is OFF by default in many repos and organisations. Without it
-# `gh pr create` fails with "GitHub Actions is not permitted to create or approve
-# pull requests". This job does not treat that as a failure: the branch is already
-# pushed by then, so it files an issue carrying the compare link and exits 0.
-#
-# One thing this job structurally cannot deliver: changes to files under
-# .github/workflows/, including this one. GITHUB_TOKEN may not push them, so they
-# are excluded from the commit and a local `install-kit.sh --pr` — run by a human,
-# whose push may touch workflows — is what updates them.
+# Off by default in many repos. Without it the sync still pushes its branch and
+# files an issue with a compare link, rather than failing.
 #
 # Green means checked. Red means the sync could not be produced or did not lint.
 
@@ -58,9 +51,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Beside this repo, not installed into it: Actions runners already ship
-      # Node, so a C++, Go, Python or Shell repo pays nothing to run the checker.
-      # Full history because the kit's version comes from `git describe --tags`.
+      # Beside this repo, not installed into it: runners already ship Node, so a
+      # C++, Go, Python or Shell repo pays nothing to run the checker. Full
+      # history because the kit's version comes from `git describe --tags`.
       - name: Check out the kit
         uses: actions/checkout@v4
         with:
@@ -68,155 +61,8 @@ jobs:
           path: .kit-sync
           fetch-depth: 0
 
-      - name: Is this repo behind?
-        id: check
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          node .kit-sync/bin/kit.mjs check . --kit .kit-sync --json >status.json
-          node -e '
-            const s = require("./status.json");
-            const behind = s.status === "behind" || s.status === "unmarked" ||
-                           s.status === "unknown" || s.missing.length || s.modified.length;
-            console.log(`status=${s.status} behind=${!!behind}`);
-            require("fs").appendFileSync(process.env.GITHUB_OUTPUT, `behind=${behind ? "true" : "false"}\n`);
-          '
-
-      - name: Apply the kit
-        if: steps.check.outputs.behind == 'true'
-        run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          .kit-sync/install-kit.sh .
-
-      # The PR the token opens will not trigger this repo's own CI — GitHub does
-      # not raise workflow runs from GITHUB_TOKEN events. So check here, where the
-      # change already exists, and gate on the result: a sync that breaks the kit's
-      # own markdown rules never becomes a PR.
-      - name: Check what the sync produced
-        if: steps.check.outputs.behind == 'true'
-        id: verify
-        run: |
-          npx --yes markdownlint-cli2 >lint.txt 2>&1 && echo "lint=pass" >>"$GITHUB_OUTPUT" || {
-            echo "lint=fail" >>"$GITHUB_OUTPUT"
-            tail -40 lint.txt
-          }
-
-      - name: Open the sync pull request
-        if: steps.check.outputs.behind == 'true' && steps.verify.outputs.lint == 'pass'
+      - name: Sync
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          version="$(node -p "require('./.agent-kit.json').installed")"
-          branch="chore/kit-sync-$version"
-
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "Nothing changed — already at $version."
-            exit 0
-          fi
-
-          git checkout -b "$branch"
-
-          # Two exclusions, for different reasons.
-          #
-          # .kit-sync — the kit checkout lives inside this work tree, and a blank
-          # `git add -A` stages it as an embedded git repository, putting a gitlink
-          # to the kit in every sync commit.
-          #
-          # .github/workflows — GITHUB_TOKEN may not push changes to a workflow
-          # file. The push is rejected outright ("refusing to allow a GitHub App to
-          # create or update workflow ... without `workflows` permission"), which
-          # would fail the whole sync over a file the job cannot deliver anyway.
-          # The kit owns this workflow, so a local `install-kit.sh --pr` run by a
-          # human updates it; the self-sync delivers everything else.
-          git add -A -- ':!.kit-sync' ':!.github/workflows'
-
-          if git diff --cached --quiet; then
-            echo "::notice::The only pending kit change is under .github/workflows/, which"
-            echo "::notice::GITHUB_TOKEN may not push. Run install-kit.sh --pr locally to deliver it."
-            git checkout -q "${GITHUB_REF_NAME}"
-            exit 0
-          fi
-
-          git commit -q -m "chore(kit): sync to $version"
-          git push -q -f -u origin "$branch"
-
-          if gh pr view "$branch" --json number >/dev/null 2>&1; then
-            echo "PR already open for $branch."
-            exit 0
-          fi
-
-          body="Automated kit sync applied by \`install-kit.sh\` from
-          [mjs-project-template](https://github.com/jwilleke/mjs-project-template).
-
-          Kit version: \`$version\`
-
-          The kit's own markdown lint ran against these changes before this PR was opened and passed.
-          GitHub does not start workflow runs for pull requests opened by \`GITHUB_TOKEN\`, so that
-          in-job check is the gate rather than the checks below.
-
-          Canonical kit files are overwritten wholesale; your own content is untouched, and
-          \`AGENTS.md\` changes stay between the \`KIT:START\` / \`KIT:END\` markers. If something here
-          is wrong, fix it upstream in the template — the next sync would overwrite a local fix."
-
-          # P2 on creation: /pstatus places a PR by its own label first, and an
-          # unlabelled one lands in Needs triage in every repo on every release.
-          if gh pr create --base "${GITHUB_REF_NAME}" --head "$branch" \
-               --label P2 --title "chore(kit): sync to $version" --body "$body" 2>pr-error.txt; then
-            exit 0
-          fi
-
-          cat pr-error.txt
-
-          # The repo has not ticked "Allow GitHub Actions to create and approve
-          # pull requests", which no `permissions:` block can grant. The branch is
-          # already pushed, so nothing is lost and there is nothing to retry — a
-          # red X here would recur on every push forever and mean neither "checked"
-          # nor "could not run".
-          if ! grep -q 'not permitted to create or approve pull requests' pr-error.txt; then
-            echo "::error::gh pr create failed for a reason other than the Actions PR setting"
-            exit 1
-          fi
-
-          compare="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${GITHUB_REF_NAME}...${branch}?expand=1"
-          echo "::notice::Sync branch pushed, but this repo does not allow Actions to open PRs. Open it here: $compare"
-
-          # One issue, reused, on the same marker principle as the drift issue —
-          # this repeats on every push until the setting is changed.
-          marker="kit-sync:cannot-open-pr"
-          if gh issue list --state open --search "$marker in:body" --json number \
-               --jq 'length' | grep -qv '^0$'; then
-            echo "Tracking issue already open."
-            exit 0
-          fi
-
-          gh issue create --label P2 \
-            --title "[kit] Kit Sync cannot open its pull request" \
-            --body "The kit sync ran and passed its own lint, but could not open the pull request:
-
-          \`\`\`text
-          $(cat pr-error.txt)
-          \`\`\`
-
-          **Nothing is lost** — the branch \`$branch\` is pushed. Open the PR here:
-
-          $compare
-
-          ## Fix it once
-
-          Settings > Actions > General > Workflow permissions, and tick
-          **Allow GitHub Actions to create and approve pull requests**.
-
-          That setting is off by default in many repos and organisations, and a workflow's
-          \`permissions:\` block cannot grant it. Until it is on, every sync will push its branch and
-          reopen this issue rather than failing the job.
-
-          <!-- $marker -->"
-
-      # Only when the sync itself failed. A repo that is merely behind gets a PR,
-      # not an issue — the issue existed because nothing could act.
-      - name: Report a sync that could not be applied
-        if: steps.check.outputs.behind == 'true' && steps.verify.outputs.lint == 'fail'
-        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node .kit-sync/bin/kit.mjs check . --kit .kit-sync --report-issue
+        run: .kit-sync/utility/kit-sync.sh .kit-sync

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- KIT:START v1.10.2-0-g0903de6 — managed by mjs-project-template; edit below the KIT:END marker -->
+<!-- KIT:START v1.11.1-0-g71bbbdf — managed by mjs-project-template; edit below the KIT:END marker -->
 ## Agent Kit Protocols
 
 This section is __managed by the kit__ (`install-kit.sh`) — it is identical across repos. Put repo-specific context __below the `KIT:END` marker__; do not edit here.

--- a/utility/kit-sync.sh
+++ b/utility/kit-sync.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# kit-sync.sh — the body of the Kit Sync workflow.
+#
+# This lives in the kit rather than in .github/workflows/kit-sync.yml because
+# GITHUB_TOKEN may not push a workflow file. Anything inside the workflow can
+# only be updated by a human running install-kit.sh against all twelve repos;
+# anything in here is an ordinary `overwrite` file that the sync itself delivers.
+#
+# That distinction is not theoretical. Every defect this mechanism has produced
+# was in the logic, never in the trigger:
+#
+#   red on every push where Actions may not open PRs   logic
+#   `git add -A` staging the kit checkout              logic
+#   pushing a workflow file the token may not touch    logic
+#   a pathspec fighting its own .gitignore             logic
+#
+# Each cost a manual round across the fleet. Held here, the next one does not.
+#
+# Usage: kit-sync.sh <kit-checkout-dir>
+# Expects: GH_TOKEN, GITHUB_REF_NAME, GITHUB_REPOSITORY, GITHUB_SERVER_URL
+
+set -euo pipefail
+
+KIT="${1:?usage: kit-sync.sh <kit-checkout-dir>}"
+BASE="${GITHUB_REF_NAME:?}"
+
+behind() {
+  node "$KIT/bin/kit.mjs" check . --kit "$KIT" --json >kit-status.json
+  node -e '
+    const s = require("./kit-status.json");
+    const yes = s.status === "behind" || s.status === "unmarked" ||
+                s.status === "unknown" || s.missing.length || s.modified.length;
+    console.log(`status=${s.status} behind=${!!yes}`);
+    process.exit(yes ? 0 : 1);
+  '
+}
+
+if ! behind; then
+  echo "Already current with the kit."
+  exit 0
+fi
+
+git config user.name  "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+"$KIT/install-kit.sh" .
+
+# GitHub does not start workflow runs for a PR opened by GITHUB_TOKEN, so the
+# checks on that PR would never arrive. Gate here instead, where the change
+# already exists: a sync that breaks the kit's own markdown rules never becomes
+# a PR at all, which is stricter than waiting for CI.
+if ! npx --yes markdownlint-cli2 >kit-lint.txt 2>&1; then
+  echo "The sync does not satisfy the kit's own markdown rules:"
+  tail -40 kit-lint.txt
+  node "$KIT/bin/kit.mjs" check . --kit "$KIT" --report-issue
+  exit 0
+fi
+
+version="$(node -p "require('./.agent-kit.json').installed")"
+branch="chore/kit-sync-$version"
+
+# .kit-sync is excluded by .gitignore, which install-kit.sh writes. Naming it in
+# a pathspec as well makes `git add` refuse an explicitly-listed ignored path.
+#
+# .github/workflows is excluded because GITHUB_TOKEN may not push it; the whole
+# push is rejected otherwise. A human running install-kit.sh --pr delivers those.
+git checkout -b "$branch"
+git add -A -- ':!.github/workflows'
+
+if git diff --cached --quiet; then
+  echo "::notice::The only pending kit change is under .github/workflows/, which"
+  echo "::notice::GITHUB_TOKEN may not push. Run install-kit.sh --pr locally to deliver it."
+  git checkout -q "$BASE"
+  exit 0
+fi
+
+git commit -q -m "chore(kit): sync to $version"
+git push -q -f -u origin "$branch"
+
+if gh pr view "$branch" --json number >/dev/null 2>&1; then
+  echo "PR already open for $branch."
+  exit 0
+fi
+
+body="Automated kit sync applied by \`install-kit.sh\` from
+[mjs-project-template](https://github.com/jwilleke/mjs-project-template).
+
+Kit version: \`$version\`
+
+The kit's own markdown lint ran against these changes before this PR was opened and passed.
+GitHub does not start workflow runs for pull requests opened by \`GITHUB_TOKEN\`, so that in-job
+check is the gate rather than the checks below.
+
+Canonical kit files are overwritten wholesale; your own content is untouched, and \`AGENTS.md\`
+changes stay between the \`KIT:START\` / \`KIT:END\` markers. If something here is wrong, fix it
+upstream in the template — the next sync would overwrite a local fix.
+
+Changes under \`.github/workflows/\` are not included: \`GITHUB_TOKEN\` may not push them."
+
+# P2 on creation: /pstatus places a PR by its own label first, and an unlabelled
+# one lands in Needs triage in every repo on every release.
+if gh pr create --base "$BASE" --head "$branch" \
+     --label P2 --title "chore(kit): sync to $version" --body "$body" 2>kit-pr-error.txt; then
+  exit 0
+fi
+
+cat kit-pr-error.txt
+
+# "Allow GitHub Actions to create and approve pull requests" is off, which no
+# `permissions:` block can grant. The branch is already pushed, so nothing is
+# lost and there is nothing to retry — a red X here would recur on every push
+# and mean neither "checked" nor "could not run".
+if ! grep -q 'not permitted to create or approve pull requests' kit-pr-error.txt; then
+  echo "::error::gh pr create failed for a reason other than the Actions PR setting"
+  exit 1
+fi
+
+compare="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${BASE}...${branch}?expand=1"
+echo "::notice::Sync branch pushed, but this repo does not allow Actions to open PRs: $compare"
+
+marker="kit-sync:cannot-open-pr"
+if [ "$(gh issue list --state open --search "$marker in:body" --json number --jq 'length')" != "0" ]; then
+  echo "Tracking issue already open."
+  exit 0
+fi
+
+gh issue create --label P2 \
+  --title "[kit] Kit Sync cannot open its pull request" \
+  --body "The kit sync ran and passed its own lint, but could not open the pull request:
+
+\`\`\`text
+$(cat kit-pr-error.txt)
+\`\`\`
+
+**Nothing is lost** — the branch \`$branch\` is pushed. Open the PR here:
+
+$compare
+
+## Fix it once
+
+Settings > Actions > General > Workflow permissions, and tick
+**Allow GitHub Actions to create and approve pull requests**.
+
+That setting is off by default in many repos and organisations, and a workflow's \`permissions:\`
+block cannot grant it. Until it is on, every sync will push its branch and reopen this issue rather
+than failing the job.
+
+<!-- $marker -->"


### PR DESCRIPTION
Automated kit sync from [mjs-project-template](https://github.com/jwilleke/mjs-project-template), applied by `install-kit.sh`.

Kit version: `v1.11.1-0-g71bbbdf`

## Files changed

```text
  M	.agent-kit.json
  M	.github/workflows/kit-sync.yml
  M	AGENTS.md
  A	utility/kit-sync.sh
```

Canonical kit files are overwritten wholesale; your own content is untouched. `AGENTS.md` changes
are confined to the managed block between the `KIT:START` / `KIT:END` markers.

Merging when CI is green is the expected path. If a change here is wrong, fix it upstream in the
template rather than in this repo — the next sync would overwrite a local fix.