### PR TITLE
feat(mcp): the patient's own AI client reads their records, over the agent-token surface

### DIFF
--- a/.github/workflows/server-ci.yaml
+++ b/.github/workflows/server-ci.yaml
@@ -79,6 +79,8 @@ jobs:
         run: npm run auth
       - name: Agent tokens — the delegated-read gate (yourphr#695)
         run: npm run agent-tokens
+      - name: MCP bridge — one patient's records, over the agent-token surface (yourphr#657)
+        run: npm run mcp-tests
       - name: Configuration system (precedence, overlay, refusals)
         run: npm run config
       - name: Bootstrap environment (.env precedence)

--- a/docs/agent-access-policy.md
+++ b/docs/agent-access-policy.md
@@ -4,7 +4,7 @@ __Status: proposed with the first slice (yourphr#657), for review before merge._
 
 __Code:__ `scripts/mcp-server.ts` (the bridge), `src/framework/managers/AgentTokensManager.ts` (the credential), `src/account/index.ts` (`accessCategoryFor`, the scope and log vocabulary), `src/server.ts` (the gate)
 __Harnesses:__ `npm run mcp-tests`, `npm run agent-tokens`
-__Companion to:__ [`connection-policy.md`](../connection-policy.md), which answers the same shape of question for medical sources — what leaves, on whose decision, and what is refused.
+__Companion to:__ [`connection-policy.md`](connection-policy.md), which answers the same shape of question for medical sources — what leaves, on whose decision, and what is refused.
 
 This is the written policy [yourphr#599](https://github.com/jwilleke/yourphr/issues/599) asked for before any LLM touched a record: *"records must not leave the machine without an explicit, per-conversation statement."*
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -34,6 +34,7 @@ This page covers running and configuring an instance. The rest of the deployment
 | [`../medicare-bluebutton.md`](../medicare-bluebutton.md) | A full worked SMART-on-FHIR connect example with exact settings. |
 | [`../cms-bluebutton-production-access.md`](../cms-bluebutton-production-access.md) | CMS production access: form, Zoom demo script, PP/ToS gates (#433). |
 | [`../FHIR/fhir-converter-local.md`](../FHIR/fhir-converter-local.md) | The optional C-CDA/CCD converter sidecar. |
+| [`../agent-access-policy.md`](../agent-access-policy.md) | Letting a patient point their own AI client at their own records ([#657](https://github.com/jwilleke/yourphr/issues/657)): the default posture, what is logged and under whose name, what the product refuses, and how to connect a client. Off unless `yourphr.auth.agent-token.enabled` is set. |
 | [`../recovery/`](../recovery/) | Backup, restore, and the __restore drill__ — what a backup contains, and how to prove your instance can come back. |
 
 > __Deployment-agnostic by rule.__ Every option below is driven by the same `YOURPHR_*` environment contract and a SQLite file — nothing requires Kubernetes, Flux, SOPS, or any specific orchestrator. The maintainer's production instance uses Flux/GitOps in a separate repo (`mj-infra-flux`); that repo's only job is to *populate the same env vars* a `docker run` would. If a feature can only be configured one way, that is a bug — file it.

--- a/docs/planning/agent-access-policy.md
+++ b/docs/planning/agent-access-policy.md
@@ -1,0 +1,97 @@
+# AI agent access policy
+
+__Status: proposed with the first slice (yourphr#657), for review before merge.__
+
+__Code:__ `scripts/mcp-server.ts` (the bridge), `src/framework/managers/AgentTokensManager.ts` (the credential), `src/account/index.ts` (`accessCategoryFor`, the scope and log vocabulary), `src/server.ts` (the gate)
+__Harnesses:__ `npm run mcp-tests`, `npm run agent-tokens`
+__Companion to:__ [`connection-policy.md`](../connection-policy.md), which answers the same shape of question for medical sources — what leaves, on whose decision, and what is refused.
+
+This is the written policy [yourphr#599](https://github.com/jwilleke/yourphr/issues/599) asked for before any LLM touched a record: *"records must not leave the machine without an explicit, per-conversation statement."*
+
+## The posture, in one paragraph
+
+YourPHR runs no model, bundles no weights, calls no inference service, and sends no record anywhere. A patient who wants an AI to help them read their own records mints a short-lived, scoped credential for themselves and hands it to a client they already run. That client fetches their records, under their own credential, on their own machine, subject to whatever terms they accepted from whoever wrote it. YourPHR's part is to serve an authenticated read and record that it happened.
+
+The distinction is the whole design and it is not a technicality: __the product is not the party disclosing anything.__ There is no configuration in which YourPHR transmits a record to a third party of its own accord, and adding one would be a different decision requiring its own review.
+
+## Default posture
+
+| Question | Default |
+|---|---|
+| Agent tokens | __Off__ — `yourphr.auth.agent-token.enabled` is `false`; an operator opts in |
+| Token lifetime | __24 hours__, a ceiling rather than a default; there is no never-expires option |
+| Token capability | __Read-only__ — no write scope exists to grant |
+| Scope | __Required__ — an unscoped token is rejected, never treated as unrestricted |
+| Which records | __Only the minting patient's own__, by the same `user_id` seam every other read uses |
+| The MCP bridge | Runs on the __patient's machine__, launched by their client; the server neither hosts nor advertises it |
+
+Nothing in that table is new to this feature. Every row is a property of [yourphr#695](https://github.com/jwilleke/yourphr/issues/695), inherited rather than re-implemented, which is the point of building the bridge on the HTTP surface instead of beside it.
+
+## What may leave the machine, and on whose decision
+
+Records leave only when a patient has taken three deliberate steps, each of which they can undo:
+
+1. An operator enabled agent tokens for the instance.
+2. The patient minted a token, chose its scopes, and saw what those scopes let an agent read.
+3. The patient pasted that token into a client they chose and configured.
+
+The __per-conversation statement__ yourphr#599 requires is served by the bridge itself. Its `initialize` response tells the connecting client, in words the model reads at the start of every session:
+
+> These are one patient's own health records, read live from their YourPHR instance. Every read is recorded in their access log under this client's name. Nothing here can be changed.
+
+That is a statement to the model rather than a consent dialog to the human, and it is worth being honest about the difference. The human's consent moment is the minting screen, which is where the scopes are chosen and where the words have to be right.
+
+## What is recorded
+
+Every agent read is written to the patient's access log __before__ the read is served, under the __token's name__ rather than the patient's — so the log says "Claude Desktop read your record search" and not "you did", on a day the patient may not have opened the app at all. `npm run mcp-tests` asserts both halves: that the agent's name appears, and that the patient's does not.
+
+The log is bucketed per owner, actor, category and day, with a count. So a chatty agent produces one row with a rising number rather than a flood, and the patient can still see how much was read and when it started and stopped.
+
+## What the product refuses
+
+- __Any write.__ Not "no write tool is offered" — no write path has an access category, and the gate admits only categorised GETs, so a write route added next year is refused by inheritance rather than by someone remembering.
+- __Any read with no category.__ An uncategorised read is one the log cannot record, and yourphr#614's rule is that an unaudited disclosure did not happen. An agent asking for one gets a 403.
+- __A token used from a browser.__ Agent tokens are accepted from an `Authorization` header only, never from a cookie, so a page cannot silently borrow one.
+- __A token that renews or mints another.__ Two independent locks: the edge gate refuses the route, and `AgentTokensManager.requireHuman` refuses the call.
+- __Bundling, recommending, or proxying a model.__ Out of scope by policy, not merely unimplemented.
+
+## The decision this policy owes: is the audit a guarantee or a list?
+
+[yourphr#657](https://github.com/jwilleke/yourphr/issues/657) asked whether "who read this record" is a manager guarantee or an HTTP-layer allow-list, and said the MCP safety case rests on the answer.
+
+__Today it is an allow-list.__ `accessCategoryFor(pathname)` maps a path to a category; `src/server.ts` consults it and writes the log entry. The managers — which `scripts/check-store-boundary.sh` does prove are the only path to a store — have no part in it. A read that reaches a manager through an uncategorised route is served and never recorded.
+
+That is not hypothetical. Find-anything-by-words ([yourphr#599](https://github.com/jwilleke/yourphr/issues/599)) shipped with no category, so the dashboard's search box read across every resource type a patient owns and the access log said nothing had happened. This slice is what fixes it, because it had to: an uncategorised route is also unreachable by an agent token, so `search_records` could not work until the route was named.
+
+__The allow-list is fail-safe for agents and fail-open for sessions.__ Omit a category and an agent gets a 403 — loud, immediate, and the reason this gap surfaced at all. Omit it and a signed-in patient's own read goes unlogged, silently, forever. The two halves of one mechanism fail in opposite directions, and only one of them tells you.
+
+__The recommendation is to keep the allow-list and make omission loud.__ Moving the audit into the managers is the tempting answer and the wrong one here: scopes are the log's categories, so a category is a property of *the surface a request arrives on*, not of the manager underneath — several routes with different categories share one manager, and `Full export` and `Records (FHIR)` are the same manager reached two ways. Binding audit to the manager would break the property that makes scoping trustworthy.
+
+What is missing is not a different mechanism but a check that fails, per the twelfth architecture principle. A CI step that requires every GET under `/api/secure/` to either resolve a category or appear on an explicit __not-an-access__ list would convert a silent hole into a build failure, and would have caught yourphr#599's search route on the commit that introduced it. That belongs in its own issue rather than this slice, and this policy is the argument for filing it.
+
+## Connecting a client
+
+The bridge is a plain stdio process; any MCP-capable client can launch it. For Claude Desktop, in its configuration file:
+
+```json
+{
+  "mcpServers": {
+    "yourphr": {
+      "command": "npx",
+      "args": ["tsx", "/path/to/yourphr/scripts/mcp-server.ts"],
+      "env": {
+        "YOURPHR_URL": "http://localhost:8080",
+        "YOURPHR_AGENT_TOKEN": "yphr_at_…"
+      }
+    }
+  }
+}
+```
+
+Mint the token at Account Profile with the __Record search__ scope. It lasts at most 24 hours by design; when it expires the client stops working and says so, and the patient mints another. That friction is the feature — a credential that outlives the patient's attention is the thing yourphr#695 exists to prevent.
+
+## What this policy does not cover
+
+- __Whether the patient's chosen client is trustworthy.__ It cannot; that is theirs to judge, and the honest scope of this design is that it makes the judgement theirs rather than the product's. What YourPHR owes is that the credential is short-lived, narrow, revocable, and that every use of it is visible.
+- __Prompt injection.__ Hostile text inside an imported document could try to induce a client to fetch more than the patient meant. Read-only, scoping and the audit bound the blast radius; they do not eliminate the class. A second tool that returns whole resources would widen it, which is one reason there is only one tool.
+- __What a model infers.__ A summary drawn from real records can be wrong in ways the records are not. Nothing here makes an AI's reading of a record clinically reliable, and no part of the product should imply otherwise.

--- a/docs/planning/agent-access-policy.md
+++ b/docs/planning/agent-access-policy.md
@@ -71,16 +71,42 @@ What is missing is not a different mechanism but a check that fails, per the twe
 
 ## Connecting a client
 
-The bridge is a plain stdio process; any MCP-capable client can launch it. For Claude Desktop, in its configuration file:
+Verified end to end against Cursor and a hand-driven client. Four steps, and the reason for each.
+
+### 1. Turn agent tokens on
+
+Off by default, so nothing below is reachable until an operator opts in:
+
+```bash
+YOURPHR_AUTH_AGENT_TOKEN_ENABLED=true
+```
+
+### 2. Mint a token
+
+__There is no minting screen yet.__ [yourphr#695](https://github.com/jwilleke/yourphr/issues/695) shipped the server side — `GET`/`POST /api/secure/account/agent-tokens`, which already serve `available_scopes` and the TTL policy for exactly such a screen — but the Angular half does not exist, so today a patient cannot do this without a terminal. That is a real gap for a feature aimed at patients rather than operators, and it is the natural next issue; the API is settled, so it is a screen over a finished contract.
+
+Until then, with a signed-in session token:
+
+```bash
+curl -s -X POST "$BASE/api/secure/account/agent-tokens" \
+  -H "authorization: Bearer $SESSION" -H 'content-type: application/json' \
+  -d '{"name":"Claude Desktop","scopes":["Record search"]}'
+```
+
+The `name` is what the access log will show, so it should say which client this is rather than which person — the log already knows the person. The cleartext token comes back __once__ and is never stored.
+
+### 3. Point a client at the bridge
+
+Claude Desktop reads `~/Library/Application Support/Claude/claude_desktop_config.json`; Cursor reads `~/.cursor/mcp.json`. The same block works in both:
 
 ```json
 {
   "mcpServers": {
     "yourphr": {
-      "command": "npx",
-      "args": ["tsx", "/path/to/yourphr/scripts/mcp-server.ts"],
+      "command": "/path/to/yourphr/node_modules/.bin/tsx",
+      "args": ["/path/to/yourphr/scripts/mcp-server.ts"],
       "env": {
-        "YOURPHR_URL": "http://localhost:8080",
+        "YOURPHR_URL": "http://127.0.0.1:8080",
         "YOURPHR_AGENT_TOKEN": "yphr_at_…"
       }
     }
@@ -88,7 +114,15 @@ The bridge is a plain stdio process; any MCP-capable client can launch it. For C
 }
 ```
 
-Mint the token at Account Profile with the __Record search__ scope. It lasts at most 24 hours by design; when it expires the client stops working and says so, and the patient mints another. That friction is the feature — a credential that outlives the patient's attention is the thing yourphr#695 exists to prevent.
+__Absolute paths, and the local `tsx` binary rather than `npx`.__ A desktop client is launched by the window manager, not a shell, so it inherits neither the shell `PATH` nor a useful working directory: `npx tsx` there resolves nothing locally and tries to fetch the package over the network, which fails on exactly the offline instance this product is built for. Naming the binary in `node_modules/.bin` removes both problems.
+
+### 4. Ask a question — there is nothing to select
+
+The bridge offers a __tool__, and MCP tools are called by the model when a question warrants one. They deliberately do not appear in the attachment or resource picker, which lists MCP __resources__ and __prompts__; this server publishes neither, so that menu is correctly empty and the server is still working. The client's MCP settings are where to confirm it: "yourphr — 1 tool enabled".
+
+Then simply ask — *"search my records for metformin"*, *"when was my last tetanus shot?"* — and check the access log afterwards, where the read appears under the token's name.
+
+A token lasts at most 24 hours by design; when it expires the client stops working and says so, and the patient mints another. That friction is the feature — a credential that outlives the patient's attention is the thing yourphr#695 exists to prevent.
 
 ## What this policy does not cover
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.3.0",
   "private": true,
   "type": "module",
-  "description": "YourPHR — your medical records, immediately and in your hands, for free. The TypeScript stack that succeeds the Go backend.",
+  "description": "YourPHR \u2014 your medical records, immediately and in your hands, for free. The TypeScript stack that succeeds the Go backend.",
   "engines": {
     "node": ">=24"
   },
@@ -58,6 +58,8 @@
     "baseline": "tsx scripts/build-demo-baseline.ts",
     "check:routes": "tsx scripts/check-routes.ts",
     "agent-tokens": "tsx scripts/agent-token-tests.ts",
+    "mcp": "tsx scripts/mcp-server.ts",
+    "mcp-tests": "tsx scripts/mcp-tests.ts",
     "lint:md": "markdownlint-cli2"
   },
   "dependencies": {

--- a/scripts/mcp-server.ts
+++ b/scripts/mcp-server.ts
@@ -1,0 +1,236 @@
+/**
+ * YourPHR as an MCP server (yourphr#657) — the patient's own AI client reads their own records.
+ *
+ *   YOURPHR_URL=http://localhost:8080 YOURPHR_AGENT_TOKEN=yphr_at_… npm run mcp
+ *
+ * A patient mints an agent token for themselves (yourphr#695), scoped to `Record search`, and hands
+ * it to an AI client they already run. The client launches this bridge; the bridge asks YourPHR's
+ * own HTTP API the same question the dashboard's search box asks. YourPHR transmits nothing to
+ * anyone: the record goes to the client the patient chose, under the patient's own credential.
+ *
+ * WHY A BRIDGE RATHER THAN A ROUTE, which is the whole design and the reason this is small:
+ *
+ * The agent-token gate in server.ts is default-deny — an agent reaches a GET whose path has an
+ * access category and whose category its token names, and nothing else. Presenting the token to
+ * that surface inherits scoping, auditing and read-only *for free*. An MCP endpoint inside the
+ * server could not: JSON-RPC is a POST, every POST is refused there, so it would have to sit
+ * outside the gate and re-implement all three — the "beside it rather than on top of it" mistake.
+ *
+ * It also cannot live under src/ even if we wanted it to: `check:boundary` refuses `fetch` there,
+ * because Node's fetch is undici and ignores the guarded DNS lookup that is the SSRF control.
+ * scripts/ is the exempt place for loopback drivers, and that exemption is why this lives here —
+ * the same reason scripts/agent-token-tests.ts does.
+ *
+ * So this process holds no database handle, no session, and no privilege. It is an HTTP client with
+ * a scoped bearer token, and every safety property it has belongs to the server it calls.
+ *
+ * ZERO DEPENDENCIES, deliberately. The official SDK would be the conventional choice, but MCP's
+ * stdio transport is newline-delimited JSON-RPC 2.0 and the surface used here is four methods. In a
+ * store of medical records, a dependency tree is a standing supply-chain question, and this repo
+ * runs on sixteen packages. If the maintainers would rather take the SDK, the shape below is the
+ * same either way — only the plumbing changes.
+ */
+import { createInterface } from 'node:readline';
+
+/** MCP revisions this bridge speaks. A client asking for one of these is answered in its own. */
+const SUPPORTED_PROTOCOLS = ['2025-06-18', '2025-03-26', '2024-11-05'];
+const FALLBACK_PROTOCOL = '2025-06-18';
+
+const BASE = (process.env['YOURPHR_URL'] ?? '').replace(/\/+$/, '');
+const TOKEN = process.env['YOURPHR_AGENT_TOKEN'] ?? '';
+
+/** Diagnostics go to stderr; stdout is the JSON-RPC channel and carries nothing else. */
+function note(message: string): void {
+  process.stderr.write(`yourphr-mcp: ${message}\n`);
+}
+
+interface Rpc {
+  jsonrpc: '2.0';
+  id?: number | string | null;
+  method?: string;
+  params?: Record<string, unknown>;
+}
+
+function reply(id: number | string | null | undefined, result: unknown): void {
+  process.stdout.write(`${JSON.stringify({ jsonrpc: '2.0', id, result })}\n`);
+}
+
+function fail(id: number | string | null | undefined, code: number, message: string): void {
+  process.stdout.write(`${JSON.stringify({ jsonrpc: '2.0', id, error: { code, message } })}\n`);
+}
+
+/** A tool result the model reads. `isError` keeps a refusal in-band, so the model can say why. */
+function toolResult(text: string, isError = false): Record<string, unknown> {
+  return { content: [{ type: 'text', text }], isError };
+}
+
+const SEARCH_RECORDS = {
+  name: 'search_records',
+  title: 'Search health records',
+  description:
+    "Search the signed-in patient's own health records by words — conditions, medications, lab " +
+    'results, immunizations, procedures, encounters and documents. Returns matching records with a ' +
+    'short snippet each, newest and best-matching first. Read-only.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: { type: 'string', description: 'Words to look for, e.g. "metformin" or "blood pressure". At least two characters.' },
+      limit: { type: 'integer', description: 'How many records to return (1–100). Defaults to 20.', minimum: 1, maximum: 100 },
+    },
+    required: ['query'],
+    additionalProperties: false,
+  },
+} as const;
+
+interface SearchHit {
+  source_resource_type: string;
+  source_resource_id: string;
+  title: string;
+  date?: string;
+  snippet: string;
+}
+
+/**
+ * One search, as the patient, against their own instance.
+ *
+ * The refusals are worth as much as the results here: an agent token that has been revoked, expired
+ * or minted without `Record search` is the normal way this stops working, and a model that is told
+ * which of those happened can tell the patient what to do about it.
+ */
+async function searchRecords(query: string, limit: number): Promise<Record<string, unknown>> {
+  const url = `${BASE}/api/secure/resources/search?q=${encodeURIComponent(query)}&limit=${limit}`;
+  let res: Response;
+  try {
+    res = await fetch(url, { headers: { authorization: `Bearer ${TOKEN}`, accept: 'application/json' } });
+  } catch (err) {
+    return toolResult(`Could not reach YourPHR at ${BASE}: ${(err as Error).message}`, true);
+  }
+
+  if (res.status === 401) {
+    return toolResult(
+      'YourPHR refused the agent token. It has been revoked, or it has expired — agent tokens last at ' +
+        'most 24 hours. Mint a fresh one from Account Profile and update this client.',
+      true,
+    );
+  }
+  if (res.status === 403) {
+    return toolResult(
+      'This agent token was not given access to record search. Mint one from Account Profile with the ' +
+        '"Record search" scope selected.',
+      true,
+    );
+  }
+  if (!res.ok) {
+    return toolResult(`YourPHR answered ${res.status} ${res.statusText}.`, true);
+  }
+
+  const body = (await res.json()) as { data?: SearchHit[] };
+  const hits = body.data ?? [];
+  if (hits.length === 0) return toolResult(`No records matched "${query}".`);
+
+  // Rendered rather than raw JSON: the reference is what a follow-up question needs, the title and
+  // date are what a person recognises, and the snippet is the evidence for the match.
+  const lines = hits.map((h) => {
+    const when = h.date ? ` (${h.date})` : '';
+    const snippet = h.snippet ? ` — ${h.snippet.replace(/\s+/g, ' ').trim()}` : '';
+    return `- ${h.source_resource_type}/${h.source_resource_id}: ${h.title}${when}${snippet}`;
+  });
+  return toolResult(`${hits.length} record${hits.length === 1 ? '' : 's'} matching "${query}":\n${lines.join('\n')}`);
+}
+
+async function handle(msg: Rpc): Promise<void> {
+  const { id, method, params } = msg;
+
+  // A notification has no id and takes no reply — `notifications/initialized` is the common one.
+  const isNotification = id === undefined;
+
+  switch (method) {
+    case 'initialize': {
+      const asked = String((params as { protocolVersion?: string } | undefined)?.protocolVersion ?? '');
+      reply(id, {
+        protocolVersion: SUPPORTED_PROTOCOLS.includes(asked) ? asked : FALLBACK_PROTOCOL,
+        capabilities: { tools: {} },
+        serverInfo: { name: 'yourphr', version: '1.0.0' },
+        instructions:
+          'These are one patient\'s own health records, read live from their YourPHR instance. Every ' +
+          'read is recorded in their access log under this client\'s name. Nothing here can be changed.',
+      });
+      return;
+    }
+
+    case 'notifications/initialized':
+      return;
+
+    case 'ping':
+      reply(id, {});
+      return;
+
+    case 'tools/list':
+      reply(id, { tools: [SEARCH_RECORDS] });
+      return;
+
+    case 'tools/call': {
+      const call = params as { name?: string; arguments?: Record<string, unknown> } | undefined;
+      if (call?.name !== SEARCH_RECORDS.name) {
+        fail(id, -32602, `unknown tool: ${String(call?.name ?? '')}`);
+        return;
+      }
+      const args = call.arguments ?? {};
+      const query = typeof args['query'] === 'string' ? args['query'].trim() : '';
+      if (query.length < 2) {
+        reply(id, toolResult('Give at least two characters to search for.', true));
+        return;
+      }
+      const asked = Number(args['limit'] ?? 20);
+      const limit = Number.isInteger(asked) ? Math.min(Math.max(asked, 1), 100) : 20;
+      reply(id, await searchRecords(query, limit));
+      return;
+    }
+
+    default:
+      if (!isNotification) fail(id, -32601, `method not found: ${String(method ?? '')}`);
+  }
+}
+
+function main(): void {
+  if (BASE === '' || TOKEN === '') {
+    note('set YOURPHR_URL and YOURPHR_AGENT_TOKEN. Mint a token at Account Profile → Agent tokens,');
+    note('with the "Record search" scope. See docs/planning/agent-access-policy.md.');
+    process.exit(1);
+  }
+
+  // Newline-delimited JSON, which is MCP's stdio framing (not LSP's Content-Length headers).
+  const lines = createInterface({ input: process.stdin });
+
+  // A tool call is a round trip to the server, so requests are in flight when stdin closes —
+  // which is the normal end of a piped session, not only a shutdown. Exiting on `close` alone
+  // dropped every answer that had not come back yet: the handshake replied and the searches
+  // vanished. Drain instead, so the last question asked is still answered.
+  let pending = 0;
+  let inputClosed = false;
+  const exitWhenDrained = (): void => { if (inputClosed && pending === 0) process.exit(0); };
+
+  lines.on('line', (line) => {
+    const text = line.trim();
+    if (text === '') return;
+    let msg: Rpc;
+    try {
+      msg = JSON.parse(text) as Rpc;
+    } catch {
+      fail(null, -32700, 'parse error');
+      return;
+    }
+    pending += 1;
+    void handle(msg)
+      .catch((err) => {
+        // Never the record, and never a stack: a tool failure is a sentence the model can pass on.
+        note(`request failed: ${(err as Error).message}`);
+        if (msg.id !== undefined) fail(msg.id, -32603, 'internal error');
+      })
+      .finally(() => { pending -= 1; exitWhenDrained(); });
+  });
+  lines.on('close', () => { inputClosed = true; exitWhenDrained(); });
+  note(`ready — ${BASE}`);
+}
+
+main();

--- a/scripts/mcp-server.ts
+++ b/scripts/mcp-server.ts
@@ -195,7 +195,7 @@ async function handle(msg: Rpc): Promise<void> {
 function main(): void {
   if (BASE === '' || TOKEN === '') {
     note('set YOURPHR_URL and YOURPHR_AGENT_TOKEN. Mint a token at Account Profile → Agent tokens,');
-    note('with the "Record search" scope. See docs/planning/agent-access-policy.md.');
+    note('with the "Record search" scope. See docs/agent-access-policy.md.');
     process.exit(1);
   }
 

--- a/scripts/mcp-tests.ts
+++ b/scripts/mcp-tests.ts
@@ -1,0 +1,219 @@
+/**
+ * The MCP bridge, over the WIRE (yourphr#657).
+ *
+ *   npm run mcp-tests
+ *
+ * scripts/mcp-server.ts is an HTTP client with a scoped bearer token, so the only way to know what
+ * it can reach is to run it: boot a real instance, mint a real agent token, speak real JSON-RPC to
+ * a real child process, and try to walk past each thing it is supposed to refuse.
+ *
+ * A harness rather than a vitest file for the same reason scripts/agent-token-tests.ts is one:
+ * `check:boundary` refuses `fetch` under src/, because Node's fetch is undici and ignores the
+ * guarded DNS lookup that is the SSRF control. scripts/ is the exempt place for loopback drivers.
+ *
+ * THE TOOTH IS THE POINT. Both accounts below are prescribed the same drug, so "metformin" matches
+ * a record in each. If the owner seam ever stops holding, one query returns two people's records
+ * and this fails — which is the only version of that test worth writing.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import type { Server } from 'node:http';
+import type { Resource } from '@medplum/fhirtypes';
+import { openStores, type Stores } from '../src/app.js';
+import { createYourPhrServer } from '../src/server.js';
+import { SqliteFhirRepository } from '../src/SqliteFhirRepository.js';
+
+const results: { name: string; ok: boolean; detail: string }[] = [];
+function check(name: string, ok: boolean, detail = ''): void {
+  results.push({ name, ok, detail });
+  console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+const PASSWORD = 'a-long-enough-password';
+const BRIDGE = ['--import', 'tsx', 'scripts/mcp-server.ts'];
+
+interface Harness {
+  base: string;
+  stores: Stores;
+  server: Server;
+  close: () => Promise<void>;
+}
+
+async function boot(): Promise<Harness> {
+  const dir = mkdtempSync(join(tmpdir(), 'yourphr-mcp-'));
+  const stores = await openStores(dir, {
+    YOURPHR_AUTH_AGENT_TOKEN_ENABLED: 'true',
+    YOURPHR_AUTH_SIGNUP_ENABLED: 'true',
+  });
+  const server = createYourPhrServer({ engine: stores.engine, auth: {} }) as Server;
+  await new Promise<void>((done) => server.listen(0, '127.0.0.1', done));
+  const base = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+  return {
+    base, stores, server,
+    close: async () => {
+      await new Promise<void>((done) => server.close(() => done()));
+      await stores.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function signIn(base: string, username: string): Promise<string> {
+  await fetch(`${base}/api/auth/signup`, {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ username, password: PASSWORD }),
+  });
+  const res = await fetch(`${base}/api/auth/signin`, {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ username, password: PASSWORD }),
+  });
+  return ((await res.json()) as { data?: string }).data ?? '';
+}
+
+async function mint(base: string, session: string, scopes: string[], name = 'Claude Desktop'): Promise<{ token: string; id: string }> {
+  const res = await fetch(`${base}/api/secure/account/agent-tokens`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${session}` },
+    body: JSON.stringify({ name, scopes }),
+  });
+  // The cleartext rides back once as `token`; the id lives on `record`, which is what revoke needs.
+  const data = ((await res.json()) as { data?: { token?: string; record?: { id?: string } } }).data ?? {};
+  return { token: data.token ?? '', id: data.record?.id ?? '' };
+}
+
+/** Records for one account, written the way the app writes them, so the search index is real. */
+async function seed(file: string, userId: string, sourceId: string, extra: Resource): Promise<void> {
+  const repo = new SqliteFhirRepository({ file, userId, sourceId });
+  await repo.createResource({
+    resourceType: 'MedicationRequest', id: `${userId}-m1`, status: 'active', intent: 'order',
+    medicationCodeableConcept: { text: 'Metformin hydrochloride 500 MG Oral Tablet' },
+    authoredOn: '2024-03-02',
+  } as Resource);
+  await repo.createResource(extra);
+}
+
+interface RpcResponse { id?: number; result?: Record<string, unknown>; error?: { message: string } }
+
+/**
+ * Drive the bridge as an AI client does: launch it, speak newline-delimited JSON-RPC on stdin, read
+ * the replies off stdout. Returns once `wanted` responses have arrived, or the child has gone.
+ */
+function speak(base: string, token: string, requests: Record<string, unknown>[], wanted: number): Promise<RpcResponse[]> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, BRIDGE, {
+      env: { ...process.env, YOURPHR_URL: base, YOURPHR_AGENT_TOKEN: token },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const out: RpcResponse[] = [];
+    let buffer = '';
+    const done = (): void => { child.kill(); resolve(out); };
+    child.stdout.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (line.trim() === '') continue;
+        try { out.push(JSON.parse(line) as RpcResponse); } catch { /* not a message */ }
+      }
+      if (out.length >= wanted) done();
+    });
+    child.on('exit', () => resolve(out));
+    setTimeout(done, 20_000).unref();
+    for (const r of requests) child.stdin.write(`${JSON.stringify(r)}\n`);
+  });
+}
+
+/** The text a tool call put in front of the model. */
+function toolText(res: RpcResponse | undefined): string {
+  const content = (res?.result?.['content'] ?? []) as { text?: string }[];
+  return content.map((c) => c.text ?? '').join('\n');
+}
+
+const HELLO = { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'harness', version: '1' } } };
+const search = (id: number, query: string): Record<string, unknown> =>
+  ({ jsonrpc: '2.0', id, method: 'tools/call', params: { name: 'search_records', arguments: { query } } });
+
+async function main(): Promise<void> {
+  const h = await boot();
+  try {
+    const recordsDb = h.stores.config.getString('yourphr.records.location');
+
+    // Two accounts, both prescribed metformin. Only the second condition differs.
+    await seed(recordsDb, 'jim', 'source-jim', {
+      resourceType: 'Condition', id: 'jim-c1', code: { text: 'Prediabetes' }, recordedDate: '2024-01-11',
+    } as Resource);
+    await seed(recordsDb, 'dana', 'source-dana', {
+      resourceType: 'Condition', id: 'dana-c1', code: { text: 'Psoriasis' }, recordedDate: '2024-02-12',
+    } as Resource);
+
+    const jimSession = await signIn(h.base, 'jim');
+    await signIn(h.base, 'dana');
+    check('a patient can sign in and mint a token for an agent', jimSession !== '');
+
+    const jim = await mint(h.base, jimSession, ['Record search']);
+    check('the mint returns a cleartext token, once', jim.token.startsWith('yphr_at_'), jim.token.slice(0, 12));
+
+    // --- the handshake ---
+    const hello = await speak(h.base, jim.token, [HELLO, { jsonrpc: '2.0', id: 2, method: 'tools/list' }], 2);
+    const init = hello.find((r) => r.id === 1);
+    check('the bridge completes the MCP handshake',
+      (init?.result?.['protocolVersion'] ?? '') === '2025-06-18');
+    const tools = (hello.find((r) => r.id === 2)?.result?.['tools'] ?? []) as { name: string }[];
+    check('it offers exactly one tool, and it is search_records',
+      tools.length === 1 && tools[0]?.name === 'search_records', tools.map((t) => t.name).join(','));
+    check('TOOTH: no write tool is offered — none exists to offer',
+      !tools.some((t) => /create|update|delete|write|add/i.test(t.name)));
+
+    // --- the read it was given ---
+    const found = toolText((await speak(h.base, jim.token, [HELLO, search(2, 'metformin')], 2)).find((r) => r.id === 2));
+    check('the agent reads the records the token was scoped to', found.includes('Metformin'), found.split('\n')[0] ?? '');
+
+    // yourphr#598 indexed every record with an EMPTY sort_title and search silently matched nothing.
+    // A title that is only the resource type is that failure wearing a hat.
+    check('and the record carries a real title, not a bare resource type (the yourphr#598 precedent)',
+      /MedicationRequest\/[^:]+: Metformin/.test(found), found.split('\n')[1] ?? '');
+
+    // --- THE TOOTH ---
+    // Counted as RESULT LINES, not occurrences of the word: the snippet highlights the match, so
+    // the drug name legitimately appears twice in one hit. Counting the string tests the renderer.
+    const hits = found.split('\n').filter((l) => l.startsWith('- '));
+    check('TOOTH: the same drug in the other account is NOT returned — one hit, not two',
+      hits.length === 1 && !found.includes('dana-'), `${hits.length} hit(s)`);
+    const other = toolText((await speak(h.base, jim.token, [HELLO, search(2, 'psoriasis')], 2)).find((r) => r.id === 2));
+    check("TOOTH: user A's token never returns user B's record",
+      other.includes('No records matched') && !other.includes('Psoriasis'), other.split('\n')[0] ?? '');
+
+    // --- the scope ---
+    const wrongScope = await mint(h.base, jimSession, ['Medications'], 'Wrongly scoped');
+    const refused = toolText((await speak(h.base, wrongScope.token, [HELLO, search(2, 'metformin')], 2)).find((r) => r.id === 2));
+    check('TOOTH: a token without Record search is refused, and told which scope it needs',
+      refused.includes('Record search'), refused.split('\n')[0] ?? '');
+
+    // --- the audit, which is the reason the scope exists at all ---
+    const log = (await (await fetch(`${h.base}/api/secure/account/access-log`, {
+      headers: { authorization: `Bearer ${jimSession}` },
+    })).json()) as { data: { actor_username: string; category: string }[] };
+    check("the agent's search is logged under the AGENT's name",
+      log.data.some((e) => e.actor_username === 'Claude Desktop' && e.category === 'Record search'));
+    check('and is NOT attributed to the patient, who was not at the keyboard',
+      !log.data.some((e) => e.actor_username === 'jim' && e.category === 'Record search'));
+
+    // --- revocation, the property the whole design rests on ---
+    await fetch(`${h.base}/api/secure/account/agent-tokens/${jim.id}/revoke`, {
+      method: 'POST', headers: { authorization: `Bearer ${jimSession}` },
+    });
+    const dead = toolText((await speak(h.base, jim.token, [HELLO, search(2, 'metformin')], 2)).find((r) => r.id === 2));
+    check('TOOTH: a revoked token stops working on the very next call, and says so plainly',
+      dead.includes('revoked') && !dead.includes('Metformin'), dead.split('\n')[0] ?? '');
+  } finally {
+    await h.close();
+  }
+
+  const failed = results.filter((r) => !r.ok);
+  console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
+  if (failed.length) process.exit(1);
+}
+
+main().catch((err) => { console.error(`mcp harness failed: ${(err as Error).stack ?? (err as Error).message}`); process.exit(1); });

--- a/src/account/index.ts
+++ b/src/account/index.ts
@@ -55,6 +55,12 @@ export function accessCategoryFor(pathname: string): string | undefined {
     '/api/secure/allergies/classified': 'Allergies',
     '/api/secure/immunizations/classified': 'Immunizations',
     '/api/secure/resources/recent': 'Record search',
+    // Find-anything-by-words (yourphr#599) was serving results without recording them: the
+    // dashboard's search box read across every resource type a person has and the access log said
+    // nothing happened. Both spellings, because server.ts answers both and a category that covers
+    // one of two aliases is a hole shaped like a typo.
+    '/api/secure/resources/search': 'Record search',
+    '/api/secure/search': 'Record search',
     '/api/secure/resource/fhir': 'Records (FHIR)',
   };
   if (exact[pathname]) return exact[pathname];


### PR DESCRIPTION
## Summary

The first slice of [#657](https://github.com/jwilleke/yourphr/issues/657), as agreed: one read-only tool, `search_records`, over [#599](https://github.com/jwilleke/yourphr/issues/599)'s FTS5 index, reached with an agent token from [#695](https://github.com/jwilleke/yourphr/issues/695).

YourPHR runs no model, bundles no weights, calls no inference service and transmits no record anywhere. A patient mints a scoped, 24-hour credential for themselves and hands it to a client they already run; that client asks YourPHR's own HTTP API the same question the dashboard's search box asks.

Six files, +597/−1. Tried end to end against Cursor on a real instance.

## A bridge rather than a route — the decision the size depends on

Built on the agent-token HTTP surface exactly as suggested, and it turns out that is the *only* place it can go:

- **JSON-RPC is a POST, and the gate refuses every POST from an agent token.** An MCP endpoint inside the server would have to sit outside the gate and re-implement scoping, auditing and read-only — the "beside it rather than on top of it" mistake named in the issue.
- **It cannot live under `src/` regardless**: `check:boundary` refuses `fetch` there, because Node's fetch is undici and ignores the guarded DNS lookup that is the SSRF control. `scripts/` is the exempt place for loopback drivers, which is why `scripts/agent-token-tests.ts` lives there too.

So the bridge holds no database handle, no session and no privilege. It is an HTTP client with a scoped bearer token, and every safety property it has belongs to the server it calls — inherited rather than rebuilt.

## The route had to be named first

`/api/secure/resources/search` had **no access category**. Two consequences, one of which blocked this work:

- The dashboard's search box was reading across every resource type a patient owns while the access log said nothing had happened — the live gap noted on the issue, now closed for sessions as well as agents.
- An uncategorised read is one the log cannot record, so the gate refuses it. `search_records` was unreachable by any agent token until the route was named.

Both spellings are mapped, because `server.ts` answers both `/api/secure/resources/search` and `/api/secure/search`, and a category covering one of two aliases is a hole shaped like a typo.

## The teeth

`npm run mcp-tests`, wired into `server-ci.yaml` after `agent-tokens`. 13 checks, all green:

- **Isolation** — both accounts are prescribed the same drug, so `metformin` matches a record in each and one query must still return exactly one hit. A search for the other patient's condition returns nothing.
- Scope — a token without `Record search` is refused, and told which scope it needs.
- Revocation — a revoked token stops working on the very next call and says so plainly.
- Audit — the read is logged under the **token's** name, and *not* the patient's.
- Read-only — exactly one tool is offered, and no write tool exists to offer.
- Index fidelity — per the [#598](https://github.com/jwilleke/yourphr/pull/598) precedent, a check that fails if a hit carries a bare resource type instead of a real title.

## The policy document

`docs/planning/agent-access-policy.md` is the written policy [#599](https://github.com/jwilleke/yourphr/issues/599) asked for, modelled on `connection-policy.md`. It answers the question [#657](https://github.com/jwilleke/yourphr/issues/657) put to it: **"who read this record" is an HTTP-layer allow-list, not a manager guarantee.**

It argues for keeping it that way — a category is a property of *the surface a request arrives on*, not of the manager underneath, and several routes with different categories share one manager (`Full export` and `Records (FHIR)` are the same manager reached two ways), so binding audit to the manager would break the property that makes scoping trustworthy.

What is missing is not a different mechanism but a check that fails, per the twelfth architecture principle: a CI step requiring every GET under `/api/secure/` to resolve a category or appear on an explicit *not-an-access* list. That would have caught #599's search route on the commit that introduced it. Left for its own issue rather than widened into this slice.

## Two deviations, flagged rather than buried

**1. No server-side config key**, though the issue asked for one "in the way agent tokens are." The bridge is a client-side process launched by the patient's AI client, so a server key would gate nothing — and in a config file whose comments are load-bearing, a key that does nothing seemed worse than no key. Off-by-default is real, it just comes from `yourphr.auth.agent-token.enabled` being `false` plus the patient having to configure a client at all. Happy to add one if you would rather have the explicit switch.

**2. Zero dependencies instead of the official MCP SDK.** The stdio transport is newline-delimited JSON-RPC and the surface used here is four methods. In a store of medical records a dependency tree is a standing supply-chain question, and this repo runs on sixteen packages. Entirely reversible — the shape is the same either way.

## Two gaps found while building, not fixed here

- **There is no minting screen.** [#695](https://github.com/jwilleke/yourphr/issues/695) shipped the routes, which already serve `available_scopes` and the TTL policy for exactly such a screen, but the Angular half does not exist — so today a patient cannot mint a token without a terminal. For a feature aimed at patients that is the difference between usable and not. The API is settled, so it is a screen over a finished contract.
- **Discoverability.** A tool does not appear in a client's attachment or resource picker, because that menu lists MCP *resources* and *prompts* and this server publishes neither. Correct behaviour, but confusing the first time. Publishing a prompt or two would fix it and carries no extra disclosure risk, since prompts are templates rather than data — worth its own issue rather than widening the agreed slice.

## Related issue

Implements the first slice of [#657](https://github.com/jwilleke/yourphr/issues/657). Builds on [#695](https://github.com/jwilleke/yourphr/issues/695) and reads [#599](https://github.com/jwilleke/yourphr/issues/599)'s index.

**Depends in practice on the `record-text` fix**, opened separately: without it `search_records` cannot find a condition, lab, procedure or allergy by name, which is most of what anyone would ask a health record.

## Type of change

- [x] Feature
- [x] Docs
- [x] CI / build
- [ ] Bug fix
- [ ] Refactor / chore

## Checklist

- [x] **No PHI/PII, secrets, keys, `.env`, real FHIR bundles, or `*.db` files** — the harness generates two synthetic accounts at runtime; `npm run check:phi` clean.
- [x] Tests pass and I added tests. `npm run mcp-tests` 13/13 (new); `npm run agent-tokens` 18/18 (unchanged by the widened category list); `npm test` 301 passing; `npm run framework` 21/21; `check:boundary`, `check:store`, `check:routes`, `typecheck`, `build` all clean.
- [x] Lint passes — `markdownlint-cli2` clean.
- [x] N/A — no tygo-exported struct or `search-parameters.json` touched. (Go-era checklist item; noting rather than silently ticking.)
- [x] Docs updated — `docs/planning/agent-access-policy.md`, including setup verified against a real client rather than written from memory.