### PR TITLE
fix(search): index a record's clinical name — `code` is a CodeableConcept, not a bare code

### DIFF
--- a/src/app/providers/__tests__/record-text.test.ts
+++ b/src/app/providers/__tests__/record-text.test.ts
@@ -54,4 +54,42 @@ describe('record text: narrative entities', () => {
     expect(text).toContain('"stable"');
     expect(text).toContain("patient's");
   });
+
+  /**
+   * The clinical name of a record, which is the thing a person actually searches for.
+   *
+   * `code` is in SKIP_KEYS to keep bare codes and identifiers out of the index — "metformin" should
+   * match the medication rather than every record with those letters in an id. But it was matched by
+   * KEY NAME, and in FHIR `code` is normally a CodeableConcept, so the whole subtree went: Condition,
+   * Observation, Procedure, AllergyIntolerance and DiagnosticReport were all indexed with their type
+   * and status and no name at all. Search returned nothing for "prediabetes" while looking like it
+   * worked, which is the yourphr#598 empty-`sort_title` failure wearing a different hat.
+   */
+  describe('the clinical name survives, the bare code does not', () => {
+    const named: [string, Record<string, unknown>, string][] = [
+      ['Condition', { resourceType: 'Condition', code: { text: 'Prediabetes' } }, 'Prediabetes'],
+      ['Procedure', { resourceType: 'Procedure', status: 'completed', code: { text: 'Colonoscopy' } }, 'Colonoscopy'],
+      ['AllergyIntolerance', { resourceType: 'AllergyIntolerance', code: { text: 'Penicillin' } }, 'Penicillin'],
+      ['DiagnosticReport', { resourceType: 'DiagnosticReport', status: 'final', code: { text: 'CBC panel' } }, 'CBC panel'],
+      ['Observation', { resourceType: 'Observation', status: 'final', code: { coding: [{ display: 'Hemoglobin A1c' }] } }, 'Hemoglobin A1c'],
+    ];
+    for (const [type, resource, name] of named) {
+      it(`indexes ${type} by its name`, () => {
+        expect(textFor(resource)).toContain(name);
+      });
+    }
+
+    it('keeps the bare code, the system URI and the identifier out', () => {
+      const text = textFor({
+        resourceType: 'Observation', status: 'final',
+        code: { coding: [{ system: 'http://loinc.org', code: '4548-4', display: 'Hemoglobin A1c' }], text: 'HbA1c' },
+        identifier: [{ system: 'urn:x', value: 'metformin-lookalike-id' }],
+      });
+      expect(text).toContain('Hemoglobin A1c');
+      expect(text).toContain('HbA1c');
+      expect(text).not.toContain('4548-4');
+      expect(text).not.toContain('loinc.org');
+      expect(text).not.toContain('metformin-lookalike-id');
+    });
+  });
 });

--- a/src/app/providers/record-text.ts
+++ b/src/app/providers/record-text.ts
@@ -43,7 +43,13 @@ export function textFor(resource: unknown): string {
     if (Array.isArray(node)) { node.forEach((n) => walk(n, key)); return; }
     if (node && typeof node === 'object') {
       for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
-        if (SKIP_KEYS.has(k)) continue;
+        // A key in SKIP_KEYS is skipped only when its VALUE is a leaf. `code` is the case that
+        // matters: in FHIR it is usually a CodeableConcept, so skipping it by name threw away the
+        // clinical name of most resources — Condition.code, Observation.code, Procedure.code,
+        // AllergyIntolerance.code, DiagnosticReport.code — and searching "prediabetes" or
+        // "colonoscopy" matched nothing while the index looked like it worked. The bare `code`
+        // STRING inside each coding is still skipped, which is what the rule was reaching for.
+        if (SKIP_KEYS.has(k) && !(k === 'code' && v !== null && typeof v === 'object')) continue;
         if (k === 'div' && typeof v === 'string') { out.push(stripTags(v)); continue; }
         walk(v, k);
       }


### PR DESCRIPTION
## Summary

Find-anything-by-words cannot find a condition, a lab, a procedure, an allergy or a diagnostic report **by name**. Searching `prediabetes` or `colonoscopy` returns nothing, while the index looks healthy because medications and immunizations still match.

`code` is in `SKIP_KEYS` so bare codes and identifiers stay out of the index — "metformin" should match the medication rather than every record carrying those letters in an id. That intent is right and this PR keeps it. But the rule was applied by **key name**, and in FHIR `code` is normally a CodeableConcept, so skipping it discarded the whole subtree — including the `text` and `coding[].display` that are the only human-readable name most clinical resources have:

| Resource | Indexed text today | Missing |
|---|---|---|
| `Condition` | `"Condition 2024-01-11"` | **Prediabetes** |
| `Observation` | `"Observation final 2024-06-02"` | **Hemoglobin A1c** |
| `Procedure` | `"Procedure completed"` | **Colonoscopy** |
| `AllergyIntolerance` | `"Allergy Intolerance"` | **Penicillin** |
| `DiagnosticReport` | `"Diagnostic Report final"` | **CBC panel** |

`MedicationRequest` and `Immunization` escaped only because their display text hangs off `medicationCodeableConcept` and `vaccineCode`, which are not called `code`.

## The fix

One condition, narrowing the rule to what it was reaching for: a key in `SKIP_KEYS` is skipped when its value is a **leaf**. The bare `code` *string* inside each coding is still excluded, along with `system`, `identifier` and the rest — only the CodeableConcept object is walked into.

```
Observation  ->  "Observation final Hemoglobin A1c HbA1c 2024-06-02"
                 contains: display, text
                 excludes: 4548-4, loinc.org, the identifier value
```

## Why this shape of bug is worth a note

This is the sibling of [#598](https://github.com/jwilleke/yourphr/pull/598)'s empty `sort_title`, and it fails the same way: an index that returns *some* results looks far healthier than one that returns none, so nothing draws attention to the records that silently cannot be found. Both were invisible until something tried to read the index in anger.

The tests added here fail on every affected resource type without the change (6 failures), and assert that the bare code, the system URI and the identifier stay out with it.

## Related issue

Relates to [#599](https://github.com/jwilleke/yourphr/issues/599), whose index this repairs. Found while building [#657](https://github.com/jwilleke/yourphr/issues/657), which reads that index — a search tool is only worth as much as what it can find.

**Please take this one first.** [#657](https://github.com/jwilleke/yourphr/issues/657)'s MCP PR depends on it in practice: without this, `search_records` cannot find most of a record and the feature reviews as half-broken.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor / chore
- [ ] CI / build

## Checklist

- [x] **No PHI/PII, secrets, keys, `.env`, real FHIR bundles, or `*.db` files** — the added fixtures are synthetic, inline, and minimal.
- [x] Tests pass and I added tests. `npm test` 307 passing (31 files); `npm run records` 18/18; `npm run app` 118/118; `npm run typecheck` clean. The new tests fail without the change.
- [x] Lint passes — `markdownlint-cli2` clean (no markdown changed here).
- [x] N/A — no tygo-exported struct or `search-parameters.json` touched. (The checklist item is Go-era; noting rather than silently ticking.)
- [x] Docs — no behaviour documented elsewhere changes, beyond search now finding what it always claimed to.