### PR TITLE
fix(frontend): make ReportMedicalHistoryEditorComponent standalone with its own imports

### DIFF
--- a/frontend/src/app/components/report-medical-history-editor/report-medical-history-editor.component.spec.ts
+++ b/frontend/src/app/components/report-medical-history-editor/report-medical-history-editor.component.spec.ts
@@ -4,7 +4,6 @@ import { ReportMedicalHistoryEditorComponent } from './report-medical-history-ed
 import {NgbActiveModal, NgbModalModule} from '@ng-bootstrap/ng-bootstrap';
 import {FastenApiService} from '../../services/fasten-api.service';
 import { HttpClient } from '@angular/common/http';
-import { FormsModule } from '@angular/forms';
 
 describe('ReportMedicalHistoryEditorComponent', () => {
   let component: ReportMedicalHistoryEditorComponent;
@@ -12,8 +11,8 @@ describe('ReportMedicalHistoryEditorComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ ReportMedicalHistoryEditorComponent ],
-      imports: [ FormsModule ],
+      // Standalone: imported, not declared (it brings FormsModule/CommonModule itself).
+      imports: [ ReportMedicalHistoryEditorComponent ],
       providers: [NgbActiveModal, {
         provide: FastenApiService,
         useValue: jasmine.createSpyObj('FastenApiService', ['createResourceComposition'])

--- a/frontend/src/app/components/report-medical-history-editor/report-medical-history-editor.component.ts
+++ b/frontend/src/app/components/report-medical-history-editor/report-medical-history-editor.component.ts
@@ -1,4 +1,6 @@
 import {Component, Input, OnInit} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {FormsModule} from '@angular/forms';
 import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import {ResourceFhir} from '../../models/fasten/resource_fhir';
 import {FastenApiService} from '../../services/fasten-api.service';
@@ -22,7 +24,8 @@ class RelatedNode {
     selector: 'app-report-medical-history-editor',
     templateUrl: './report-medical-history-editor.component.html',
     styleUrls: ['./report-medical-history-editor.component.scss'],
-    standalone: false
+    standalone: true,
+    imports: [CommonModule, FormsModule]
 })
 export class ReportMedicalHistoryEditorComponent implements OnInit {
 

--- a/frontend/src/app/components/shared.module.ts
+++ b/frontend/src/app/components/shared.module.ts
@@ -15,7 +15,6 @@ import { NlmTypeaheadComponent } from './nlm-typeahead/nlm-typeahead.component';
 import { ReportHeaderComponent } from './report-header/report-header.component';
 import { ReportLabsObservationComponent } from './report-labs-observation/report-labs-observation.component';
 import { ReportMedicalHistoryConditionComponent } from './report-medical-history-condition/report-medical-history-condition.component';
-import { ReportMedicalHistoryEditorComponent } from './report-medical-history-editor/report-medical-history-editor.component';
 import { ReportMedicalHistoryExplanationOfBenefitComponent } from './report-medical-history-explanation-of-benefit/report-medical-history-explanation-of-benefit.component';
 import { ToastComponent } from './toast/toast.component';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
@@ -75,7 +74,6 @@ import { RawResourceComponent } from './raw-resource/raw-resource.component';
     UtilitiesSidebarComponent,
     ToastComponent,
     ReportHeaderComponent,
-    ReportMedicalHistoryEditorComponent,
     ReportMedicalHistoryConditionComponent,
     ReportLabsObservationComponent,
     ReportMedicalHistoryTimelinePanelComponent,
@@ -95,7 +93,6 @@ import { RawResourceComponent } from './raw-resource/raw-resource.component';
         ReportHeaderComponent,
         ReportLabsObservationComponent,
         ReportMedicalHistoryConditionComponent,
-        ReportMedicalHistoryEditorComponent,
         ReportMedicalHistoryExplanationOfBenefitComponent,
         ToastComponent,
         UtilitiesSidebarComponent,

--- a/frontend/tsconfig.spec.json
+++ b/frontend/tsconfig.spec.json
@@ -6,7 +6,7 @@
     "resolveJsonModule": true,
     "outDir": "./out-tsc/spec",
     "types": [
-      "jasmine",
+      "jasmine"
     ],
   },
   "files": [


### PR DESCRIPTION
Lifted from [#598](https://github.com/jwilleke/yourphr/pull/598) (Parth Kheni, co-authored) so the fix ships in the next patch regardless of that PR's outcome. Reasoning in the commit message. Production build verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQTRA2dzEQLLpBE1rc52F7